### PR TITLE
fix: restore terminal focus on tab switch

### DIFF
--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -1,0 +1,261 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { PtyTerminal } from '../components/pty-terminal';
+
+const mocks = vi.hoisted(() => {
+  const terminals: Array<any> = [];
+  const fitAddons: Array<any> = [];
+  const webSockets: Array<any> = [];
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    buffer = {
+      active: {
+        length: 0,
+        getLine: vi.fn(),
+      },
+    };
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    refresh = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
+    onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    attachCustomKeyEventHandler = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => '');
+    selectAll = vi.fn();
+    clear = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      fitAddons.push(this);
+    }
+  }
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = 3;
+    });
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: (() => void) | null = null;
+
+    constructor(public url: string) {
+      webSockets.push(this);
+    }
+  }
+
+  const Terminal = vi.fn(function Terminal() {
+    const terminal = new MockTerminal();
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  return { terminals, fitAddons, webSockets, Terminal, MockFitAddon, MockWebSocket };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.Terminal,
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: mocks.MockFitAddon,
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: vi.fn(function SearchAddon() {
+    return {
+      findNext: vi.fn(),
+      findPrevious: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+}));
+
+vi.mock('../lib/terminal-config', () => ({
+  loadAppearanceSettings: vi.fn(() => ({
+    allowTransparency: false,
+    backgroundImage: '',
+    opacity: 100,
+  })),
+  getThemeAwareTerminalOptions: vi.fn(() => ({
+    cursorBlink: true,
+    cursorStyle: 'block',
+    fontFamily: 'monospace',
+    fontSize: 14,
+    theme: {},
+  })),
+}));
+
+vi.mock('../components/terminal/terminal-context-menu', () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/terminal/terminal-search-bar', () => ({
+  TerminalSearchBar: () => null,
+}));
+
+vi.mock('../lib/restoration-manager', () => ({
+  signalReady: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => ({}),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+function renderTerminal(isActive: boolean) {
+  return render(
+    <PtyTerminal
+      connectionId="connection-1"
+      connectionName="SSH Server"
+      host="127.0.0.1"
+      username="root"
+      isActive={isActive}
+    />,
+  );
+}
+
+async function flushTimers() {
+  await act(async () => {
+    await vi.runOnlyPendingTimersAsync();
+  });
+}
+
+describe('PtyTerminal activation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.terminals.length = 0;
+    mocks.fitAddons.length = 0;
+    mocks.webSockets.length = 0;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 600,
+    });
+
+    vi.stubGlobal('WebSocket', mocks.MockWebSocket);
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        return window.setTimeout(() => callback(performance.now()), 0);
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => window.clearTimeout(id)));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not focus the terminal when it mounts inactive', () => {
+    renderTerminal(false);
+
+    expect(mocks.terminals[0].focus).not.toHaveBeenCalled();
+  });
+
+  it('fits, refreshes, and focuses the terminal when it becomes active', async () => {
+    const { rerender } = renderTerminal(false);
+    const terminal = mocks.terminals[0];
+    const fitAddon = mocks.fitAddons[0];
+    terminal.focus.mockClear();
+    terminal.refresh.mockClear();
+    fitAddon.fit.mockClear();
+
+    rerender(
+      <PtyTerminal
+        connectionId="connection-1"
+        connectionName="SSH Server"
+        host="127.0.0.1"
+        username="root"
+        isActive={true}
+      />,
+    );
+    await flushTimers();
+
+    expect(fitAddon.fit).toHaveBeenCalled();
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+    expect(terminal.focus).toHaveBeenCalled();
+  });
+
+  it('does not recreate the terminal or WebSocket when only active state changes', async () => {
+    const { rerender } = renderTerminal(false);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+    expect(mocks.webSockets).toHaveLength(1);
+
+    const terminal = mocks.terminals[0];
+    terminal.refresh.mockClear();
+    const terminalCount = mocks.terminals.length;
+    const webSocketCount = mocks.webSockets.length;
+
+    rerender(
+      <PtyTerminal
+        connectionId="connection-1"
+        connectionName="SSH Server"
+        host="127.0.0.1"
+        username="root"
+        isActive={true}
+      />,
+    );
+    await flushTimers();
+
+    expect(mocks.terminals).toHaveLength(terminalCount);
+    expect(mocks.webSockets).toHaveLength(webSocketCount);
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+});

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -20,6 +20,7 @@ interface PtyTerminalProps {
   username?: string;
   appearanceKey?: number;
   themeKey?: number;
+  isActive?: boolean;
   onConnectionStatusChange?: (connectionId: string, status: 'connected' | 'connecting' | 'disconnected' | 'pending') => void;
 }
 
