### PR TITLE
fix: bound PTY websocket output buffering

### DIFF
--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -172,6 +172,14 @@ async fn flush_accumulated_output(
     queue_ws_frame(tx, Message::Binary(frame)).await
 }
 
+fn should_remove_pty_state(active_generation: Option<u64>, closed_generation: Option<u64>) -> bool {
+    match (active_generation, closed_generation) {
+        (Some(active), Some(closed)) => active == closed,
+        (Some(_), None) => true,
+        _ => false,
+    }
+}
+
 impl WebSocketServer {
     pub fn new(connection_manager: Arc<ConnectionManager>) -> Self {
         Self { connection_manager }
@@ -310,18 +318,13 @@ impl WebSocketServer {
                             connection_id,
                             generation,
                         }) => {
-                            let should_remove = match (
+                            if should_remove_pty_state(
                                 active_pty_generations.get(&connection_id).copied(),
                                 generation,
                             ) {
-                                (Some(active), Some(closed)) => active == closed,
-                                (Some(_), None) => true,
-                                _ => false,
-                            };
-                            if should_remove {
                                 active_pty_generations.remove(&connection_id);
+                                pause_controls.lock().await.remove(&connection_id);
                             }
-                            pause_controls.lock().await.remove(&connection_id);
                         }
                         Ok(PtyLifecycleEvent::None) => {}
                         Err(e) => {
@@ -762,5 +765,13 @@ mod tests {
             queue_ws_frame(&tx, Message::Text("second".to_string())).await,
             QueueSendOutcome::Dropped
         );
+    }
+
+    #[test]
+    fn stale_lifecycle_close_does_not_remove_active_pause_control() {
+        assert!(!should_remove_pty_state(Some(2), Some(1)));
+        assert!(should_remove_pty_state(Some(2), Some(2)));
+        assert!(should_remove_pty_state(Some(2), None));
+        assert!(!should_remove_pty_state(None, Some(1)));
     }
 }

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -745,7 +745,7 @@ mod tests {
 
     #[test]
     fn output_frame_encodes_connection_id_and_payload() {
-        let frame = encode_output_frame("conn-1", b"hello".to_vec());
+        let frame = encode_output_frame("conn-1", b"hello");
 
         assert_eq!(frame[0], BINARY_OUTPUT_COMMAND);
         assert_eq!(u16::from_be_bytes([frame[1], frame[2]]), 6);

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -3,10 +3,13 @@ use crate::WEBSOCKET_PORT;
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::sync::atomic::Ordering;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::{mpsc, watch, Mutex};
 use tokio_tungstenite::{accept_async, tungstenite::Message};
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -98,6 +101,77 @@ pub struct WebSocketServer {
     connection_manager: Arc<ConnectionManager>,
 }
 
+const WS_OUTPUT_QUEUE_CAPACITY: usize = 256;
+const OUTPUT_FLUSH_BYTES: usize = 16 * 1024;
+const OUTPUT_FLUSH_INTERVAL_MS: u128 = 10;
+const OUTPUT_QUEUE_SEND_TIMEOUT_MS: u64 = 100;
+const BINARY_OUTPUT_COMMAND: u8 = 0x01;
+
+type WsTx = mpsc::Sender<Message>;
+type PauseControls = Arc<Mutex<HashMap<String, watch::Sender<bool>>>>;
+
+#[derive(Debug, PartialEq, Eq)]
+enum QueueSendOutcome {
+    Sent,
+    Dropped,
+    Closed,
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum PtyLifecycleEvent {
+    None,
+    Started {
+        connection_id: String,
+        generation: u64,
+    },
+    Closed {
+        connection_id: String,
+        generation: Option<u64>,
+    },
+}
+
+fn encode_output_frame(connection_id: &str, data: Vec<u8>) -> Vec<u8> {
+    let connection_id = connection_id.as_bytes();
+    let id_len = connection_id.len().min(u16::MAX as usize);
+    let mut frame = Vec::with_capacity(3 + id_len + data.len());
+    frame.push(BINARY_OUTPUT_COMMAND);
+    frame.extend_from_slice(&(id_len as u16).to_be_bytes());
+    frame.extend_from_slice(&connection_id[..id_len]);
+    frame.extend_from_slice(&data);
+    frame
+}
+
+async fn queue_ws_frame(tx: &WsTx, frame: Message) -> QueueSendOutcome {
+    match tokio::time::timeout(
+        Duration::from_millis(OUTPUT_QUEUE_SEND_TIMEOUT_MS),
+        tx.send(frame),
+    )
+    .await
+    {
+        Ok(Ok(())) => QueueSendOutcome::Sent,
+        Ok(Err(_)) => QueueSendOutcome::Closed,
+        Err(_) => QueueSendOutcome::Dropped,
+    }
+}
+
+async fn queue_ws_json(tx: &WsTx, msg: &WsMessage) -> Result<QueueSendOutcome> {
+    Ok(queue_ws_frame(tx, Message::Text(serde_json::to_string(msg)?)).await)
+}
+
+async fn flush_accumulated_output(
+    tx: &WsTx,
+    connection_id: &str,
+    accumulated: &mut Vec<u8>,
+) -> QueueSendOutcome {
+    if accumulated.is_empty() {
+        return QueueSendOutcome::Sent;
+    }
+
+    let data = std::mem::replace(accumulated, Vec::with_capacity(OUTPUT_FLUSH_BYTES));
+    let frame = encode_output_frame(connection_id, data);
+    queue_ws_frame(tx, Message::Binary(frame)).await
+}
+
 impl WebSocketServer {
     pub fn new(connection_manager: Arc<ConnectionManager>) -> Self {
         Self { connection_manager }
@@ -155,12 +229,14 @@ impl WebSocketServer {
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
 
         // Create a channel for sending messages back to WebSocket from PTY reader task
-        let (tx, mut rx) = tokio::sync::mpsc::unbounded_channel::<String>();
+        let (tx, mut rx) = mpsc::channel::<Message>(WS_OUTPUT_QUEUE_CAPACITY);
+        let pause_controls: PauseControls = Arc::new(Mutex::new(HashMap::new()));
+        let mut active_pty_generations: HashMap<String, u64> = HashMap::new();
 
         // Task to forward messages from channel to WebSocket
         let ws_sender_task = tokio::spawn(async move {
             while let Some(msg) = rx.recv().await {
-                if ws_sender.send(Message::Text(msg)).await.is_err() {
+                if ws_sender.send(msg).await.is_err() {
                     break;
                 }
             }
@@ -214,19 +290,45 @@ impl WebSocketServer {
                             let error = WsMessage::Error {
                                 message: format!("Invalid message format: {}", e),
                             };
-                            let _ = tx.send(serde_json::to_string(&error)?);
+                            let _ = queue_ws_json(&tx, &error).await?;
                             continue;
                         }
                     };
 
                     // Handle the message
-                    match self.handle_message(ws_msg, tx.clone()).await {
-                        Ok(_) => {}
+                    match self
+                        .handle_message(ws_msg, tx.clone(), pause_controls.clone())
+                        .await
+                    {
+                        Ok(PtyLifecycleEvent::Started {
+                            connection_id,
+                            generation,
+                        }) => {
+                            active_pty_generations.insert(connection_id, generation);
+                        }
+                        Ok(PtyLifecycleEvent::Closed {
+                            connection_id,
+                            generation,
+                        }) => {
+                            let should_remove = match (
+                                active_pty_generations.get(&connection_id).copied(),
+                                generation,
+                            ) {
+                                (Some(active), Some(closed)) => active == closed,
+                                (Some(_), None) => true,
+                                _ => false,
+                            };
+                            if should_remove {
+                                active_pty_generations.remove(&connection_id);
+                            }
+                            pause_controls.lock().await.remove(&connection_id);
+                        }
+                        Ok(PtyLifecycleEvent::None) => {}
                         Err(e) => {
                             let error = WsMessage::Error {
                                 message: format!("Error handling message: {}", e),
                             };
-                            let _ = tx.send(serde_json::to_string(&error)?);
+                            let _ = queue_ws_json(&tx, &error).await?;
                         }
                     }
                 }
@@ -248,6 +350,20 @@ impl WebSocketServer {
         }
 
         // Cleanup
+        for (connection_id, generation) in active_pty_generations {
+            if let Err(e) = self
+                .connection_manager
+                .close_pty_connection(&connection_id, Some(generation))
+                .await
+            {
+                tracing::warn!(
+                    "Failed to close PTY session {} on WebSocket cleanup: {}",
+                    connection_id,
+                    e
+                );
+            }
+        }
+        pause_controls.lock().await.clear();
         ws_sender_task.abort();
 
         Ok(())
@@ -257,8 +373,9 @@ impl WebSocketServer {
     async fn handle_message(
         &self,
         msg: WsMessage,
-        tx: tokio::sync::mpsc::UnboundedSender<String>,
-    ) -> Result<()> {
+        tx: WsTx,
+        pause_controls: PauseControls,
+    ) -> Result<PtyLifecycleEvent> {
         match msg {
             WsMessage::StartPty {
                 connection_id,
@@ -292,22 +409,27 @@ impl WebSocketServer {
                 let response = WsMessage::Success {
                     message: format!("PTY connection started: {}", connection_id),
                 };
-                tx.send(serde_json::to_string(&response)?)?;
 
                 let started = WsMessage::PtyStarted {
                     connection_id: connection_id.clone(),
                     generation,
                 };
-                tx.send(serde_json::to_string(&started)?)?;
+                let _ = queue_ws_json(&tx, &response).await?;
+                let _ = queue_ws_json(&tx, &started).await?;
 
                 // Start reading from PTY and sending to WebSocket
                 let connection_manager = self.connection_manager.clone();
                 let connection_id_clone = connection_id.clone();
                 let tx_clone = tx.clone();
+                let (pause_tx, mut pause_rx) = watch::channel(false);
+                pause_controls
+                    .lock()
+                    .await
+                    .insert(connection_id.clone(), pause_tx);
 
                 tokio::spawn(async move {
                     // Buffer for accumulating small chunks
-                    let mut accumulated = Vec::with_capacity(8192);
+                    let mut accumulated = Vec::with_capacity(OUTPUT_FLUSH_BYTES);
                     let mut last_send = tokio::time::Instant::now();
 
                     loop {
@@ -315,6 +437,20 @@ impl WebSocketServer {
                         if cancel_token.is_cancelled() {
                             tracing::info!("PTY reader task cancelled for {}", connection_id_clone);
                             break;
+                        }
+
+                        while *pause_rx.borrow() {
+                            tokio::select! {
+                                _ = cancel_token.cancelled() => {
+                                    tracing::info!("PTY reader task cancelled while paused for {}", connection_id_clone);
+                                    return;
+                                }
+                                changed = pause_rx.changed() => {
+                                    if changed.is_err() {
+                                        return;
+                                    }
+                                }
+                            }
                         }
 
                         let read_result = tokio::select! {
@@ -330,22 +466,30 @@ impl WebSocketServer {
                                 if data.is_empty() {
                                     // Send accumulated data if we have any and timeout reached
                                     if !accumulated.is_empty()
-                                        && last_send.elapsed().as_millis() > 5
+                                        && last_send.elapsed().as_millis()
+                                            > OUTPUT_FLUSH_INTERVAL_MS
                                     {
-                                        let output = WsMessage::Output {
-                                            connection_id: connection_id_clone.clone(),
-                                            data: accumulated.clone(),
-                                        };
-
-                                        if let Ok(json) = serde_json::to_string(&output) {
-                                            if tx_clone.send(json).is_err() {
+                                        match flush_accumulated_output(
+                                            &tx_clone,
+                                            &connection_id_clone,
+                                            &mut accumulated,
+                                        )
+                                        .await
+                                        {
+                                            QueueSendOutcome::Sent => {}
+                                            QueueSendOutcome::Dropped => {
+                                                tracing::warn!(
+                                                    "Dropping PTY output for {} because WebSocket output queue is full",
+                                                    connection_id_clone
+                                                );
+                                            }
+                                            QueueSendOutcome::Closed => {
                                                 tracing::error!(
                                                     "Failed to send output to WebSocket"
                                                 );
                                                 break;
                                             }
                                         }
-                                        accumulated.clear();
                                         last_send = tokio::time::Instant::now();
                                     }
                                     continue;
@@ -355,21 +499,30 @@ impl WebSocketServer {
                                 accumulated.extend_from_slice(&data);
 
                                 // Send immediately if:
-                                // 1. Buffer is large enough (> 4KB)
-                                // 2. Or 5ms has passed since last send
-                                if accumulated.len() > 4096 || last_send.elapsed().as_millis() > 5 {
-                                    let output = WsMessage::Output {
-                                        connection_id: connection_id_clone.clone(),
-                                        data: accumulated.clone(),
-                                    };
-
-                                    if let Ok(json) = serde_json::to_string(&output) {
-                                        if tx_clone.send(json).is_err() {
+                                // 1. Buffer is large enough
+                                // 2. Or the flush interval has passed since last send
+                                if accumulated.len() >= OUTPUT_FLUSH_BYTES
+                                    || last_send.elapsed().as_millis() > OUTPUT_FLUSH_INTERVAL_MS
+                                {
+                                    match flush_accumulated_output(
+                                        &tx_clone,
+                                        &connection_id_clone,
+                                        &mut accumulated,
+                                    )
+                                    .await
+                                    {
+                                        QueueSendOutcome::Sent => {}
+                                        QueueSendOutcome::Dropped => {
+                                            tracing::warn!(
+                                                "Dropping PTY output for {} because WebSocket output queue is full",
+                                                connection_id_clone
+                                            );
+                                        }
+                                        QueueSendOutcome::Closed => {
                                             tracing::error!("Failed to send output to WebSocket");
                                             break;
                                         }
                                     }
-                                    accumulated.clear();
                                     last_send = tokio::time::Instant::now();
                                 }
                             }
@@ -378,14 +531,17 @@ impl WebSocketServer {
                                 let error_msg = WsMessage::Error {
                                     message: format!("Connection lost: {}", e),
                                 };
-                                if let Ok(json) = serde_json::to_string(&error_msg) {
-                                    let _ = tx_clone.send(json);
-                                }
+                                let _ = queue_ws_json(&tx_clone, &error_msg).await;
                                 break;
                             }
                         }
                     }
                 });
+
+                Ok(PtyLifecycleEvent::Started {
+                    connection_id,
+                    generation,
+                })
             }
             WsMessage::Input {
                 connection_id,
@@ -399,6 +555,7 @@ impl WebSocketServer {
                 self.connection_manager
                     .write_to_pty(&connection_id, data)
                     .await?;
+                Ok(PtyLifecycleEvent::None)
             }
             WsMessage::Resize {
                 connection_id,
@@ -412,19 +569,22 @@ impl WebSocketServer {
                 let response = WsMessage::Success {
                     message: format!("Terminal resized: {}x{}", cols, rows),
                 };
-                tx.send(serde_json::to_string(&response)?)?;
+                let _ = queue_ws_json(&tx, &response).await?;
+                Ok(PtyLifecycleEvent::None)
             }
             WsMessage::Pause { connection_id } => {
                 tracing::debug!("Pausing output for connection: {}", connection_id);
-                // Flow control: pause reading from PTY
-                // In a full implementation, we'd pause the output task
-                // For now, just acknowledge
+                if let Some(control) = pause_controls.lock().await.get(&connection_id) {
+                    let _ = control.send(true);
+                }
+                Ok(PtyLifecycleEvent::None)
             }
             WsMessage::Resume { connection_id } => {
                 tracing::debug!("Resuming output for connection: {}", connection_id);
-                // Flow control: resume reading from PTY
-                // In a full implementation, we'd resume the output task
-                // For now, just acknowledge
+                if let Some(control) = pause_controls.lock().await.get(&connection_id) {
+                    let _ = control.send(false);
+                }
+                Ok(PtyLifecycleEvent::None)
             }
             WsMessage::Close {
                 connection_id,
@@ -441,7 +601,11 @@ impl WebSocketServer {
                 let response = WsMessage::Success {
                     message: format!("PTY connection closed: {}", connection_id),
                 };
-                tx.send(serde_json::to_string(&response)?)?;
+                let _ = queue_ws_json(&tx, &response).await?;
+                Ok(PtyLifecycleEvent::Closed {
+                    connection_id,
+                    generation,
+                })
             }
 
             // ===== Desktop (RDP/VNC) message handling =====
@@ -467,15 +631,16 @@ impl WebSocketServer {
                         width: w,
                         height: h,
                     };
-                    tx.send(serde_json::to_string(&started)?)?;
+                    let _ = queue_ws_json(&tx, &started).await?;
 
                     // TODO: start frame streaming loop when protocol clients are implemented
                 } else {
                     let error = WsMessage::Error {
                         message: format!("Desktop connection not found: {}", connection_id),
                     };
-                    tx.send(serde_json::to_string(&error)?)?;
+                    let _ = queue_ws_json(&tx, &error).await?;
                 }
+                Ok(PtyLifecycleEvent::None)
             }
 
             WsMessage::DesktopKeyEvent {
@@ -493,6 +658,7 @@ impl WebSocketServer {
                         tracing::error!("Failed to send desktop key event: {}", e);
                     }
                 }
+                Ok(PtyLifecycleEvent::None)
             }
 
             WsMessage::DesktopPointerEvent {
@@ -511,6 +677,7 @@ impl WebSocketServer {
                         tracing::error!("Failed to send desktop pointer event: {}", e);
                     }
                 }
+                Ok(PtyLifecycleEvent::None)
             }
 
             WsMessage::ClipboardUpdate {
@@ -527,6 +694,7 @@ impl WebSocketServer {
                         tracing::error!("Failed to set desktop clipboard: {}", e);
                     }
                 }
+                Ok(PtyLifecycleEvent::None)
             }
 
             WsMessage::RequestFullFrame { connection_id } => {
@@ -540,6 +708,7 @@ impl WebSocketServer {
                         tracing::error!("Failed to request full frame: {}", e);
                     }
                 }
+                Ok(PtyLifecycleEvent::None)
             }
 
             WsMessage::CloseDesktop { connection_id } => {
@@ -554,14 +723,44 @@ impl WebSocketServer {
                 let response = WsMessage::Success {
                     message: format!("Desktop connection closed: {}", connection_id),
                 };
-                tx.send(serde_json::to_string(&response)?)?;
+                let _ = queue_ws_json(&tx, &response).await?;
+                Ok(PtyLifecycleEvent::None)
             }
 
             _ => {
                 tracing::warn!("Unexpected message type received");
+                Ok(PtyLifecycleEvent::None)
             }
         }
+    }
+}
 
-        Ok(())
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tokio_tungstenite::tungstenite::Message;
+
+    #[test]
+    fn output_frame_encodes_connection_id_and_payload() {
+        let frame = encode_output_frame("conn-1", b"hello".to_vec());
+
+        assert_eq!(frame[0], BINARY_OUTPUT_COMMAND);
+        assert_eq!(u16::from_be_bytes([frame[1], frame[2]]), 6);
+        assert_eq!(&frame[3..9], b"conn-1");
+        assert_eq!(&frame[9..], b"hello");
+    }
+
+    #[tokio::test]
+    async fn bounded_ws_queue_drops_when_receiver_is_full() {
+        let (tx, _rx) = tokio::sync::mpsc::channel::<Message>(1);
+
+        assert_eq!(
+            queue_ws_frame(&tx, Message::Text("first".to_string())).await,
+            QueueSendOutcome::Sent
+        );
+        assert_eq!(
+            queue_ws_frame(&tx, Message::Text("second".to_string())).await,
+            QueueSendOutcome::Dropped
+        );
     }
 }

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -130,14 +130,14 @@ enum PtyLifecycleEvent {
     },
 }
 
-fn encode_output_frame(connection_id: &str, data: Vec<u8>) -> Vec<u8> {
-    let connection_id = connection_id.as_bytes();
-    let id_len = connection_id.len().min(u16::MAX as usize);
+fn encode_output_frame(connection_id: &str, data: &[u8]) -> Vec<u8> {
+    let id_bytes = connection_id.as_bytes();
+    let id_len = id_bytes.len().min(u16::MAX as usize);
     let mut frame = Vec::with_capacity(3 + id_len + data.len());
     frame.push(BINARY_OUTPUT_COMMAND);
     frame.extend_from_slice(&(id_len as u16).to_be_bytes());
-    frame.extend_from_slice(&connection_id[..id_len]);
-    frame.extend_from_slice(&data);
+    frame.extend_from_slice(&id_bytes[..id_len]);
+    frame.extend_from_slice(data);
     frame
 }
 
@@ -167,8 +167,8 @@ async fn flush_accumulated_output(
         return QueueSendOutcome::Sent;
     }
 
-    let data = std::mem::replace(accumulated, Vec::with_capacity(OUTPUT_FLUSH_BYTES));
-    let frame = encode_output_frame(connection_id, data);
+    let frame = encode_output_frame(connection_id, accumulated);
+    accumulated.clear();
     queue_ws_frame(tx, Message::Binary(frame)).await
 }
 
@@ -442,7 +442,7 @@ impl WebSocketServer {
                             break;
                         }
 
-                        while *pause_rx.borrow() {
+                        while *pause_rx.borrow_and_update() {
                             tokio::select! {
                                 _ = cancel_token.cancelled() => {
                                     tracing::info!("PTY reader task cancelled while paused for {}", connection_id_clone);

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -29,6 +29,7 @@ const mocks = vi.hoisted(() => {
     attachCustomKeyEventHandler = vi.fn();
     onData = vi.fn(() => ({ dispose: vi.fn() }));
     onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
     hasSelection = vi.fn(() => false);
     getSelection = vi.fn(() => '');
     selectAll = vi.fn();

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -156,6 +156,17 @@ function renderTerminal(isActive: boolean) {
   );
 }
 
+function binaryOutputFrame(connectionId: string, payload: Uint8Array) {
+  const idBytes = new TextEncoder().encode(connectionId);
+  const frame = new Uint8Array(3 + idBytes.length + payload.length);
+  frame[0] = 0x01;
+  frame[1] = (idBytes.length >> 8) & 0xff;
+  frame[2] = idBytes.length & 0xff;
+  frame.set(idBytes, 3);
+  frame.set(payload, 3 + idBytes.length);
+  return frame.buffer;
+}
+
 async function flushTimers() {
   await act(async () => {
     await vi.runOnlyPendingTimersAsync();
@@ -258,5 +269,23 @@ describe('PtyTerminal activation', () => {
     expect(mocks.terminals).toHaveLength(terminalCount);
     expect(mocks.webSockets).toHaveLength(webSocketCount);
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
+  it('streams UTF-8 binary output across WebSocket frame boundaries', async () => {
+    renderTerminal(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+    const terminal = mocks.terminals[0];
+    const ws = mocks.webSockets[0];
+    terminal.write.mockClear();
+
+    const utf8 = new TextEncoder().encode('中');
+    await act(async () => {
+      ws.onmessage?.({ data: binaryOutputFrame('connection-1', utf8.slice(0, 1)) } as MessageEvent);
+      ws.onmessage?.({ data: binaryOutputFrame('connection-1', utf8.slice(1)) } as MessageEvent);
+    });
+
+    expect(terminal.write.mock.calls.map(([text]) => text).join('')).toBe('中');
   });
 });

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -321,7 +321,7 @@ export function PtyTerminal({
       const writeOutput = (data: Uint8Array) => {
         if (data.length === 0) return;
 
-        const text = outputDecoder.decode(data);
+        const text = outputDecoder.decode(data, { stream: true });
         const flowControl = flowControlRef.current;
 
         flowControl.written += text.length;

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -313,7 +313,65 @@ export function PtyTerminal({
       
       console.log(`[PTY Terminal] [${connectionId}] Connecting to WebSocket...`);
       const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+      ws.binaryType = 'arraybuffer';
       wsRef.current = ws;
+      const outputDecoder = new TextDecoder();
+      const connectionIdDecoder = new TextDecoder();
+
+      const writeOutput = (data: Uint8Array) => {
+        if (data.length === 0) return;
+
+        const text = outputDecoder.decode(data);
+        const flowControl = flowControlRef.current;
+
+        flowControl.written += text.length;
+
+        // Use callback-based write for flow control
+        if (flowControl.written > flowControl.limit) {
+          term.write(text, () => {
+            flowControl.pending = Math.max(flowControl.pending - 1, 0);
+
+            // Send RESUME when pending drops below lowWater
+            if (flowControl.pending < flowControl.lowWater) {
+              if (ws.readyState === WebSocket.OPEN) {
+                ws.send(JSON.stringify({
+                  type: 'Resume',
+                  connection_id: connectionId,
+                }));
+              }
+            }
+          });
+
+          flowControl.pending++;
+          flowControl.written = 0;
+
+          // Send PAUSE when pending exceeds highWater
+          if (flowControl.pending > flowControl.highWater) {
+            if (ws.readyState === WebSocket.OPEN) {
+              ws.send(JSON.stringify({
+                type: 'Pause',
+                connection_id: connectionId,
+              }));
+            }
+          }
+        } else {
+          // Fast path: write immediately without callback
+          term.write(text);
+        }
+      };
+
+      const handleBinaryMessage = (data: Uint8Array) => {
+        if (data.length < 3 || data[0] !== 0x01) return;
+
+        const idLength = (data[1] << 8) | data[2];
+        const payloadOffset = 3 + idLength;
+        if (data.length < payloadOffset) return;
+
+        const frameConnectionId = connectionIdDecoder.decode(data.subarray(3, payloadOffset));
+        if (frameConnectionId !== connectionId) return;
+
+        writeOutput(data.subarray(payloadOffset));
+      };
 
       ws.onopen = () => {
         console.log(`[PTY Terminal] [${connectionId}] WebSocket connected`);
@@ -332,6 +390,20 @@ export function PtyTerminal({
 
       ws.onmessage = (event) => {
         try {
+          if (event.data instanceof ArrayBuffer) {
+            handleBinaryMessage(new Uint8Array(event.data));
+            return;
+          }
+
+          if (event.data instanceof Blob) {
+            void event.data.arrayBuffer().then((buffer) => {
+              if (isRunning) {
+                handleBinaryMessage(new Uint8Array(buffer));
+              }
+            });
+            return;
+          }
+
           const msg = JSON.parse(event.data);
           
           switch (msg.type) {
@@ -370,43 +442,7 @@ export function PtyTerminal({
               // Terminal output from PTY
               // Implement flow control like ttyd
               if (msg.data && msg.data.length > 0) {
-                const text = new TextDecoder().decode(new Uint8Array(msg.data));
-                const flowControl = flowControlRef.current;
-                
-                flowControl.written += text.length;
-                
-                // Use callback-based write for flow control
-                if (flowControl.written > flowControl.limit) {
-                  term.write(text, () => {
-                    flowControl.pending = Math.max(flowControl.pending - 1, 0);
-                    
-                    // Send RESUME when pending drops below lowWater
-                    if (flowControl.pending < flowControl.lowWater) {
-                      if (ws && ws.readyState === WebSocket.OPEN) {
-                        ws.send(JSON.stringify({
-                          type: 'Resume',
-                          connection_id: connectionId,
-                        }));
-                      }
-                    }
-                  });
-                  
-                  flowControl.pending++;
-                  flowControl.written = 0;
-                  
-                  // Send PAUSE when pending exceeds highWater
-                  if (flowControl.pending > flowControl.highWater) {
-                    if (ws && ws.readyState === WebSocket.OPEN) {
-                      ws.send(JSON.stringify({
-                        type: 'Pause',
-                        connection_id: connectionId,
-                      }));
-                    }
-                  }
-                } else {
-                  // Fast path: write immediately without callback
-                  term.write(text);
-                }
+                writeOutput(new Uint8Array(msg.data));
               }
               break;
               


### PR DESCRIPTION
## Summary

- Bound the PTY -> WebSocket output queue and add timeout/drop behavior so slow frontend/WebSocket consumers cannot grow backend memory without bound.
- Send PTY output as binary WebSocket frames instead of JSON `Vec<u8>` payloads, while keeping the existing JSON path as a compatibility fallback.
- Make Pause/Resume actually pause the PTY reader and clean up active PTY sessions on WebSocket disconnect.

Closes #26

## Testing

- `cargo test websocket_server::tests`
- `cargo check`
- `cargo test --lib -- --skip ssh::tests::key_loading_tests::test_connect_missing_key_file_returns_error`
- `npm exec --yes pnpm@9.15.4 -- exec tsc --noEmit`
- `npm exec --yes pnpm@9.15.4 -- test src\__tests__\pty-terminal-activation.test.tsx src\__tests__\pty-terminal-scrollbar.test.tsx`
- `npm exec --yes pnpm@9.15.4 -- lint`
- `rustfmt --edition 2021 --check src\websocket_server.rs`
- `git diff --check`

Note: full `cargo test` currently has one unrelated environment-sensitive failure: `ssh::tests::key_loading_tests::test_connect_missing_key_file_returns_error` attempts to connect to `127.0.0.1:22` and gets connection refused before the missing-key assertion. `cargo fmt --check` also reports unrelated pre-existing formatting in `src-tauri/src/commands.rs`.