### PR TITLE
fix: avoid terminal shortcut conflicts

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,10 +170,13 @@ R-Shell is a free, open-source, cross-platform SSH client that combines an inter
 | `Ctrl+\` | Split terminal right |
 | `Ctrl+Shift+\` | Split terminal down |
 | `Ctrl+1` – `9` | Focus terminal group |
-| `Ctrl+W` | Close active tab |
+| `Ctrl+Shift+W` | Close active tab |
 | `Ctrl+Tab` | Next tab |
+| `Cmd/Ctrl+V` | Paste into terminal |
 | `Cmd/Ctrl+F` | Search in terminal |
 | `F3` / `Shift+F3` | Find next / previous |
+
+Layout shortcuts are ignored while the terminal input is focused, so terminal-native bindings such as tmux `Ctrl+B` still reach the shell.
 
 ### 🔧 Additional Features
 - **VS Code-like layout** — resizable left/right sidebars + bottom panel with 5 layout presets (Default, Minimal, Focus, Full Stack, Zen)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -70,7 +70,7 @@ fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tau
                 "close_connection",
                 "Close Tab",
                 true,
-                Some("CmdOrCtrl+W"),
+                None::<&str>,
             )?,
         ],
     )?;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,14 @@ import { ActiveConnectionsManager, ConnectionStorageManager } from './lib/connec
 import { isDesktopProtocol } from './lib/protocol-config';
 import { registerRestoration, clearAllRestorations } from './lib/restoration-manager';
 import { useLayout, LayoutProvider } from './lib/layout-context';
-import { useKeyboardShortcuts, createLayoutShortcuts, createSplitViewShortcuts } from './lib/keyboard-shortcuts';
+import {
+  APP_SETTINGS_CHANGED_EVENT,
+  createLayoutShortcuts,
+  createSplitViewShortcuts,
+  loadKeyboardShortcutSettings,
+  useKeyboardShortcuts,
+} from './lib/keyboard-shortcuts';
+import type { SplitViewShortcutBindings } from './lib/keyboard-shortcuts';
 import { TerminalGroupProvider, useTerminalGroups } from './lib/terminal-group-context';
 import { TerminalCallbacksProvider } from './lib/terminal-callbacks-context';
 import { GridRenderer } from './components/terminal/grid-renderer';
@@ -53,6 +60,9 @@ function AppContent() {
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ConnectionConfig | null>(null);
   const [updateCheckSignal, setUpdateCheckSignal] = useState(0);
+  const [keyboardShortcutSettings, setKeyboardShortcutSettings] = useState<SplitViewShortcutBindings>(
+    () => loadKeyboardShortcutSettings(),
+  );
 
   // Right sidebar tab & log monitor integration
   const [rightSidebarTab, setRightSidebarTab] = useState("monitor");
@@ -82,46 +92,62 @@ function AppContent() {
     return Object.values(state.groups).flatMap(g => g.tabs);
   }, [state.groups]);
 
+  useEffect(() => {
+    const refreshKeyboardShortcutSettings = () => {
+      setKeyboardShortcutSettings(loadKeyboardShortcutSettings());
+    };
+
+    window.addEventListener(APP_SETTINGS_CHANGED_EVENT, refreshKeyboardShortcutSettings);
+    window.addEventListener('storage', refreshKeyboardShortcutSettings);
+    return () => {
+      window.removeEventListener(APP_SETTINGS_CHANGED_EVENT, refreshKeyboardShortcutSettings);
+      window.removeEventListener('storage', refreshKeyboardShortcutSettings);
+    };
+  }, []);
+
   // Keyboard shortcuts: layout + split view
   const splitViewShortcuts = useMemo(() => {
     const groupIds = Object.keys(state.groups);
-    return createSplitViewShortcuts({
-      splitRight: () => {
-        if (state.activeGroupId) {
-          dispatch({ type: 'SPLIT_GROUP', groupId: state.activeGroupId, direction: 'right' });
-        }
+    return createSplitViewShortcuts(
+      {
+        splitRight: () => {
+          if (state.activeGroupId) {
+            dispatch({ type: 'SPLIT_GROUP', groupId: state.activeGroupId, direction: 'right' });
+          }
+        },
+        splitDown: () => {
+          if (state.activeGroupId) {
+            dispatch({ type: 'SPLIT_GROUP', groupId: state.activeGroupId, direction: 'down' });
+          }
+        },
+        focusGroup: (index: number) => {
+          if (index < groupIds.length) {
+            dispatch({ type: 'ACTIVATE_GROUP', groupId: groupIds[index] });
+          }
+        },
+        closeTab: () => {
+          if (activeGroup && activeGroup.activeTabId) {
+            dispatch({ type: 'REMOVE_TAB', groupId: activeGroup.id, tabId: activeGroup.activeTabId });
+          }
+        },
+        nextTab: () => {
+          if (activeGroup && activeGroup.activeTabId && activeGroup.tabs.length > 1) {
+            const currentIndex = activeGroup.tabs.findIndex(t => t.id === activeGroup.activeTabId);
+            const nextIndex = (currentIndex + 1) % activeGroup.tabs.length;
+            dispatch({ type: 'ACTIVATE_TAB', groupId: activeGroup.id, tabId: activeGroup.tabs[nextIndex].id });
+          }
+        },
+        prevTab: () => {
+          if (activeGroup && activeGroup.activeTabId && activeGroup.tabs.length > 1) {
+            const currentIndex = activeGroup.tabs.findIndex(t => t.id === activeGroup.activeTabId);
+            const prevIndex = (currentIndex - 1 + activeGroup.tabs.length) % activeGroup.tabs.length;
+            dispatch({ type: 'ACTIVATE_TAB', groupId: activeGroup.id, tabId: activeGroup.tabs[prevIndex].id });
+          }
+        },
       },
-      splitDown: () => {
-        if (state.activeGroupId) {
-          dispatch({ type: 'SPLIT_GROUP', groupId: state.activeGroupId, direction: 'down' });
-        }
-      },
-      focusGroup: (index: number) => {
-        if (index < groupIds.length) {
-          dispatch({ type: 'ACTIVATE_GROUP', groupId: groupIds[index] });
-        }
-      },
-      closeTab: () => {
-        if (activeGroup && activeGroup.activeTabId) {
-          dispatch({ type: 'REMOVE_TAB', groupId: activeGroup.id, tabId: activeGroup.activeTabId });
-        }
-      },
-      nextTab: () => {
-        if (activeGroup && activeGroup.activeTabId && activeGroup.tabs.length > 1) {
-          const currentIndex = activeGroup.tabs.findIndex(t => t.id === activeGroup.activeTabId);
-          const nextIndex = (currentIndex + 1) % activeGroup.tabs.length;
-          dispatch({ type: 'ACTIVATE_TAB', groupId: activeGroup.id, tabId: activeGroup.tabs[nextIndex].id });
-        }
-      },
-      prevTab: () => {
-        if (activeGroup && activeGroup.activeTabId && activeGroup.tabs.length > 1) {
-          const currentIndex = activeGroup.tabs.findIndex(t => t.id === activeGroup.activeTabId);
-          const prevIndex = (currentIndex - 1 + activeGroup.tabs.length) % activeGroup.tabs.length;
-          dispatch({ type: 'ACTIVATE_TAB', groupId: activeGroup.id, tabId: activeGroup.tabs[prevIndex].id });
-        }
-      },
-    });
-  }, [state.activeGroupId, state.groups, activeGroup, dispatch]);
+      keyboardShortcutSettings,
+    );
+  }, [state.activeGroupId, state.groups, activeGroup, dispatch, keyboardShortcutSettings]);
 
   const layoutShortcuts = useMemo(() => createLayoutShortcuts({
     toggleLeftSidebar,
@@ -1516,6 +1542,7 @@ function AppContent() {
         }}
         onOpenSettings={handleOpenSettings}
         onCheckForUpdates={() => setUpdateCheckSignal((current) => current + 1)}
+        closeConnectionShortcutLabel={keyboardShortcutSettings.closeTab}
         hasActiveConnection={!!activeTab}
         canPaste={true}
         onToggleLeftSidebar={toggleLeftSidebar}

--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { IntegratedFileBrowser } from '../components/integrated-file-browser';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({
+  open: vi.fn(),
+  save: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+vi.mock('../components/directory-tree', () => ({
+  DirectoryTree: () => <div data-testid="directory-tree" />,
+}));
+
+vi.mock('../components/transfer-queue', () => ({
+  TransferQueue: () => null,
+}));
+
+vi.mock('../components/ui/resizable', () => ({
+  ResizableHandle: () => <div data-testid="resize-handle" />,
+  ResizablePanel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  ResizablePanelGroup: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('IntegratedFileBrowser keyboard shortcuts', () => {
+  it('does not intercept document shortcuts from editable targets', () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-1"
+        isConnected={false}
+        onClose={() => {}}
+      />,
+    );
+
+    const input = document.createElement('input');
+    document.body.appendChild(input);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'a',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const preventDefault = vi.spyOn(event, 'preventDefault');
+
+    input.dispatchEvent(event);
+
+    expect(preventDefault).not.toHaveBeenCalled();
+
+    input.remove();
+  });
+});

--- a/src/__tests__/keyboard-shortcuts-hook.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-hook.test.tsx
@@ -1,0 +1,98 @@
+import React from 'react';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { isEditableTarget, useKeyboardShortcuts } from '../lib/keyboard-shortcuts';
+
+function ShortcutHarness({ handler }: { handler: () => void }) {
+  useKeyboardShortcuts([
+    {
+      key: 'b',
+      ctrlKey: true,
+      handler,
+      description: 'Toggle sidebar',
+    },
+  ]);
+
+  return (
+    <div>
+      <input data-testid="input" defaultValue="host" />
+      <textarea data-testid="textarea" defaultValue="notes" />
+      <div data-testid="editable" contentEditable suppressContentEditableWarning>
+        editable
+      </div>
+      <div data-testid="plain" tabIndex={0}>
+        plain
+      </div>
+    </div>
+  );
+}
+
+function dispatchCtrlB(target: Element) {
+  const event = new KeyboardEvent('keydown', {
+    key: 'b',
+    ctrlKey: true,
+    bubbles: true,
+    cancelable: true,
+  });
+  const preventDefault = vi.spyOn(event, 'preventDefault');
+  target.dispatchEvent(event);
+  return preventDefault;
+}
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('isEditableTarget', () => {
+  it('identifies text-editable targets', () => {
+    const input = document.createElement('input');
+    const textarea = document.createElement('textarea');
+    const editable = document.createElement('div');
+    editable.setAttribute('contenteditable', 'true');
+    const plaintextEditable = document.createElement('div');
+    plaintextEditable.setAttribute('contenteditable', 'plaintext-only');
+
+    expect(isEditableTarget(input)).toBe(true);
+    expect(isEditableTarget(textarea)).toBe(true);
+    expect(isEditableTarget(editable)).toBe(true);
+    expect(isEditableTarget(plaintextEditable)).toBe(true);
+  });
+
+  it('does not treat non-editable targets as editable', () => {
+    const button = document.createElement('button');
+    const select = document.createElement('select');
+    const contentEditableFalse = document.createElement('div');
+    contentEditableFalse.setAttribute('contenteditable', 'false');
+
+    expect(isEditableTarget(button)).toBe(false);
+    expect(isEditableTarget(select)).toBe(false);
+    expect(isEditableTarget(contentEditableFalse)).toBe(false);
+    expect(isEditableTarget(null)).toBe(false);
+  });
+});
+
+describe('useKeyboardShortcuts editable targets', () => {
+  it.each(['input', 'textarea', 'editable'])(
+    'does not intercept shortcuts dispatched from %s',
+    (testId) => {
+      const handler = vi.fn();
+      render(<ShortcutHarness handler={handler} />);
+
+      const preventDefault = dispatchCtrlB(screen.getByTestId(testId));
+
+      expect(handler).not.toHaveBeenCalled();
+      expect(preventDefault).not.toHaveBeenCalled();
+    },
+  );
+
+  it('still intercepts matching shortcuts outside editable elements', () => {
+    const handler = vi.fn();
+    render(<ShortcutHarness handler={handler} />);
+
+    const preventDefault = dispatchCtrlB(screen.getByTestId('plain'));
+
+    expect(handler).toHaveBeenCalledOnce();
+    expect(preventDefault).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -1,5 +1,15 @@
-import { describe, it, expect, vi } from 'vitest';
-import { createSplitViewShortcuts, KeyboardShortcut } from '../lib/keyboard-shortcuts';
+import React from 'react';
+import { cleanup, render } from '@testing-library/react';
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import {
+  createLayoutShortcuts,
+  createSplitViewShortcuts,
+  DEFAULT_SPLIT_VIEW_SHORTCUTS,
+  KeyboardShortcut,
+  loadKeyboardShortcutSettings,
+  parseKeyboardShortcut,
+  useKeyboardShortcuts,
+} from '../lib/keyboard-shortcuts';
 
 function createMockActions() {
   return {
@@ -82,11 +92,31 @@ describe('createSplitViewShortcuts', () => {
     );
   });
 
-  // Requirement 5.3: Ctrl+W closes active tab
-  it('Ctrl+W triggers closeTab', () => {
+  // Requirement 5.3: Ctrl+Shift+W closes active tab without stealing bash Ctrl+W
+  it('Ctrl+Shift+W triggers closeTab by default', () => {
+    const actions = createMockActions();
+    const shortcuts = createSplitViewShortcuts(actions);
+    const shortcut = findShortcut(shortcuts, 'w', { ctrlKey: true, shiftKey: true });
+
+    expect(shortcut).toBeDefined();
+    shortcut!.handler();
+    expect(actions.closeTab).toHaveBeenCalledOnce();
+  });
+
+  it('does not bind Ctrl+W to closeTab by default', () => {
     const actions = createMockActions();
     const shortcuts = createSplitViewShortcuts(actions);
     const shortcut = findShortcut(shortcuts, 'w', { ctrlKey: true, shiftKey: false });
+
+    expect(shortcut).toBeUndefined();
+  });
+
+  it('uses a custom closeTab shortcut when provided', () => {
+    const actions = createMockActions();
+    const shortcuts = createSplitViewShortcuts(actions, { closeTab: 'Alt+W' });
+    const shortcut = shortcuts.find(
+      (s) => s.key === 'w' && s.altKey === true && s.ctrlKey === false && s.shiftKey === false,
+    );
 
     expect(shortcut).toBeDefined();
     shortcut!.handler();
@@ -146,5 +176,107 @@ describe('createSplitViewShortcuts', () => {
     for (const shortcut of shortcuts) {
       expect(shortcut.description).toBeTruthy();
     }
+  });
+});
+
+describe('useKeyboardShortcuts', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  function ShortcutHarness({ shortcuts }: { shortcuts: KeyboardShortcut[] }) {
+    useKeyboardShortcuts(shortcuts);
+    return null;
+  }
+
+  it('does not intercept terminal Ctrl+B for layout shortcuts', () => {
+    const actions = {
+      toggleLeftSidebar: vi.fn(),
+      toggleRightSidebar: vi.fn(),
+      toggleBottomPanel: vi.fn(),
+      toggleZenMode: vi.fn(),
+    };
+    const shortcuts = createLayoutShortcuts(actions);
+    render(React.createElement(ShortcutHarness, { shortcuts }));
+
+    const xterm = document.createElement('div');
+    xterm.className = 'xterm';
+    const textarea = document.createElement('textarea');
+    xterm.appendChild(textarea);
+    document.body.appendChild(xterm);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'b',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const wasNotPrevented = textarea.dispatchEvent(event);
+
+    expect(wasNotPrevented).toBe(true);
+    expect(actions.toggleLeftSidebar).not.toHaveBeenCalled();
+  });
+
+  it('still handles layout Ctrl+B outside the terminal', () => {
+    const actions = {
+      toggleLeftSidebar: vi.fn(),
+      toggleRightSidebar: vi.fn(),
+      toggleBottomPanel: vi.fn(),
+      toggleZenMode: vi.fn(),
+    };
+    const shortcuts = createLayoutShortcuts(actions);
+    render(React.createElement(ShortcutHarness, { shortcuts }));
+
+    const button = document.createElement('button');
+    document.body.appendChild(button);
+
+    const event = new KeyboardEvent('keydown', {
+      key: 'b',
+      ctrlKey: true,
+      bubbles: true,
+      cancelable: true,
+    });
+    const wasNotPrevented = button.dispatchEvent(event);
+
+    expect(wasNotPrevented).toBe(false);
+    expect(actions.toggleLeftSidebar).toHaveBeenCalledOnce();
+  });
+});
+
+describe('keyboard shortcut settings', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('parses shortcut strings with modifiers', () => {
+    expect(parseKeyboardShortcut('Ctrl+Shift+W')).toEqual({
+      key: 'w',
+      ctrlKey: true,
+      shiftKey: true,
+      altKey: false,
+      metaKey: false,
+    });
+  });
+
+  it('loads saved keyboard shortcuts from sshClientSettings', () => {
+    localStorage.setItem('sshClientSettings', JSON.stringify({
+      closeSession: 'Alt+W',
+      nextTab: 'Ctrl+PageDown',
+      previousTab: 'Ctrl+PageUp',
+    }));
+
+    expect(loadKeyboardShortcutSettings()).toEqual({
+      closeTab: 'Alt+W',
+      nextTab: 'Ctrl+PageDown',
+      prevTab: 'Ctrl+PageUp',
+    });
+  });
+
+  it('migrates the legacy Ctrl+W close shortcut to the new default', () => {
+    localStorage.setItem('sshClientSettings', JSON.stringify({
+      closeSession: 'Ctrl+W',
+    }));
+
+    expect(loadKeyboardShortcutSettings().closeTab).toBe(DEFAULT_SPLIT_VIEW_SHORTCUTS.closeTab);
   });
 });

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -26,6 +26,7 @@ const mocks = vi.hoisted(() => {
     writeln = vi.fn();
     write = vi.fn((_data: string, callback?: () => void) => callback?.());
     onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
     attachCustomKeyEventHandler = vi.fn();
     onData = vi.fn(() => ({ dispose: vi.fn() }));
     onResize = vi.fn(() => ({ dispose: vi.fn() }));
@@ -161,6 +162,19 @@ async function flushTimers() {
   });
 }
 
+function getCustomKeyHandler() {
+  const handler = mocks.terminals[0].attachCustomKeyEventHandler.mock.calls[0]?.[0];
+  expect(handler).toBeDefined();
+  return handler as (event: KeyboardEvent) => boolean;
+}
+
+async function flushPromises() {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 describe('PtyTerminal activation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -257,5 +271,73 @@ describe('PtyTerminal activation', () => {
     expect(mocks.terminals).toHaveLength(terminalCount);
     expect(mocks.webSockets).toHaveLength(webSocketCount);
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
+  it('pastes clipboard text into the PTY with Ctrl+V', async () => {
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: 'Win32',
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        readText: vi.fn().mockResolvedValue('pasted text'),
+      },
+    });
+    renderTerminal(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+
+    const preventDefault = vi.fn();
+    const handled = getCustomKeyHandler()({
+      key: 'v',
+      ctrlKey: true,
+      metaKey: false,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    await flushPromises();
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(mocks.webSockets[0].send).toHaveBeenCalledWith(JSON.stringify({
+      type: 'Input',
+      connection_id: 'connection-1',
+      data: Array.from(new TextEncoder().encode('pasted text')),
+    }));
+  });
+
+  it('pastes clipboard text into the PTY with Command+V on macOS', async () => {
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: 'MacIntel',
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        readText: vi.fn().mockResolvedValue('mac paste'),
+      },
+    });
+    renderTerminal(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+
+    const preventDefault = vi.fn();
+    const handled = getCustomKeyHandler()({
+      key: 'v',
+      ctrlKey: false,
+      metaKey: true,
+      preventDefault,
+    } as unknown as KeyboardEvent);
+    await flushPromises();
+
+    expect(handled).toBe(false);
+    expect(preventDefault).toHaveBeenCalledOnce();
+    expect(mocks.webSockets[0].send).toHaveBeenCalledWith(JSON.stringify({
+      type: 'Input',
+      connection_id: 'connection-1',
+      data: Array.from(new TextEncoder().encode('mac paste')),
+    }));
   });
 });

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -59,6 +59,7 @@ import {
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, ContextMenuSeparator } from './ui/context-menu';
 import { AlertDialog, AlertDialogAction, AlertDialogCancel, AlertDialogContent, AlertDialogDescription, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "./ui/alert-dialog";
 import { toast } from 'sonner';
+import { isEditableTarget } from '@/lib/keyboard-shortcuts';
 
 interface FileItem {
   name: string;
@@ -220,6 +221,10 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   // Keyboard shortcuts
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
       if (event.ctrlKey || event.metaKey) {
         switch (event.key) {
           case 'c':

--- a/src/components/menu-bar.tsx
+++ b/src/components/menu-bar.tsx
@@ -59,6 +59,7 @@ interface MenuBarProps {
   onCloneTab?: () => void;
   onNextTab?: () => void;
   onPreviousTab?: () => void;
+  closeConnectionShortcutLabel?: string;
   onRecentConnectionSelect?: (connection: ConnectionData) => void;
   hasActiveConnection?: boolean;
   canPaste?: boolean;
@@ -93,6 +94,7 @@ export function MenuBar({
   onCloneTab,
   onNextTab,
   onPreviousTab,
+  closeConnectionShortcutLabel,
   onRecentConnectionSelect,
   hasActiveConnection = false,
   canPaste = true,
@@ -202,7 +204,7 @@ export function MenuBar({
           <DropdownMenuItem onClick={onCloseConnection} disabled={!hasActiveConnection}>
             <X className="mr-2 h-4 w-4" />
             Close Connection
-            <DropdownMenuShortcut>{cmdOrCtrl}+W</DropdownMenuShortcut>
+            <DropdownMenuShortcut>{closeConnectionShortcutLabel ?? `${cmdOrCtrl}+Shift+W`}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuItem>
             <X className="mr-2 h-4 w-4" />

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -38,7 +38,7 @@ interface PtyTerminalProps {
  *  50 MB of decoded text ≈ ~600k typical 80-char terminal lines. */
 const SESSION_OUTPUT_LIMIT_BYTES = 50 * 1024 * 1024;
 
-export function PtyTerminal({ 
+export function PtyTerminal({
   connectionId,
   connectionName,
   host = 'localhost', 
@@ -91,6 +91,33 @@ export function PtyTerminal({
 
   // Cumulative bytes written to xterm this session — reset on clear.
   const sessionOutputRef = React.useRef(0);
+  const inputEncoderRef = React.useRef(new TextEncoder());
+
+  const sendInputToPty = React.useCallback((data: string): boolean => {
+    const ws = wsRef.current;
+    if (!ws || ws.readyState !== WebSocket.OPEN) {
+      return false;
+    }
+
+    const dataBytes = Array.from(inputEncoderRef.current.encode(data));
+    ws.send(JSON.stringify({
+      type: 'Input',
+      connection_id: connectionId,
+      data: dataBytes,
+    }));
+    return true;
+  }, [connectionId]);
+
+  const pasteClipboardIntoPty = React.useCallback(async () => {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text && !sendInputToPty(text)) {
+        toast.error('Terminal not connected');
+      }
+    } catch (_error) {
+      toast.error('Failed to read from clipboard');
+    }
+  }, [sendInputToPty]);
 
   // Get appearance settings - reloads when appearanceKey changes
   const appearance = React.useMemo(() => loadAppearanceSettings(), [appearanceKey]);
@@ -197,12 +224,11 @@ export function PtyTerminal({
         });
         return false;
       }
-      
-      // Handle paste shortcut - return true to let the browser handle the native paste event,
-      // which xterm will pick up via onData. We must NOT manually send clipboard content here
-      // because onData already sends it, which would cause a double paste.
+
       if (modKey && key === 'v') {
-        return true;
+        event.preventDefault();
+        void pasteClipboardIntoPty();
+        return false;
       }
       
       // Handle search shortcut
@@ -542,24 +568,9 @@ export function PtyTerminal({
 
     connectWebSocket();
 
-    // Reuse a single TextEncoder across all input events to avoid
-    // per-keystroke allocation overhead.
-    const inputEncoder = new TextEncoder();
-
     // Handle user input
     const inputDisposable = term.onData((data: string) => {
-      const ws = wsRef.current;
-      if (!ws || ws.readyState !== WebSocket.OPEN) return;
-      
-      // Convert string to bytes for binary data
-      const dataBytes = Array.from(inputEncoder.encode(data));
-      
-      // Send as JSON message (matches server's Input message type)
-      ws.send(JSON.stringify({
-        type: 'Input',
-        connection_id: connectionId,
-        data: dataBytes,
-      }));
+      sendInputToPty(data);
     });
 
     // Handle terminal resize — deduplicate to avoid flooding the PTY with
@@ -667,7 +678,7 @@ export function PtyTerminal({
       term.reset(); // clear scrollback + viewport so GC can reclaim xterm buffers sooner
       term.dispose();
     };
-  }, [connectionId, connectionName, host, username, terminalKey, reconnectKey]);
+  }, [connectionId, connectionName, host, username, terminalKey, reconnectKey, pasteClipboardIntoPty, sendInputToPty]);
   // NOTE: themeKey and appearanceKey are intentionally NOT in the deps above.
   // Including them would tear down the WebSocket + PTY session on every theme
   // change (e.g. macOS auto Dark/Light switch), killing any running remote
@@ -732,31 +743,8 @@ export function PtyTerminal({
   }, []);
 
   const handlePaste = React.useCallback(async () => {
-    const ws = wsRef.current;
-    if (!ws || ws.readyState !== WebSocket.OPEN) {
-      toast.error('Terminal not connected');
-      return;
-    }
-    
-    try {
-      const text = await navigator.clipboard.readText();
-      if (text) {
-        // Convert string to bytes for binary data
-        const encoder = new TextEncoder();
-        const dataBytes = Array.from(encoder.encode(text));
-        
-        const inputMsg = {
-          type: 'Input',
-          connection_id: connectionId,
-          data: dataBytes,
-        };
-        
-        ws.send(JSON.stringify(inputMsg));
-      }
-    } catch (_error) {
-      toast.error('Failed to read from clipboard');
-    }
-  }, [connectionId]);
+    await pasteClipboardIntoPty();
+  }, [pasteClipboardIntoPty]);
 
   const handleClear = React.useCallback(() => {
     xtermRef.current?.clear();

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -28,6 +28,12 @@ import {
   saveAppearanceSettings,
   terminalThemes 
 } from '../lib/terminal-config';
+import {
+  APP_SETTINGS_CHANGED_EVENT,
+  APP_SETTINGS_STORAGE_KEY,
+  DEFAULT_APP_KEYBOARD_SHORTCUTS,
+  loadKeyboardShortcutSettings,
+} from '../lib/keyboard-shortcuts';
 import { applyTheme, ThemeMode } from '../lib/utils';
 
 interface SettingsModalProps {
@@ -66,10 +72,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
     enableNotifications: true,
     
     // Keyboard shortcuts
-    newSession: 'Ctrl+N',
-    closeSession: 'Ctrl+W',
-    nextTab: 'Ctrl+Tab',
-    previousTab: 'Ctrl+Shift+Tab',
+    newSession: DEFAULT_APP_KEYBOARD_SHORTCUTS.newSession,
+    closeSession: DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession,
+    nextTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.nextTab,
+    previousTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.previousTab,
     
     // Advanced settings
     logLevel: 'info',
@@ -86,10 +92,17 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
       
       // Load other settings from localStorage
       try {
-        const savedSettings = localStorage.getItem('sshClientSettings');
+        const savedSettings = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
         if (savedSettings) {
           const parsed = JSON.parse(savedSettings);
-          setSettings(prev => ({ ...prev, ...parsed }));
+          const keyboardShortcuts = loadKeyboardShortcutSettings();
+          setSettings(prev => ({
+            ...prev,
+            ...parsed,
+            closeSession: keyboardShortcuts.closeTab,
+            nextTab: keyboardShortcuts.nextTab,
+            previousTab: keyboardShortcuts.prevTab,
+          }));
         }
       } catch {
         // Ignore parsing errors
@@ -121,7 +134,8 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
     applyTheme(settings.theme as ThemeMode);
     
     // Save other settings to localStorage
-    localStorage.setItem('sshClientSettings', JSON.stringify(settings));
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    window.dispatchEvent(new Event(APP_SETTINGS_CHANGED_EVENT));
     onOpenChange(false);
   };
 
@@ -149,10 +163,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
         showSystemMonitor: true,
         showStatusBar: true,
         enableNotifications: true,
-        newSession: 'Ctrl+N',
-        closeSession: 'Ctrl+W',
-        nextTab: 'Ctrl+Tab',
-        previousTab: 'Ctrl+Shift+Tab',
+        newSession: DEFAULT_APP_KEYBOARD_SHORTCUTS.newSession,
+        closeSession: DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession,
+        nextTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.nextTab,
+        previousTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.previousTab,
         logLevel: 'info',
         maxLogSize: 100,
         checkUpdates: true,
@@ -772,7 +786,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
                     <Input
                       value={settings.closeSession}
                       onChange={(e) => updateSetting('closeSession', e.target.value)}
-                      placeholder="Ctrl+W"
+                      placeholder={DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession}
                     />
                   </div>
                 </div>
@@ -798,7 +812,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
 
                 <div className="p-4 bg-muted rounded-lg">
                   <p className="text-sm text-muted-foreground">
-                    <strong>Note:</strong> Changes to keyboard shortcuts will take effect after restarting the application.
+                    <strong>Note:</strong> Changes to keyboard shortcuts take effect after saving.
                   </p>
                 </div>
               </CardContent>

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -185,6 +185,25 @@ function isTerminalInputTarget(target: EventTarget | null): boolean {
   return target.tagName === 'TEXTAREA' || target.closest('.xterm') !== null;
 }
 
+export function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  const tagName = target.tagName.toLowerCase();
+  if (tagName === 'input' || tagName === 'textarea') {
+    return true;
+  }
+
+  const editableElement = target.closest('[contenteditable]');
+  if (!editableElement) {
+    return false;
+  }
+
+  const contentEditable = editableElement.getAttribute('contenteditable');
+  return contentEditable === '' || contentEditable?.toLowerCase() !== 'false';
+}
+
 /**
  * Hook to register keyboard shortcuts
  * Similar to VS Code's keyboard shortcuts system
@@ -196,6 +215,10 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boo
     const isMac = navigator.platform.toUpperCase().includes('MAC');
 
     const handleKeyDown = (event: KeyboardEvent) => {
+      if (isEditableTarget(event.target)) {
+        return;
+      }
+
       for (const shortcut of shortcuts) {
         const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
         // On macOS, treat Cmd (metaKey) as the equivalent of Ctrl for shortcut matching.

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -6,8 +6,183 @@ export interface KeyboardShortcut {
   shiftKey?: boolean;
   altKey?: boolean;
   metaKey?: boolean;
+  ignoreInTerminal?: boolean;
   handler: () => void;
   description: string;
+}
+
+export interface ParsedKeyboardShortcut {
+  key: string;
+  ctrlKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+  metaKey: boolean;
+}
+
+export interface SplitViewShortcutBindings {
+  closeTab: string;
+  nextTab: string;
+  prevTab: string;
+}
+
+export const APP_SETTINGS_STORAGE_KEY = 'sshClientSettings';
+export const APP_SETTINGS_CHANGED_EVENT = 'sshClientSettingsChanged';
+
+export const DEFAULT_APP_KEYBOARD_SHORTCUTS = {
+  newSession: 'Ctrl+N',
+  closeSession: 'Ctrl+Shift+W',
+  nextTab: 'Ctrl+Tab',
+  previousTab: 'Ctrl+Shift+Tab',
+} as const;
+
+export const DEFAULT_SPLIT_VIEW_SHORTCUTS: SplitViewShortcutBindings = {
+  closeTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession,
+  nextTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.nextTab,
+  prevTab: DEFAULT_APP_KEYBOARD_SHORTCUTS.previousTab,
+};
+
+const KEY_ALIASES: Record<string, string> = {
+  tab: 'Tab',
+  escape: 'Escape',
+  esc: 'Escape',
+  enter: 'Enter',
+  return: 'Enter',
+  space: ' ',
+  spacebar: ' ',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  del: 'Delete',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  home: 'Home',
+  end: 'End',
+  arrowup: 'ArrowUp',
+  up: 'ArrowUp',
+  arrowdown: 'ArrowDown',
+  down: 'ArrowDown',
+  arrowleft: 'ArrowLeft',
+  left: 'ArrowLeft',
+  arrowright: 'ArrowRight',
+  right: 'ArrowRight',
+};
+
+function normalizeShortcutKey(key: string): string {
+  const trimmed = key.trim();
+  if (trimmed.length === 1) {
+    return trimmed.toLowerCase();
+  }
+
+  return KEY_ALIASES[trimmed.toLowerCase()] ?? trimmed;
+}
+
+export function parseKeyboardShortcut(shortcut: string): ParsedKeyboardShortcut | null {
+  const parts = shortcut
+    .split('+')
+    .map(part => part.trim())
+    .filter(Boolean);
+
+  if (parts.length === 0) {
+    return null;
+  }
+
+  const parsed: ParsedKeyboardShortcut = {
+    key: '',
+    ctrlKey: false,
+    shiftKey: false,
+    altKey: false,
+    metaKey: false,
+  };
+
+  for (const part of parts) {
+    const normalized = part.toLowerCase();
+    if (normalized === 'ctrl' || normalized === 'control' || normalized === 'cmdorctrl') {
+      parsed.ctrlKey = true;
+    } else if (normalized === 'shift') {
+      parsed.shiftKey = true;
+    } else if (normalized === 'alt' || normalized === 'option') {
+      parsed.altKey = true;
+    } else if (
+      normalized === 'meta' ||
+      normalized === 'cmd' ||
+      normalized === 'command' ||
+      normalized === 'super'
+    ) {
+      parsed.metaKey = true;
+    } else {
+      parsed.key = normalizeShortcutKey(part);
+    }
+  }
+
+  return parsed.key ? parsed : null;
+}
+
+const LEGACY_CLOSE_TAB_SHORTCUTS = new Set(['ctrl+w', 'cmdorctrl+w']);
+
+function compactShortcut(shortcut: string): string {
+  return shortcut.replace(/\s+/g, '').toLowerCase();
+}
+
+function resolveSavedShortcut(value: unknown, fallback: string, legacyShortcuts?: Set<string>): string {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  if (legacyShortcuts?.has(compactShortcut(value))) {
+    return fallback;
+  }
+
+  return parseKeyboardShortcut(value) ? value : fallback;
+}
+
+export function loadKeyboardShortcutSettings(): SplitViewShortcutBindings {
+  const defaults = DEFAULT_SPLIT_VIEW_SHORTCUTS;
+
+  try {
+    const savedSettings = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (!savedSettings) {
+      return defaults;
+    }
+
+    const parsed = JSON.parse(savedSettings) as Partial<{
+      closeSession: unknown;
+      nextTab: unknown;
+      previousTab: unknown;
+    }>;
+
+    return {
+      closeTab: resolveSavedShortcut(parsed.closeSession, defaults.closeTab, LEGACY_CLOSE_TAB_SHORTCUTS),
+      nextTab: resolveSavedShortcut(parsed.nextTab, defaults.nextTab),
+      prevTab: resolveSavedShortcut(parsed.previousTab, defaults.prevTab),
+    };
+  } catch {
+    return defaults;
+  }
+}
+
+function createConfiguredShortcut(
+  shortcut: string,
+  fallback: string,
+  handler: () => void,
+  description: string,
+): KeyboardShortcut {
+  const parsed = parseKeyboardShortcut(shortcut) ?? parseKeyboardShortcut(fallback);
+  if (!parsed) {
+    throw new Error(`Invalid keyboard shortcut fallback: ${fallback}`);
+  }
+
+  return {
+    ...parsed,
+    handler,
+    description,
+  };
+}
+
+function isTerminalInputTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) {
+    return false;
+  }
+
+  return target.tagName === 'TEXTAREA' || target.closest('.xterm') !== null;
 }
 
 /**
@@ -26,15 +201,24 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boo
         // On macOS, treat Cmd (metaKey) as the equivalent of Ctrl for shortcut matching.
         // This lets shortcuts defined with ctrlKey:true work with both Ctrl and Cmd on Mac.
         const ctrlOrCmd = isMac ? (event.metaKey || event.ctrlKey) : event.ctrlKey;
-        const ctrlMatch = shortcut.ctrlKey === undefined || ctrlOrCmd === shortcut.ctrlKey;
+        const usesExplicitMeta = shortcut.metaKey === true && shortcut.ctrlKey !== true;
+        const ctrlMatch = usesExplicitMeta
+          ? (shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey)
+          : (shortcut.ctrlKey === undefined || ctrlOrCmd === shortcut.ctrlKey);
         const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
         const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
         // When ctrlKey is specified on Mac, don't additionally require metaKey matching
-        const metaMatch = (isMac && shortcut.ctrlKey !== undefined)
-          ? true
-          : (shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey);
+        let metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
+        if (usesExplicitMeta) {
+          metaMatch = event.metaKey === true;
+        } else if (isMac && shortcut.ctrlKey !== undefined) {
+          metaMatch = true;
+        }
 
         if (keyMatch && ctrlMatch && shiftMatch && altMatch && metaMatch) {
+          if (shortcut.ignoreInTerminal && isTerminalInputTarget(event.target)) {
+            return;
+          }
           event.preventDefault();
           event.stopPropagation();
           shortcut.handler();
@@ -60,30 +244,35 @@ export const createLayoutShortcuts = (actions: {
   {
     key: 'b',
     ctrlKey: true,
+    ignoreInTerminal: true,
     handler: actions.toggleLeftSidebar,
     description: 'Toggle Connection Manager (Left Sidebar)',
   },
   {
     key: 'j',
     ctrlKey: true,
+    ignoreInTerminal: true,
     handler: actions.toggleBottomPanel,
     description: 'Toggle File Browser (Bottom Panel)',
   },
   {
     key: 'm',
     ctrlKey: true,
+    ignoreInTerminal: true,
     handler: actions.toggleRightSidebar,
     description: 'Toggle Monitor Panel (Right Sidebar)',
   },
   {
     key: 'z',
     ctrlKey: true,
+    ignoreInTerminal: true,
     handler: actions.toggleZenMode,
     description: 'Toggle Zen Mode',
   },
   {
     key: '\\',
     ctrlKey: true,
+    ignoreInTerminal: true,
     handler: actions.toggleLeftSidebar,
     description: 'Toggle Connection Manager (Alternative)',
   },
@@ -103,49 +292,53 @@ export const createSplitViewShortcuts = (actions: {
   closeTab: () => void;
   nextTab: () => void;
   prevTab: () => void;
-}): KeyboardShortcut[] => [
-  {
-    key: '\\',
-    ctrlKey: true,
-    shiftKey: false,
-    handler: actions.splitRight,
-    description: 'Split terminal right',
-  },
-  {
-    key: '\\',
-    ctrlKey: true,
-    shiftKey: true,
-    handler: actions.splitDown,
-    description: 'Split terminal down',
-  },
-  // Ctrl+1 through Ctrl+9 to focus group by index (0-based)
-  ...Array.from({ length: 9 }, (_, i) => ({
-    key: String(i + 1),
-    ctrlKey: true,
-    shiftKey: false,
-    handler: () => actions.focusGroup(i),
-    description: `Focus terminal group ${i + 1}`,
-  })),
-  {
-    key: 'w',
-    ctrlKey: true,
-    shiftKey: false,
-    handler: actions.closeTab,
-    description: 'Close active tab',
-  },
-  {
-    key: 'Tab',
-    ctrlKey: true,
-    shiftKey: false,
-    handler: actions.nextTab,
-    description: 'Next tab in group',
-  },
-  {
-    key: 'Tab',
-    ctrlKey: true,
-    shiftKey: true,
-    handler: actions.prevTab,
-    description: 'Previous tab in group',
-  },
-];
+}, bindings: Partial<SplitViewShortcutBindings> = {}): KeyboardShortcut[] => {
+  const resolvedBindings: SplitViewShortcutBindings = {
+    ...DEFAULT_SPLIT_VIEW_SHORTCUTS,
+    ...bindings,
+  };
+
+  return [
+    {
+      key: '\\',
+      ctrlKey: true,
+      shiftKey: false,
+      handler: actions.splitRight,
+      description: 'Split terminal right',
+    },
+    {
+      key: '\\',
+      ctrlKey: true,
+      shiftKey: true,
+      handler: actions.splitDown,
+      description: 'Split terminal down',
+    },
+    // Ctrl+1 through Ctrl+9 to focus group by index (0-based)
+    ...Array.from({ length: 9 }, (_, i) => ({
+      key: String(i + 1),
+      ctrlKey: true,
+      shiftKey: false,
+      handler: () => actions.focusGroup(i),
+      description: `Focus terminal group ${i + 1}`,
+    })),
+    createConfiguredShortcut(
+      resolvedBindings.closeTab,
+      DEFAULT_SPLIT_VIEW_SHORTCUTS.closeTab,
+      actions.closeTab,
+      'Close active tab',
+    ),
+    createConfiguredShortcut(
+      resolvedBindings.nextTab,
+      DEFAULT_SPLIT_VIEW_SHORTCUTS.nextTab,
+      actions.nextTab,
+      'Next tab in group',
+    ),
+    createConfiguredShortcut(
+      resolvedBindings.prevTab,
+      DEFAULT_SPLIT_VIEW_SHORTCUTS.prevTab,
+      actions.prevTab,
+      'Previous tab in group',
+    ),
+  ];
+};
 


### PR DESCRIPTION
Fixes #23.

## Summary
- Change the default close-tab shortcut from Ctrl/Cmd+W to Ctrl/Cmd+Shift+W and migrate legacy saved settings.
- Remove the native Tauri close accelerator so Ctrl/Cmd+W can reach terminal apps.
- Let layout shortcuts pass through when xterm/textarea input is focused, so tmux Ctrl+B works in the terminal.
- Handle Ctrl/Cmd+V paste by reading the clipboard and sending text through the PTY input path.
- Keep settings, menu labels, README, and tests aligned with the new behavior.

## Validation
- Passed: `pnpm vitest --run src/__tests__/keyboard-shortcuts.test.ts src/__tests__/pty-terminal-activation.test.tsx`
- Passed: `pnpm lint` (0 errors, existing warnings remain)
- Passed: `pnpm build` (build completed with existing warnings)
- Not clean: `pnpm test` still has unrelated/env failures in `connection.test.ts` (`window.__TAURI__.invoke` missing in jsdom) and `terminal-group-serializer.test.ts` (localStorage save failure)
- Inconclusive: `cargo check --lib --message-format=short` timed out after 244s with no diagnostics