@@ -38,6 +39,7 @@ export function PtyTerminal({
   username = 'user',
   appearanceKey = 0,
   themeKey = 0,
+  isActive = true,
   onConnectionStatusChange
 }: PtyTerminalProps) {
   const terminalRef = React.useRef<HTMLDivElement | null>(null);
@@ -47,6 +49,8 @@ export function PtyTerminal({
   const wsRef = React.useRef<WebSocket | null>(null);
   const rendererRef = React.useRef<string>('canvas');
   const containerRef = React.useRef<HTMLDivElement | null>(null);
+  const initialIsActiveRef = React.useRef(isActive);
+  const wasActiveRef = React.useRef(isActive);
   
   // Search bar state
   const [searchVisible, setSearchVisible] = React.useState(false);
@@ -140,8 +144,10 @@ export function PtyTerminal({
     fitRef.current = fitAddon;
     searchRef.current = searchAddon;
 
-    // Focus terminal to enable keyboard input
-    term.focus();
+    // Focus terminal to enable keyboard input when this tab is mounted active.
+    if (initialIsActiveRef.current) {
+      term.focus();
+    }
     
     // Track selection changes for context menu
     term.onSelectionChange(() => {
@@ -652,6 +658,35 @@ export function PtyTerminal({
     // Refit so any font-size change propagates as a PTY resize.
     fitRef.current?.fit();
   }, [themeKey, appearanceKey]);
+
+  React.useEffect(() => {
+    if (!isActive) {
+      wasActiveRef.current = false;
+      return;
+    }
+
+    if (wasActiveRef.current) {
+      return;
+    }
+
+    wasActiveRef.current = true;
+
+    const frameId = window.requestAnimationFrame(() => {
+      const term = xtermRef.current;
+      const fitAddon = fitRef.current;
+      const container = containerRef.current;
+      if (!term || !fitAddon || !container) return;
+      if (container.offsetWidth <= 0 || container.offsetHeight <= 0) return;
+
+      fitAddon.fit();
+      if (term.rows > 0) {
+        term.refresh(0, term.rows - 1);
+      }
+      term.focus();
+    });
+
+    return () => window.cancelAnimationFrame(frameId);
+  }, [isActive]);
 
   // Context menu handlers
   const handleCopy = React.useCallback(() => {

--- a/src/components/terminal/terminal-group-view.tsx
+++ b/src/components/terminal/terminal-group-view.tsx
@@ -160,6 +160,7 @@ export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
                   host={tab.host}
                   username={tab.username}
                   themeKey={themeKey}
+                  isActive={isActive && tab.id === group.activeTabId}
                   onConnectionStatusChange={handleConnectionStatusChange}
                 />
               ) : (


### PR DESCRIPTION
## Summary
- Add an active-tab signal to `PtyTerminal` so hidden terminal instances do not steal focus on mount.
- Restore xterm focus, fit, and renderer refresh when a terminal tab becomes active again.
- Add Vitest coverage for inactive mount, activation recovery, and avoiding terminal/WebSocket recreation on active-state changes.

## Root cause
`TerminalGroupView` keeps terminal tabs mounted and switches visibility with `display: none/block`, but `PtyTerminal` only focused the xterm instance during initial mount. When a hidden terminal became visible again, it was not explicitly refit, refreshed, or focused, so the active SSH tab could miss keyboard input and WebGL/canvas rendering could appear stale or blank.

## Test plan
- [x] `pnpm install --frozen-lockfile`
- [x] RED: `pnpm test src/__tests__/pty-terminal-activation.test.tsx` failed with 3 expected activation/focus failures before implementation
- [x] GREEN: `pnpm test src/__tests__/pty-terminal-activation.test.tsx` passed 3/3 after implementation
- [x] `pnpm build`
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint` (0 errors, existing warnings remain)
- [ ] `pnpm test` currently fails on pre-existing unrelated tests: `connection.test.ts` requires Tauri runtime invoke, `file-entry-types.test.ts` has Windows path expectation failures, and `terminal-group-serializer.test.ts` fails saving a state without `tabToGroupMap`.
- [ ] `cd src-tauri && cargo test` is blocked in this Windows environment because `openssl-sys` needs `perl` to build vendored OpenSSL and `perl` is not installed.

Closes #7