### PR TITLE
fix: preserve editable shortcut handling

### DIFF
--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IntegratedFileBrowser } from '../components/integrated-file-browser';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('../components/directory-tree', () => ({
+  DirectoryTree: () => <div data-testid="directory-tree" />,
+}));
+
+vi.mock('../components/transfer-queue', () => ({
+  TransferQueue: () => null,
+}));
+
+vi.mock('../components/ui/resizable', () => ({
+  ResizableHandle: () => <div data-testid="resize-handle" />,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('IntegratedFileBrowser keyboard shortcuts', () => {
+  it('does not intercept document shortcuts from editable targets', () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-1"
+        isConnected={false}
+        onClose={() => {}}
+      />,
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'a',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    input.dispatchEvent(event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    input.remove();
+  });
+});

--- a/src/__tests__/keyboard-shortcuts-hook.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-hook.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isEditableTarget, useKeyboardShortcuts } from '../lib/keyboard-shortcuts';
+
+function ShortcutHarness({ handler }: { handler: () => void }) {
+  useKeyboardShortcuts([
+    {
+      key: 'b',
+      ctrlKey: true,
+      handler,
+      description: 'Toggle sidebar',
+    },
+  ]);
+
+  return (
+    <div>
+      <input data-testid="input" defaultValue="host" />
+      <textarea data-testid="textarea" defaultValue="notes" />
+      <div data-testid="editable" contentEditable suppressContentEditableWarning>
+        editable
+      </div>
+      <div data-testid="plain" tabIndex={0}>
+        plain
+      </div>
+    </div>
+  );
+}
+
+function dispatchCtrlB(target: Element) {
+  const event = new KeyboardEvent('keydown', {
+    key: 'b',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  const preventDefault = vi.spyOn(event, 'preventDefault');
+  target.dispatchEvent(event);
+  return preventDefault;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('isEditableTarget', () => {
+  it('identifies text-editable targets', () => {
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    const plaintextEditable = document.createElement('div');
+    plaintextEditable.setAttribute('contenteditable', 'plaintext-only');
+
+    expect(isEditableTarget(input)).toBe(true);
+    expect(isEditableTarget(textarea)).toBe(true);
+    expect(isEditableTarget(editable)).toBe(true);
+    expect(isEditableTarget(plaintextEditable)).toBe(true);
+  });
+
+  it('does not treat non-editable targets as editable', () => {
+    const button = document.createElement('button');
+    const select = document.createElement('select');
+    const contentEditableFalse = document.createElement('div');
+    contentEditableFalse.setAttribute('contenteditable', 'false');
+
+    expect(isEditableTarget(button)).toBe(false);
+    expect(isEditableTarget(select)).toBe(false);
+    expect(isEditableTarget(contentEditableFalse)).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('useKeyboardShortcuts editable targets', () => {
+  it.each(['input', 'textarea', 'editable'])(
+    'does not intercept shortcuts dispatched from %s',
+    (testId) => {
+      const handler = vi.fn();
+      render(<ShortcutHarness handler={handler} />);
+
+      const preventDefault = dispatchCtrlB(screen.getByTestId(testId));
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(preventDefault).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still intercepts matching shortcuts outside editable elements', () => {
+    const handler = vi.fn();
+    render(<ShortcutHarness handler={handler} />);
+
+    const preventDefault = dispatchCtrlB(screen.getByTestId('plain'));
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+});

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -59,6 +59,7 @@ import {
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, ContextMenuSeparator } from './ui/context-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 import { toast } from 'sonner';
+import { isEditableTarget } from '@/lib/keyboard-shortcuts';
 
 interface FileItem {
   name: string;
@@ -220,6 +221,10 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
       if (event.ctrlKey || event.metaKey) {
         switch (event.key) {
           case 'c':

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -10,6 +10,25 @@ export interface KeyboardShortcut {
   description: string;
 }
 
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === 'input' || tagName === 'textarea') {
+    return true;
+  }
+
+  const editableElement = target.closest('[contenteditable]');
+  if (!editableElement) {
+    return false;
+  }
+
+  const contentEditable = editableElement.getAttribute('contenteditable');
+  return contentEditable === '' || contentEditable?.toLowerCase() !== 'false';
+}
+
 /**
  * Hook to register keyboard shortcuts
  * Similar to VS Code's keyboard shortcuts system
@@ -21,6 +40,10 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boo
     const isMac = navigator.platform.toUpperCase().includes('MAC');
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
       for (const shortcut of shortcuts) {
         const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
         // On macOS, treat Cmd (metaKey) as the equivalent of Ctrl for shortcut matching.


### PR DESCRIPTION
## Root cause
Global and document-level keyboard handlers ran before text editing defaults could complete. `useKeyboardShortcuts` listened on `window` with capture and always called `preventDefault()` for matching shortcuts, while the integrated file browser kept a `document` keydown handler for Ctrl+C/V/X/A/R even when focus was inside a modal input.

## Fix
- Added `isEditableTarget()` for input, textarea, and contenteditable targets.
- Skipped global layout/terminal shortcuts when the key event comes from an editable target.
- Reused the same guard in the integrated file browser document shortcut handler so background panels do not cancel New Connection form editing shortcuts.
- Added TDD coverage for editable target detection, hook interception behavior, and the integrated file browser document listener.

## Verification
- `pnpm.cmd test src/__tests__/keyboard-shortcuts-hook.test.tsx src/__tests__/keyboard-shortcuts.test.ts src/__tests__/integrated-file-browser-keyboard.test.tsx` - passed, 26 tests.
- `pnpm.cmd exec tsc --noEmit` - passed.
- `pnpm.cmd lint` - passed with existing warnings only: 0 errors, 203 warnings.
- `pnpm.cmd build` - passed with existing Vite/PostCSS/browser-data warnings.
- `pnpm.cmd test` - still fails on existing main-branch suites unrelated to this change: `connection.test.ts` needs a Tauri invoke runtime, `file-entry-types.test.ts` has Windows separator expectation mismatches, and `terminal-group-serializer.test.ts` has the pre-existing missing `tabToGroupMap` save failure.
- `cargo test` - blocked locally because `openssl-sys` cannot build vendored OpenSSL without `perl` installed.

Closes #8