### PR TITLE
fix: support Windows upload basenames and folders

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2662,6 +2662,14 @@ pub async fn list_local_files_recursive(
 ) -> Result<Vec<SyncFileEntry>, String> {
     use std::fs;
 
+    fn relative_path_to_string(path: &std::path::Path) -> String {
+        path.components()
+            .map(|component| component.as_os_str().to_string_lossy())
+            .filter(|component| !component.is_empty())
+            .collect::<Vec<_>>()
+            .join("/")
+    }
+
     fn walk_dir(
         base: &std::path::Path,
         current: &std::path::Path,
@@ -2692,8 +2700,8 @@ pub async fn list_local_files_recursive(
                 .path()
                 .strip_prefix(base)
                 .unwrap_or(item.path().as_path())
-                .to_string_lossy()
-                .to_string();
+                .to_path_buf();
+            let rel_path = relative_path_to_string(&rel_path);
 
             let file_type = if metadata.is_dir() {
                 FileEntryType::Directory
@@ -3101,6 +3109,26 @@ mod local_fs_tests {
         let result = create_local_directory(new_dir.clone()).await;
         assert!(result.is_ok());
         assert!(std::path::Path::new(&new_dir).is_dir());
+    }
+
+    #[tokio::test]
+    async fn test_list_local_files_recursive_returns_portable_relative_paths() {
+        let dir = create_test_dir();
+        let path = dir.path().to_string_lossy().to_string();
+        let entries = list_local_files_recursive(path, vec![]).await.unwrap();
+        let relative_paths: Vec<&str> = entries
+            .iter()
+            .map(|entry| entry.relative_path.as_str())
+            .collect();
+
+        assert!(relative_paths.contains(&"subdir/nested.txt"));
+        assert!(
+            relative_paths
+                .iter()
+                .all(|relative_path| !relative_path.contains('\\')),
+            "relative paths should use forward slashes: {:?}",
+            relative_paths
+        );
     }
 
     #[test]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -457,6 +457,14 @@ pub async fn sftp_upload_file(
 }
 
 // File operation commands
+
+/// Escape a path for use inside a POSIX single-quoted shell argument.
+/// Single quotes cannot appear inside a single-quoted string, so we end the
+/// quote, emit the escaped quote, and reopen the quote: `'` → `'\''`.
+fn shell_escape_single_quoted(path: &str) -> String {
+    path.replace('\'', "'\\''")
+}
+
 #[tauri::command]
 pub async fn create_directory(
     connection_id: String,
@@ -469,7 +477,7 @@ pub async fn create_directory(
         .ok_or("Connection not found")?;
 
     let client = connection.read().await;
-    let command = format!("mkdir -p '{}'", path);
+    let command = format!("mkdir -p '{}'", shell_escape_single_quoted(&path));
 
     match client.execute_command(&command).await {
         Ok(_) => Ok(true),
@@ -491,9 +499,9 @@ pub async fn delete_file(
 
     let client = connection.read().await;
     let command = if is_directory {
-        format!("rm -rf '{}'", path)
+        format!("rm -rf '{}'", shell_escape_single_quoted(&path))
     } else {
-        format!("rm -f '{}'", path)
+        format!("rm -f '{}'", shell_escape_single_quoted(&path))
     };
 
     match client.execute_command(&command).await {
@@ -515,7 +523,7 @@ pub async fn rename_file(
         .ok_or("Connection not found")?;
 
     let client = connection.read().await;
-    let command = format!("mv '{}' '{}'", old_path, new_path);
+    let command = format!("mv '{}' '{}'", shell_escape_single_quoted(&old_path), shell_escape_single_quoted(&new_path));
 
     match client.execute_command(&command).await {
         Ok(_) => Ok(true),

--- a/src/__tests__/upload-paths.test.ts
+++ b/src/__tests__/upload-paths.test.ts
@@ -3,10 +3,91 @@ import {
   buildDirectoryUploadPlan,
   buildFileUploadItems,
   getLocalPathBasename,
+  joinRemotePath,
+  normalizeRelativeUploadPath,
 } from "../lib/upload-paths";
 
-describe("upload path helpers", () => {
-  it("uses only the basename when upload files come from Windows paths", () => {
+describe("getLocalPathBasename", () => {
+  it("extracts basename from a Windows absolute path", () => {
+    expect(
+      getLocalPathBasename(
+        "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3",
+      ),
+    ).toBe("db_v2.sqlite3");
+  });
+
+  it("extracts basename from a Unix absolute path", () => {
+    expect(getLocalPathBasename("/home/me/id_ed25519.pub")).toBe(
+      "id_ed25519.pub",
+    );
+  });
+
+  it("handles paths with trailing separators", () => {
+    expect(getLocalPathBasename("C:\\Users\\me\\Downloads\\")).toBe(
+      "Downloads",
+    );
+    expect(getLocalPathBasename("/home/me/docs/")).toBe("docs");
+  });
+
+  it("handles UNC Windows network paths", () => {
+    expect(
+      getLocalPathBasename("\\\\server\\share\\folder\\file.txt"),
+    ).toBe("file.txt");
+  });
+
+  it("handles a bare filename with no directory component", () => {
+    expect(getLocalPathBasename("file.txt")).toBe("file.txt");
+  });
+
+  it("handles filenames with dots and spaces", () => {
+    expect(
+      getLocalPathBasename("C:\\Users\\me\\my file (v2).tar.gz"),
+    ).toBe("my file (v2).tar.gz");
+  });
+});
+
+describe("normalizeRelativeUploadPath", () => {
+  it("converts Windows backslashes to forward slashes", () => {
+    expect(normalizeRelativeUploadPath("nested\\logs\\server.log")).toBe(
+      "nested/logs/server.log",
+    );
+  });
+
+  it("removes leading separators", () => {
+    expect(normalizeRelativeUploadPath("\\nested\\logs")).toBe("nested/logs");
+  });
+
+  it("is a no-op for already-normalized paths", () => {
+    expect(normalizeRelativeUploadPath("nested/logs/server.log")).toBe(
+      "nested/logs/server.log",
+    );
+  });
+});
+
+describe("joinRemotePath", () => {
+  it("joins a base and a relative path", () => {
+    expect(joinRemotePath("/root/data", "logs/server.log")).toBe(
+      "/root/data/logs/server.log",
+    );
+  });
+
+  it("handles root base correctly", () => {
+    expect(joinRemotePath("/", "file.txt")).toBe("/file.txt");
+  });
+
+  it("strips trailing slash from base", () => {
+    expect(joinRemotePath("/root/data/", "file.txt")).toBe(
+      "/root/data/file.txt",
+    );
+  });
+
+  it("returns base when relative path is empty", () => {
+    expect(joinRemotePath("/root/data", "")).toBe("/root/data");
+  });
+});
+
+describe("buildFileUploadItems", () => {
+  it("uses only the basename for Windows absolute paths", () => {
     const [item] = buildFileUploadItems(
       ["C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3"],
       "/root/rustdesk/data",
@@ -20,16 +101,37 @@ describe("upload path helpers", () => {
     expect(item.destinationPath).not.toContain("C:\\Users");
   });
 
-  it("handles both Windows and Unix separators when extracting basenames", () => {
-    expect(getLocalPathBasename("C:\\Users\\me\\Downloads\\id_ed25519")).toBe(
-      "id_ed25519",
+  it("uses only the basename for Unix absolute paths", () => {
+    const [item] = buildFileUploadItems(
+      ["/home/user/Downloads/id_ed25519"],
+      "/root/.ssh",
     );
-    expect(getLocalPathBasename("/home/me/id_ed25519.pub")).toBe(
-      "id_ed25519.pub",
-    );
+
+    expect(item.fileName).toBe("id_ed25519");
+    expect(item.destinationPath).toBe("/root/.ssh/id_ed25519");
   });
 
-  it("preserves only relative directory structure for folder uploads", () => {
+  it("uploads multiple files from Windows paths correctly", () => {
+    const items = buildFileUploadItems(
+      [
+        "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3",
+        "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3-wal",
+        "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\id_ed25519",
+      ],
+      "/root/rustdesk/data",
+    );
+
+    expect(items.map((i) => i.fileName)).toEqual([
+      "db_v2.sqlite3",
+      "db_v2.sqlite3-wal",
+      "id_ed25519",
+    ]);
+    expect(items.every((i) => !i.destinationPath.includes("C:\\"))).toBe(true);
+  });
+});
+
+describe("buildDirectoryUploadPlan", () => {
+  it("preserves relative directory structure for Windows folder uploads", () => {
     const plan = buildDirectoryUploadPlan(
       "C:\\Users\\60977\\Downloads\\rustdesk-server\\data",
       "/root/rustdesk",
@@ -77,5 +179,51 @@ describe("upload path helpers", () => {
         totalBytes: 20,
       },
     ]);
+  });
+
+  it("handles Unix source directory paths", () => {
+    const plan = buildDirectoryUploadPlan(
+      "/home/user/project",
+      "/var/www",
+      [
+        { relative_path: "index.html", name: "index.html", size: 500, file_type: "File" },
+        { relative_path: "css/style.css", name: "style.css", size: 200, file_type: "File" },
+        { relative_path: "css", name: "css", size: 0, file_type: "Directory" },
+      ],
+    );
+
+    expect(plan.directories).toContain("/var/www/project");
+    expect(plan.directories).toContain("/var/www/project/css");
+    expect(
+      plan.items.find((i) => i.fileName === "style.css")?.destinationPath,
+    ).toBe("/var/www/project/css/style.css");
+  });
+
+  it("returns only the root directory for an empty folder", () => {
+    const plan = buildDirectoryUploadPlan(
+      "C:\\Users\\me\\empty-folder",
+      "/remote",
+      [],
+    );
+
+    expect(plan.directories).toEqual(["/remote/empty-folder"]);
+    expect(plan.items).toEqual([]);
+  });
+
+  it("sorts directories by depth so parents are created before children", () => {
+    const plan = buildDirectoryUploadPlan(
+      "/src/deep",
+      "/dest",
+      [
+        { relative_path: "a/b/c", name: "c", size: 0, file_type: "Directory" },
+        { relative_path: "a", name: "a", size: 0, file_type: "Directory" },
+        { relative_path: "a/b", name: "b", size: 0, file_type: "Directory" },
+      ],
+    );
+
+    const depths = plan.directories.map((d) => d.split("/").filter(Boolean).length);
+    for (let i = 1; i < depths.length; i++) {
+      expect(depths[i]).toBeGreaterThanOrEqual(depths[i - 1]);
+    }
   });
 });

--- a/src/__tests__/upload-paths.test.ts
+++ b/src/__tests__/upload-paths.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildDirectoryUploadPlan,
+  buildFileUploadItems,
+  getLocalPathBasename,
+} from "../lib/upload-paths";
+
+describe("upload path helpers", () => {
+  it("uses only the basename when upload files come from Windows paths", () => {
+    const [item] = buildFileUploadItems(
+      ["C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3"],
+      "/root/rustdesk/data",
+    );
+
+    expect(item.fileName).toBe("db_v2.sqlite3");
+    expect(item.sourcePath).toBe(
+      "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3",
+    );
+    expect(item.destinationPath).toBe("/root/rustdesk/data/db_v2.sqlite3");
+    expect(item.destinationPath).not.toContain("C:\\Users");
+  });
+
+  it("handles both Windows and Unix separators when extracting basenames", () => {
+    expect(getLocalPathBasename("C:\\Users\\me\\Downloads\\id_ed25519")).toBe(
+      "id_ed25519",
+    );
+    expect(getLocalPathBasename("/home/me/id_ed25519.pub")).toBe(
+      "id_ed25519.pub",
+    );
+  });
+
+  it("preserves only relative directory structure for folder uploads", () => {
+    const plan = buildDirectoryUploadPlan(
+      "C:\\Users\\60977\\Downloads\\rustdesk-server\\data",
+      "/root/rustdesk",
+      [
+        {
+          relative_path: "db_v2.sqlite3",
+          name: "db_v2.sqlite3",
+          size: 10,
+          file_type: "File",
+        },
+        {
+          relative_path: "nested\\logs",
+          name: "logs",
+          size: 0,
+          file_type: "Directory",
+        },
+        {
+          relative_path: "nested\\logs\\server.log",
+          name: "server.log",
+          size: 20,
+          file_type: "File",
+        },
+      ],
+    );
+
+    expect(plan.directories).toEqual([
+      "/root/rustdesk/data",
+      "/root/rustdesk/data/nested/logs",
+    ]);
+    expect(plan.items).toEqual([
+      {
+        fileName: "db_v2.sqlite3",
+        direction: "upload",
+        sourcePath:
+          "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\db_v2.sqlite3",
+        destinationPath: "/root/rustdesk/data/db_v2.sqlite3",
+        totalBytes: 10,
+      },
+      {
+        fileName: "server.log",
+        direction: "upload",
+        sourcePath:
+          "C:\\Users\\60977\\Downloads\\rustdesk-server\\data\\nested\\logs\\server.log",
+        destinationPath: "/root/rustdesk/data/nested/logs/server.log",
+        totalBytes: 20,
+      },
+    ]);
+  });
+});

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -728,6 +728,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
 
       const queuedItems: UploadQueueInput[] = [];
       let createdDirectoryCount = 0;
+      const dirErrors: string[] = [];
 
       for (const directoryPath of directoryPaths) {
         const entries = await invoke<LocalRecursiveUploadEntry[]>(
@@ -743,17 +744,28 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
           entries,
         );
 
+        // Create remote directories before enqueuing file transfers.
+        // Shell-quote escaping is handled on the Rust side.
         for (const remoteDirectory of plan.directories) {
-          // create_directory wraps the path in single quotes on the Rust side,
-          // so escape single quotes to avoid shell parsing/injection issues.
-          const escapedRemoteDirectory = remoteDirectory.replace(/'/g, `'\\''`);
-          await invoke<boolean>("create_directory", {
-            connectionId,
-            path: escapedRemoteDirectory,
-          });
-          createdDirectoryCount += 1;
+          try {
+            await invoke<boolean>("create_directory", {
+              connectionId,
+              path: remoteDirectory,
+            });
+            createdDirectoryCount += 1;
+          } catch (err) {
+            dirErrors.push(
+              `${remoteDirectory}: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          }
         }
         queuedItems.push(...plan.items);
+      }
+
+      if (dirErrors.length > 0) {
+        toast.warning(`${dirErrors.length} directory creation(s) failed`, {
+          description: dirErrors.slice(0, 3).join("\n"),
+        });
       }
 
       if (queuedItems.length > 0) {
@@ -761,13 +773,14 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
           type: "ENQUEUE",
           items: queuedItems,
         });
-      } else {
+        toast.info(
+          `Queued ${queuedItems.length} file(s) from ${directoryPaths.length} folder(s); created ${createdDirectoryCount} remote folder(s)`,
+        );
+      } else if (dirErrors.length === 0) {
+        // Folder(s) were empty — just refresh
         void loadFiles();
+        toast.info(`Created ${createdDirectoryCount} remote folder(s)`);
       }
-
-      toast.info(
-        `Queued ${queuedItems.length} file(s) from ${directoryPaths.length} folder(s); created ${createdDirectoryCount} remote folder(s)`,
-      );
     } catch (error) {
       console.error('Upload folder dialog error:', error);
       toast.error('Folder upload failed', {

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -744,9 +744,12 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
         );
 
         for (const remoteDirectory of plan.directories) {
+          // create_directory wraps the path in single quotes on the Rust side,
+          // so escape single quotes to avoid shell parsing/injection issues.
+          const escapedRemoteDirectory = remoteDirectory.replace(/'/g, `'\\''`);
           await invoke<boolean>("create_directory", {
             connectionId,
-            path: remoteDirectory,
+            path: escapedRemoteDirectory,
           });
           createdDirectoryCount += 1;
         }

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -9,6 +9,12 @@ import {
   transferQueueReducer,
   getNextQueuedTransfer,
 } from '@/lib/transfer-queue-reducer';
+import {
+  buildDirectoryUploadPlan,
+  buildFileUploadItems,
+  type LocalRecursiveUploadEntry,
+  type UploadQueueInput,
+} from '@/lib/upload-paths';
 import { TransferQueue } from './transfer-queue';
 import { DirectoryTree } from './directory-tree';
 import {
@@ -18,6 +24,7 @@ import {
 } from './ui/resizable';
 import { 
   Folder, 
+  FolderUp,
   File, 
   Upload, 
   Download, 
@@ -699,21 +706,71 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
 
       dispatchTransfer({
         type: "ENQUEUE",
-        items: paths.map((p) => {
-          const fileName = p.split('/').pop() || p;
-          const remotePath = currentPath === '/' ? `/${fileName}` : `${currentPath}/${fileName}`;
-          return {
-            fileName,
-            direction: "upload" as const,
-            sourcePath: p,
-            destinationPath: remotePath,
-            totalBytes: 0,
-          };
-        }),
+        items: buildFileUploadItems(paths, currentPath),
       });
       toast.info(`Queued ${paths.length} file(s) for upload`);
     } catch (error) {
       console.error('Upload dialog error:', error);
+    }
+  };
+
+  const handleUploadFolder = async () => {
+    try {
+      const selected = await tauriOpen({
+        multiple: true,
+        directory: true,
+        recursive: true,
+      });
+      if (!selected) return;
+
+      const directoryPaths = Array.isArray(selected) ? selected : [selected];
+      if (directoryPaths.length === 0) return;
+
+      const queuedItems: UploadQueueInput[] = [];
+      let createdDirectoryCount = 0;
+
+      for (const directoryPath of directoryPaths) {
+        const entries = await invoke<LocalRecursiveUploadEntry[]>(
+          "list_local_files_recursive",
+          {
+            path: directoryPath,
+            excludePatterns: [],
+          },
+        );
+        const plan = buildDirectoryUploadPlan(
+          directoryPath,
+          currentPath,
+          entries,
+        );
+
+        for (const remoteDirectory of plan.directories) {
+          await invoke<boolean>("create_directory", {
+            connectionId,
+            path: remoteDirectory,
+          });
+          createdDirectoryCount += 1;
+        }
+        queuedItems.push(...plan.items);
+      }
+
+      if (queuedItems.length > 0) {
+        dispatchTransfer({
+          type: "ENQUEUE",
+          items: queuedItems,
+        });
+      } else {
+        void loadFiles();
+      }
+
+      toast.info(
+        `Queued ${queuedItems.length} file(s) from ${directoryPaths.length} folder(s); created ${createdDirectoryCount} remote folder(s)`,
+      );
+    } catch (error) {
+      console.error('Upload folder dialog error:', error);
+      toast.error('Folder upload failed', {
+        description:
+          error instanceof Error ? error.message : 'Unable to upload folder.',
+      });
     }
   };
 
@@ -993,7 +1050,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
       return entry?.isDirectory;
     });
     if (hasDirectory) {
-      toast.info('Directory upload is not supported via drag-and-drop. Use the upload button.');
+      toast.info('Directory drag-and-drop is not supported yet. Use the upload folder button.');
       return;
     }
 
@@ -1197,8 +1254,11 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
           <Button variant="ghost" size="sm" className="h-6 shrink-0 rounded-md px-2" onClick={handleCreateFolder}>
             <FolderPlus className="h-3.5 w-3.5" />
           </Button>
-          <Button variant="ghost" size="sm" className="h-6 shrink-0 rounded-md px-2" onClick={handleUpload}>
+          <Button variant="ghost" size="sm" className="h-6 shrink-0 rounded-md px-2" title="Upload files" onClick={handleUpload}>
             <Upload className="h-3.5 w-3.5" />
+          </Button>
+          <Button variant="ghost" size="sm" className="h-6 shrink-0 rounded-md px-2" title="Upload folder" onClick={handleUploadFolder}>
+            <FolderUp className="h-3.5 w-3.5" />
           </Button>
 
           <div className="mx-1 h-4 w-px shrink-0 bg-border/60" />
@@ -1551,6 +1611,10 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
               <ContextMenuItem onClick={handleUpload}>
                 <Upload className="mr-2 h-4 w-4" />
                 Upload Files
+              </ContextMenuItem>
+              <ContextMenuItem onClick={handleUploadFolder}>
+                <FolderUp className="mr-2 h-4 w-4" />
+                Upload Folder
               </ContextMenuItem>
               <ContextMenuItem onClick={() => loadFiles()}>
                 <RefreshCw className="mr-2 h-4 w-4" />

--- a/src/lib/file-entry-types.tsx
+++ b/src/lib/file-entry-types.tsx
@@ -122,12 +122,17 @@ export function localParentPath(p: string): string {
   // Normalize to forward slashes
   const normalized = p.replace(/\\/g, "/");
   const parts = normalized.split("/").filter(Boolean);
+
+  if (parts[0]?.match(/^[A-Za-z]:$/)) {
+    if (parts.length <= 1) return `${parts[0]}\\`;
+    parts.pop();
+    return parts.length === 1
+      ? `${parts[0]}\\`
+      : `${parts[0]}\\${parts.slice(1).join("\\")}`;
+  }
+
   parts.pop();
   if (parts.length === 0) return "/";
-  // Preserve drive letter on Windows (e.g., "C:")
-  if (parts[0].match(/^[A-Za-z]:$/)) {
-    return parts.length === 1 ? `${parts[0]}/` : parts.join("/");
-  }
   return `/${parts.join("/")}`;
 }
 
@@ -140,10 +145,10 @@ export function localBreadcrumbSegments(
 
   // Check for drive letter (Windows)
   if (parts.length > 0 && parts[0].match(/^[A-Za-z]:$/)) {
-    segs.push({ label: parts[0], path: `${parts[0]}/` });
+    segs.push({ label: `${parts[0]}\\`, path: `${parts[0]}\\` });
     let acc = parts[0];
     for (let i = 1; i < parts.length; i++) {
-      acc += `/${parts[i]}`;
+      acc += `\\${parts[i]}`;
       segs.push({ label: parts[i], path: acc });
     }
   } else {

--- a/src/lib/upload-paths.ts
+++ b/src/lib/upload-paths.ts
@@ -1,0 +1,108 @@
+import type { TransferDirection } from "./transfer-queue-reducer";
+
+export interface LocalRecursiveUploadEntry {
+  relative_path: string;
+  name: string;
+  size: number;
+  file_type: string;
+}
+
+export interface UploadQueueInput {
+  fileName: string;
+  direction: TransferDirection;
+  sourcePath: string;
+  destinationPath: string;
+  totalBytes: number;
+}
+
+export interface DirectoryUploadPlan {
+  directories: string[];
+  items: UploadQueueInput[];
+}
+
+export function getLocalPathBasename(path: string): string {
+  const trimmed = path.replace(/[\\/]+$/, "");
+  const normalized = trimmed.replace(/\\/g, "/");
+  return normalized.split("/").filter(Boolean).pop() ?? trimmed;
+}
+
+export function normalizeRelativeUploadPath(path: string): string {
+  return path.replace(/\\/g, "/").split("/").filter(Boolean).join("/");
+}
+
+export function joinRemotePath(base: string, relativePath: string): string {
+  const cleanBase = base.replace(/\\/g, "/").replace(/\/+$/, "");
+  const cleanRelative = normalizeRelativeUploadPath(relativePath);
+
+  if (!cleanRelative) return cleanBase || "/";
+  if (!cleanBase || cleanBase === "/") return `/${cleanRelative}`;
+  return `${cleanBase}/${cleanRelative}`;
+}
+
+function joinLocalPath(base: string, relativePath: string): string {
+  const cleanBase = base.replace(/[\\/]+$/, "");
+  const separator = base.includes("\\") || /^[A-Za-z]:/.test(base) ? "\\" : "/";
+  const cleanRelative = relativePath
+    .replace(/[\\/]+/g, separator)
+    .replace(/^[\\/]+/, "");
+
+  if (!cleanRelative) return cleanBase || base;
+  return cleanBase ? `${cleanBase}${separator}${cleanRelative}` : cleanRelative;
+}
+
+function remotePathDepth(path: string): number {
+  return path.split("/").filter(Boolean).length;
+}
+
+export function buildFileUploadItems(
+  localPaths: string[],
+  remoteDirectory: string,
+): UploadQueueInput[] {
+  return localPaths.map((localPath) => {
+    const fileName = getLocalPathBasename(localPath);
+    return {
+      fileName,
+      direction: "upload",
+      sourcePath: localPath,
+      destinationPath: joinRemotePath(remoteDirectory, fileName),
+      totalBytes: 0,
+    };
+  });
+}
+
+export function buildDirectoryUploadPlan(
+  sourceDirectory: string,
+  remoteParentDirectory: string,
+  entries: LocalRecursiveUploadEntry[],
+): DirectoryUploadPlan {
+  const rootName = getLocalPathBasename(sourceDirectory);
+  const remoteRoot = joinRemotePath(remoteParentDirectory, rootName);
+  const directories = new Set<string>([remoteRoot]);
+  const items: UploadQueueInput[] = [];
+
+  for (const entry of entries) {
+    const relativePath = normalizeRelativeUploadPath(entry.relative_path);
+    if (!relativePath) continue;
+
+    if (entry.file_type === "Directory") {
+      directories.add(joinRemotePath(remoteRoot, relativePath));
+      continue;
+    }
+
+    items.push({
+      fileName: getLocalPathBasename(relativePath) || entry.name,
+      direction: "upload",
+      sourcePath: joinLocalPath(sourceDirectory, relativePath),
+      destinationPath: joinRemotePath(remoteRoot, relativePath),
+      totalBytes: entry.size,
+    });
+  }
+
+  return {
+    directories: Array.from(directories).sort((a, b) => {
+      const depthDelta = remotePathDepth(a) - remotePathDepth(b);
+      return depthDelta === 0 ? a.localeCompare(b) : depthDelta;
+    }),
+    items,
+  };
+}


### PR DESCRIPTION
## Root cause
- `IntegratedFileBrowser` extracted upload filenames with `p.split('/')`, so Windows paths like `C:\Users\...\db_v2.sqlite3` were treated as one filename and sent to the Linux remote unchanged.
- Folder upload had no picker path: directory drag/drop was explicitly rejected, and the upload button only selected files.
- Local recursive listings could expose platform-specific separators, which is unsafe when those relative paths are later used as remote paths.

## Fix
- Added upload path helpers that extract basenames from both `\` and `/`, join remote paths with `/`, and preserve only relative folder structure.
- File upload now queues remote destinations using the basename only.
- Added an Upload Folder toolbar/context-menu action that selects directories, recursively lists local contents, creates remote directories, and queues all files under the selected folder root.
- Normalized local recursive `relative_path` values to forward slashes in the Rust command.
- Fixed local Windows breadcrumb/parent helpers so existing Windows path tests pass.

## Verification
- RED: `pnpm test src/__tests__/upload-paths.test.ts` failed before implementation because `../lib/upload-paths` did not exist.
- PASS: `pnpm test src/__tests__/upload-paths.test.ts src/__tests__/file-entry-types.test.ts`
- PASS: `pnpm exec tsc --noEmit`
- PASS: `pnpm build`
- PASS: `pnpm lint` (0 errors; existing warnings remain)
- PASS: `cd src-tauri && cargo fmt --check`

## Local verification notes
- `pnpm test` still has pre-existing/environment failures outside this change: `connection.test.ts` calls Tauri `invoke` outside a Tauri runtime, `pty-terminal-activation.test.tsx` has an xterm mock missing `onLineFeed`, and `terminal-group-serializer.test.ts` uses a state shape missing `tabToGroupMap`.
- `cargo test test_list_local_files_recursive_returns_portable_relative_paths` is blocked on this Windows machine by the vendored OpenSSL build requiring a complete Perl install (`Locale::Maketext::Simple` missing). The Rust formatting check passed and the path-normalization helper was separately compile-checked with `rustc`.

Closes #22