### PR TITLE
fix: support terminal tab drag reorder

### DIFF
--- a/src/__tests__/group-tab-bar-drag-reorder.test.tsx
+++ b/src/__tests__/group-tab-bar-drag-reorder.test.tsx
@@ -1,0 +1,130 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { GroupTabBar } from '../components/terminal/group-tab-bar';
+import type { TerminalTab } from '../lib/terminal-group-types';
+
+const mocks = vi.hoisted(() => ({
+  dispatch: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-group-context', () => ({
+  useTerminalGroups: () => ({
+    dispatch: mocks.dispatch,
+  }),
+}));
+
+vi.mock('../components/ui/button', () => ({
+  Button: ({
+    children,
+    variant: _variant,
+    size: _size,
+    ...props
+  }: React.ButtonHTMLAttributes<HTMLButtonElement> & {
+    variant?: string;
+    size?: string;
+  }) => <button type="button" {...props}>{children}</button>,
+}));
+
+vi.mock('../components/ui/context-menu', () => ({
+  ContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuItem: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  ContextMenuSeparator: () => null,
+  ContextMenuTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuSub: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuSubTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  ContextMenuSubContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const tabs: TerminalTab[] = [
+  {
+    id: 'tab-1',
+    name: 'server-a',
+    tabType: 'terminal',
+    connectionStatus: 'connected',
+    reconnectCount: 0,
+  },
+  {
+    id: 'tab-2',
+    name: 'server-b',
+    tabType: 'terminal',
+    connectionStatus: 'connected',
+    reconnectCount: 0,
+  },
+  {
+    id: 'tab-3',
+    name: 'server-c',
+    tabType: 'terminal',
+    connectionStatus: 'connected',
+    reconnectCount: 0,
+  },
+];
+
+function createDataTransfer(): DataTransfer {
+  const data = new Map<string, string>();
+
+  return {
+    dropEffect: 'none',
+    effectAllowed: 'all',
+    files: [] as unknown as FileList,
+    items: [] as unknown as DataTransferItemList,
+    types: [],
+    clearData: vi.fn(),
+    getData: vi.fn((type: string) => data.get(type) ?? ''),
+    setData: vi.fn((type: string, value: string) => {
+      data.set(type, value);
+    }),
+    setDragImage: vi.fn(),
+  } as unknown as DataTransfer;
+}
+
+function mockTabRects(container: HTMLElement) {
+  const tabElements = Array.from(container.querySelectorAll('[data-tab-id]')) as HTMLElement[];
+
+  tabElements.forEach((element, index) => {
+    vi.spyOn(element, 'getBoundingClientRect').mockReturnValue({
+      x: index * 100,
+      y: 0,
+      left: index * 100,
+      right: index * 100 + 100,
+      top: 0,
+      bottom: 32,
+      width: 100,
+      height: 32,
+      toJSON: () => ({}),
+    });
+  });
+
+  return tabElements;
+}
+
+describe('GroupTabBar drag-and-drop reordering', () => {
+  beforeEach(() => {
+    mocks.dispatch.mockClear();
+  });
+
+  it('moves the active tab to the end when dropped on empty tab strip space', () => {
+    const { container } = render(
+      <GroupTabBar groupId="group-1" tabs={tabs} activeTabId="tab-1" />,
+    );
+    const tabStrip = container.firstElementChild as HTMLElement;
+    const [firstTab] = mockTabRects(container);
+    const dataTransfer = createDataTransfer();
+
+    fireEvent.dragStart(firstTab, { dataTransfer });
+    fireEvent.dragOver(tabStrip, { dataTransfer, clientX: 360 });
+    fireEvent.drop(tabStrip, { dataTransfer, clientX: 360 });
+
+    expect(mocks.dispatch).toHaveBeenCalledWith({
+      type: 'REORDER_TAB',
+      groupId: 'group-1',
+      fromIndex: 0,
+      toIndex: 2,
+    });
+  });
+});

--- a/src/components/terminal/group-tab-bar.tsx
+++ b/src/components/terminal/group-tab-bar.tsx
@@ -140,13 +140,15 @@ export function GroupTabBar({
   );
 
   return (
-    <div className="bg-muted border-b border-border flex items-center">
+    <div
+      className="bg-muted border-b border-border flex items-center"
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
       <div
         ref={tabBarRef}
-        className="flex items-center overflow-x-auto relative"
-        onDragOver={handleDragOver}
-        onDragLeave={handleDragLeave}
-        onDrop={handleDrop}
+        className="flex flex-1 min-w-0 items-center overflow-x-auto relative"
       >
         {tabs.map((tab, index) => (
           <React.Fragment key={tab.id}>


### PR DESCRIPTION
## Root cause

The tab drag handlers were attached only to the inner tab list whose width is the rendered tabs. When a user dragged a tab to the empty area at the end of the tab strip, no `drop` event reached the reorder handler, so the tab could appear impossible to move to the end.

## Fix

- Moved the tab drag-over, drag-leave, and drop handlers to the outer tab bar so the whole strip is a drop target.
- Let the inner tab list grow with `flex-1 min-w-0`, preserving overflow scrolling while exposing the empty strip area for drops.
- Added a component-level Vitest regression test that drags the active tab into the empty strip area and expects `REORDER_TAB` to move it to the end.

Closes #16

## Verification

RED/GREEN:
- RED confirmed: `pnpm.cmd test src/__tests__/group-tab-bar-drag-reorder.test.tsx` failed before the fix with 0 dispatch calls.
- GREEN confirmed: `pnpm.cmd test src/__tests__/group-tab-bar-drag-reorder.test.tsx` passed after the fix.

Passed:
- `pnpm.cmd test src/__tests__/group-tab-bar-drag-reorder.test.tsx`
- `pnpm.cmd test src/__tests__/terminal-group-reducer.test.ts src/__tests__/terminal-group-reducer.property.test.ts`
- `pnpm.cmd exec tsc --noEmit`
- `pnpm.cmd lint` (0 errors; existing warnings remain)
- `pnpm.cmd build`

Known local failures unrelated to this change:
- `pnpm.cmd test` still fails in existing suites: `src/__tests__/connection.test.ts` needs a Tauri runtime/invoke bridge, `src/__tests__/file-entry-types.test.ts` has Windows path separator expectation failures, and `src/__tests__/terminal-group-serializer.test.ts` fails when saving a fixture without `tabToGroupMap`. The new drag reorder test passes in the full run.
- `cd src-tauri && cargo test` was checked during this issue pass and fails locally because `openssl-sys` cannot find `perl` while building vendored OpenSSL.