### PR TITLE
fix: bound PTY output memory growth

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -523,7 +523,11 @@ pub async fn rename_file(
         .ok_or("Connection not found")?;
 
     let client = connection.read().await;
-    let command = format!("mv '{}' '{}'", shell_escape_single_quoted(&old_path), shell_escape_single_quoted(&new_path));
+    let command = format!(
+        "mv '{}' '{}'",
+        shell_escape_single_quoted(&old_path),
+        shell_escape_single_quoted(&new_path)
+    );
 
     match client.execute_command(&command).await {
         Ok(_) => Ok(true),

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -65,13 +65,7 @@ fn build_app_menu(app: &tauri::AppHandle) -> tauri::Result<tauri::menu::Menu<tau
                 true,
                 Some("CmdOrCtrl+S"),
             )?,
-            &MenuItem::with_id(
-                app,
-                "close_connection",
-                "Close Tab",
-                true,
-                None::<&str>,
-            )?,
+            &MenuItem::with_id(app, "close_connection", "Close Tab", true, None::<&str>)?,
         ],
     )?;
 

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -66,7 +66,75 @@ pub struct PtySession {
     pub cancel: CancellationToken,
 }
 
+#[derive(Debug, Default)]
+struct PtyOutputForwardStats {
+    dropped_chunks: u64,
+    dropped_bytes: u64,
+}
+
 pub struct Client;
+
+fn forward_pty_output(
+    output_tx: &mpsc::Sender<Vec<u8>>,
+    data: &[u8],
+    stats: &mut PtyOutputForwardStats,
+) -> bool {
+    if data.is_empty() {
+        return true;
+    }
+
+    if output_tx.capacity() == 0 {
+        stats.dropped_chunks += 1;
+        stats.dropped_bytes += data.len() as u64;
+        return true;
+    }
+
+    match output_tx.try_send(data.to_vec()) {
+        Ok(()) => true,
+        Err(mpsc::error::TrySendError::Full(_)) => {
+            stats.dropped_chunks += 1;
+            stats.dropped_bytes += data.len() as u64;
+            true
+        }
+        Err(mpsc::error::TrySendError::Closed(_)) => false,
+    }
+}
+
+fn log_pty_output_drops(stats: &mut PtyOutputForwardStats) {
+    if stats.dropped_chunks == 0 {
+        return;
+    }
+
+    tracing::warn!(
+        "Dropped {} PTY output chunks ({} bytes) because the frontend output queue was full",
+        stats.dropped_chunks,
+        stats.dropped_bytes
+    );
+    *stats = PtyOutputForwardStats::default();
+}
+
+fn expand_key_path(key_path: &str) -> String {
+    if key_path.starts_with("~/") || key_path.starts_with("~\\") {
+        if let Some(home) = dirs::home_dir() {
+            let home_str = home.to_string_lossy();
+            return key_path.replacen('~', &home_str, 1);
+        }
+    }
+    key_path.to_string()
+}
+
+fn validate_public_key_file(auth_method: &AuthMethod) -> Result<()> {
+    if let AuthMethod::PublicKey { key_path, .. } = auth_method {
+        let expanded_path = expand_key_path(key_path);
+        if !std::path::Path::new(&expanded_path).exists() {
+            return Err(anyhow::anyhow!(
+                "SSH key file not found: {}. Please check the file path and try again.",
+                key_path
+            ));
+        }
+    }
+    Ok(())
+}
 
 #[async_trait::async_trait]
 impl client::Handler for Client {
@@ -86,6 +154,8 @@ impl SshClient {
     }
 
     pub async fn connect(&mut self, config: &SshConfig) -> Result<()> {
+        validate_public_key_file(&config.auth_method)?;
+
         let ssh_config = client::Config {
             preferred: russh::Preferred {
                 key: PREFERRED_HOST_KEY_ALGOS,
@@ -120,24 +190,7 @@ impl SshClient {
             } => {
                 // Expand tilde in path — use dirs::home_dir() for cross-platform
                 // support (HOME is not set on Windows; USERPROFILE is used instead).
-                let expanded_path = if key_path.starts_with("~/") || key_path.starts_with("~\\") {
-                    if let Some(home) = dirs::home_dir() {
-                        let home_str = home.to_string_lossy();
-                        key_path.replacen('~', &home_str, 1)
-                    } else {
-                        key_path.clone()
-                    }
-                } else {
-                    key_path.clone()
-                };
-
-                // Check if file exists
-                if !std::path::Path::new(&expanded_path).exists() {
-                    return Err(anyhow::anyhow!(
-                        "SSH key file not found: {}. Please check the file path and try again.",
-                        key_path
-                    ));
-                }
+                let expanded_path = expand_key_path(key_path);
 
                 // Read the key file and normalise CRLF line endings so that keys
                 // created or edited on Windows (which use \r\n) are parsed correctly
@@ -287,7 +340,7 @@ impl SshClient {
             // Create channels for bidirectional communication (like ttyd's pty_buf)
             // Increased capacity for better buffering during fast input
             let (input_tx, mut input_rx) = mpsc::channel::<Vec<u8>>(1000); // Increased from 100
-            let (output_tx, output_rx) = mpsc::channel::<Vec<u8>>(128); // Bounded: back-pressure to SSH window
+            let (output_tx, output_rx) = mpsc::channel::<Vec<u8>>(128); // Bounded: drop overflow while draining SSH
 
             let channel_id = channel.id();
 
@@ -322,22 +375,30 @@ impl SshClient {
             // but we also need `window_change()` which only requires `&self`.
             // We use `tokio::select!` to multiplex between output reading and resize.
             tokio::spawn(async move {
+                let mut output_stats = PtyOutputForwardStats::default();
                 loop {
                     tokio::select! {
                         msg = channel.wait() => {
                             match msg {
                                 Some(ChannelMsg::Data { data }) => {
-                                    if output_tx.send(data.to_vec()).await.is_err() {
+                                    if !forward_pty_output(&output_tx, data.as_ref(), &mut output_stats) {
                                         break;
+                                    }
+                                    if output_stats.dropped_chunks > 0 && output_tx.capacity() > 0 {
+                                        log_pty_output_drops(&mut output_stats);
                                     }
                                 }
                                 Some(ChannelMsg::ExtendedData { data, .. }) => {
                                     // stderr data (also send to output)
-                                    if output_tx.send(data.to_vec()).await.is_err() {
+                                    if !forward_pty_output(&output_tx, data.as_ref(), &mut output_stats) {
                                         break;
+                                    }
+                                    if output_stats.dropped_chunks > 0 && output_tx.capacity() > 0 {
+                                        log_pty_output_drops(&mut output_stats);
                                     }
                                 }
                                 Some(ChannelMsg::Eof) | Some(ChannelMsg::Close) | None => {
+                                    log_pty_output_drops(&mut output_stats);
                                     eprintln!("[PTY] Channel closed");
                                     break;
                                 }

--- a/src-tauri/src/ssh/tests.rs
+++ b/src-tauri/src/ssh/tests.rs
@@ -347,3 +347,135 @@ mod key_loading_tests {
         key_path.to_string()
     }
 }
+
+#[cfg(test)]
+mod pty_output_flow_tests {
+    use super::super::{forward_pty_output, PtyOutputForwardStats};
+
+    #[test]
+    fn test_pty_output_drops_immediately_when_queue_is_full() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel(1);
+        let mut stats = PtyOutputForwardStats::default();
+
+        assert!(forward_pty_output(&tx, b"first", &mut stats));
+        assert!(forward_pty_output(&tx, b"second", &mut stats));
+
+        assert_eq!(stats.dropped_chunks, 1);
+        assert_eq!(stats.dropped_bytes, 6);
+        assert_eq!(rx.try_recv().unwrap(), b"first".to_vec());
+        assert!(rx.try_recv().is_err());
+    }
+}
+
+#[cfg(test)]
+mod pty_memory_stress_tests {
+    use super::super::{AuthMethod, SshClient, SshConfig};
+    use std::time::Duration;
+    use tokio::time::{sleep, Instant};
+
+    #[tokio::test]
+    #[ignore = "requires tools/paramiko_stress_ssh_server.py and R_SHELL_STRESS_SSH_PORT"]
+    async fn test_pty_output_memory_stays_bounded_when_output_is_not_consumed() {
+        let port = std::env::var("R_SHELL_STRESS_SSH_PORT")
+            .expect("set R_SHELL_STRESS_SSH_PORT to the local stress SSH server port")
+            .parse::<u16>()
+            .expect("R_SHELL_STRESS_SSH_PORT must be a u16");
+        let duration = stress_env_u64("R_SHELL_STRESS_SECONDS", 30);
+        let max_growth_mb = stress_env_u64("R_SHELL_STRESS_MAX_GROWTH_MB", 96);
+
+        let mut client = SshClient::new();
+        client
+            .connect(&SshConfig {
+                host: "127.0.0.1".to_string(),
+                port,
+                username: "test".to_string(),
+                auth_method: AuthMethod::Password {
+                    password: "test".to_string(),
+                },
+            })
+            .await
+            .expect("stress SSH server should accept test/test");
+
+        let pty = client
+            .create_pty_session(80, 24)
+            .await
+            .expect("PTY session should start");
+        pty.input_tx
+            .send(b"yes\n".to_vec())
+            .await
+            .expect("input channel should accept command");
+
+        let baseline = private_memory_bytes().expect("private memory must be measurable");
+        let deadline = Instant::now() + Duration::from_secs(duration);
+        let mut max_seen = baseline;
+
+        while Instant::now() < deadline {
+            sleep(Duration::from_secs(1)).await;
+            let current = private_memory_bytes().expect("private memory must be measurable");
+            max_seen = max_seen.max(current);
+            eprintln!(
+                "pty stress memory: current={:.1} MB max={:.1} MB growth={:.1} MB",
+                bytes_to_mb(current),
+                bytes_to_mb(max_seen),
+                bytes_to_mb(max_seen.saturating_sub(baseline))
+            );
+        }
+
+        pty.cancel.cancel();
+        drop(pty);
+        let _ = client.disconnect().await;
+
+        let growth = max_seen.saturating_sub(baseline);
+        assert!(
+            growth <= max_growth_mb * 1024 * 1024,
+            "private memory grew by {:.1} MB, expected <= {} MB",
+            bytes_to_mb(growth),
+            max_growth_mb
+        );
+    }
+
+    fn stress_env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(default)
+    }
+
+    fn bytes_to_mb(bytes: u64) -> f64 {
+        bytes as f64 / 1024.0 / 1024.0
+    }
+
+    #[cfg(windows)]
+    fn private_memory_bytes() -> Option<u64> {
+        let output = std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "(Get-Process -Id {}).PrivateMemorySize64",
+                    std::process::id()
+                ),
+            ])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+    }
+
+    #[cfg(not(windows))]
+    fn private_memory_bytes() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let kb = rest
+                    .split_whitespace()
+                    .next()
+                    .and_then(|value| value.parse::<u64>().ok())?;
+                return Some(kb * 1024);
+            }
+        }
+        None
+    }
+}

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -106,10 +106,10 @@ pub struct WebSocketServer {
 // Constants
 // ---------------------------------------------------------------------------
 
-/// Back-pressure bound: maximum binary output frames queued between the PTY
-/// reader task and the WebSocket sender task.  When this fills up the PTY
-/// reader *blocks*, propagating pressure back through output_tx → SSH channel
-/// → TCP window → the remote process (e.g. `yes`).
+/// Maximum binary output frames queued between the PTY reader task and the
+/// WebSocket sender task. When this fills up the WebSocket-side reader blocks;
+/// the SSH channel reader keeps draining upstream output and drops overflow in
+/// `ssh::forward_pty_output` so russh buffers cannot grow without bound.
 const WS_OUTPUT_QUEUE_CAPACITY: usize = 256;
 
 /// Batch PTY output into frames of at most this size before sending.
@@ -181,7 +181,12 @@ fn encode_output_frame(connection_id: &str, data: &[u8]) -> Vec<u8> {
 /// Control messages are best-effort — a saturated channel returns `Dropped`.
 async fn send_control(tx: &WsTx, msg: &WsMessage) -> Result<SendOutcome> {
     let frame = Message::Text(serde_json::to_string(msg)?);
-    match tokio::time::timeout(Duration::from_millis(CONTROL_SEND_TIMEOUT_MS), tx.send(frame)).await {
+    match tokio::time::timeout(
+        Duration::from_millis(CONTROL_SEND_TIMEOUT_MS),
+        tx.send(frame),
+    )
+    .await
+    {
         Ok(Ok(())) => Ok(SendOutcome::Sent),
         Ok(Err(_)) => Ok(SendOutcome::Closed),
         Err(_) => Ok(SendOutcome::Dropped),
@@ -191,9 +196,9 @@ async fn send_control(tx: &WsTx, msg: &WsMessage) -> Result<SendOutcome> {
 /// Flush accumulated PTY bytes as a binary output frame.
 ///
 /// **Blocks** until the WS channel has room or the session is cancelled.
-/// This is the end-to-end backpressure mechanism: a full WS channel stalls
-/// the PTY reader, which stalls `output_tx`, which stalls `channel.wait()`,
-/// which exhausts the SSH window and stops the remote process from sending.
+/// This bounds the WebSocket-side queue. The SSH reader must not rely on this
+/// as upstream backpressure; it keeps draining the SSH channel and drops
+/// overflow before data reaches this layer.
 async fn flush_output(
     tx: &WsTx,
     connection_id: &str,
@@ -340,10 +345,16 @@ impl WebSocketServer {
                         .handle_message(ws_msg, tx.clone(), output_controls.clone())
                         .await
                     {
-                        Ok(PtyLifecycleEvent::Started { connection_id, generation }) => {
+                        Ok(PtyLifecycleEvent::Started {
+                            connection_id,
+                            generation,
+                        }) => {
                             active_pty_generations.insert(connection_id, generation);
                         }
-                        Ok(PtyLifecycleEvent::Closed { connection_id, generation }) => {
+                        Ok(PtyLifecycleEvent::Closed {
+                            connection_id,
+                            generation,
+                        }) => {
                             if should_remove_pty_state(
                                 active_pty_generations.get(&connection_id).copied(),
                                 generation,
@@ -431,7 +442,10 @@ impl WebSocketServer {
                 // 1 permit before each flush; the frontend grants permits via
                 // Resume messages (1 per frame processed by xterm).
                 let credits: OutputCredits = Arc::new(Semaphore::new(0));
-                output_controls.lock().await.insert(connection_id.clone(), Arc::clone(&credits));
+                output_controls
+                    .lock()
+                    .await
+                    .insert(connection_id.clone(), Arc::clone(&credits));
 
                 let response = WsMessage::Success {
                     message: format!("PTY connection started: {}", connection_id),
@@ -444,9 +458,10 @@ impl WebSocketServer {
                 };
                 send_control(&tx, &started).await?;
 
-                // Spawn the PTY reader task.
-                // `flush_output` blocks when the WS channel is full — this
-                // propagates back-pressure through output_tx to the SSH window.
+                // Spawn the PTY reader task. `flush_output` blocks when the WS
+                // channel is full, bounding the WebSocket-side queue. The SSH
+                // reader drains upstream output independently and drops
+                // overflow before it can accumulate inside russh.
                 let connection_manager = self.connection_manager.clone();
                 let connection_id_clone = connection_id.clone();
                 let tx_clone = tx.clone();
@@ -480,8 +495,7 @@ impl WebSocketServer {
                             Ok(data) if data.is_empty() => {
                                 // 1 ms poll returned nothing — flush if interval elapsed.
                                 if !accumulated.is_empty()
-                                    && last_flush.elapsed().as_millis()
-                                        >= OUTPUT_FLUSH_INTERVAL_MS
+                                    && last_flush.elapsed().as_millis() >= OUTPUT_FLUSH_INTERVAL_MS
                                 {
                                     // Wait for 1 frontend ACK before sending.
                                     let ok = tokio::select! {
@@ -509,8 +523,7 @@ impl WebSocketServer {
                             Ok(data) => {
                                 accumulated.extend_from_slice(&data);
                                 if accumulated.len() >= OUTPUT_FLUSH_BYTES
-                                    || last_flush.elapsed().as_millis()
-                                        >= OUTPUT_FLUSH_INTERVAL_MS
+                                    || last_flush.elapsed().as_millis() >= OUTPUT_FLUSH_INTERVAL_MS
                                 {
                                     // Wait for 1 frontend ACK before sending.
                                     let ok = tokio::select! {
@@ -746,5 +759,200 @@ impl WebSocketServer {
                 Ok(PtyLifecycleEvent::None)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ssh::{AuthMethod, SshConfig};
+    use futures::{SinkExt, StreamExt};
+    use std::time::Duration;
+    use tokio::time::{sleep, Instant};
+    use tokio_tungstenite::connect_async;
+
+    #[tokio::test]
+    #[ignore = "requires tools/paramiko_stress_ssh_server.py and R_SHELL_STRESS_SSH_PORT"]
+    async fn test_websocket_pty_memory_stays_bounded_when_frontend_stalls() -> Result<()> {
+        let port = std::env::var("R_SHELL_STRESS_SSH_PORT")
+            .expect("set R_SHELL_STRESS_SSH_PORT to the local stress SSH server port")
+            .parse::<u16>()
+            .expect("R_SHELL_STRESS_SSH_PORT must be a u16");
+        let duration = stress_env_u64("R_SHELL_STRESS_SECONDS", 60);
+        let max_growth_mb = stress_env_u64("R_SHELL_STRESS_MAX_GROWTH_MB", 96);
+        let connection_id = "stress-ws-pty".to_string();
+
+        let manager = Arc::new(ConnectionManager::new());
+        manager
+            .create_connection(
+                connection_id.clone(),
+                SshConfig {
+                    host: "127.0.0.1".to_string(),
+                    port,
+                    username: "test".to_string(),
+                    auth_method: AuthMethod::Password {
+                        password: "test".to_string(),
+                    },
+                },
+            )
+            .await?;
+
+        let server = WebSocketServer::new(Arc::clone(&manager));
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        let server_task = tokio::spawn(async move {
+            let (stream, _) = listener.accept().await?;
+            server.handle_connection(stream).await
+        });
+
+        let (mut ws, _) = connect_async(format!("ws://{}", addr)).await?;
+        ws.send(Message::Text(serde_json::to_string(
+            &WsMessage::StartPty {
+                connection_id: connection_id.clone(),
+                cols: 80,
+                rows: 24,
+            },
+        )?))
+        .await?;
+
+        let generation = wait_for_pty_started(&mut ws, &connection_id).await?;
+        for _ in 0..4 {
+            ws.send(Message::Text(serde_json::to_string(&WsMessage::Resume {
+                connection_id: connection_id.clone(),
+            })?))
+            .await?;
+        }
+        ws.send(Message::Text(serde_json::to_string(&WsMessage::Input {
+            connection_id: connection_id.clone(),
+            data: b"yes\n".to_vec(),
+        })?))
+        .await?;
+
+        let baseline = private_memory_bytes().expect("private memory must be measurable");
+        let deadline = Instant::now() + Duration::from_secs(duration);
+        let mut max_seen = baseline;
+        let mut received_frames = 0u64;
+        let mut received_bytes = 0u64;
+
+        while Instant::now() < deadline {
+            tokio::select! {
+                msg = ws.next() => {
+                    match msg {
+                        Some(Ok(Message::Binary(data))) => {
+                            received_frames += 1;
+                            received_bytes += data.len() as u64;
+                        }
+                        Some(Ok(_)) => {}
+                        Some(Err(e)) => return Err(e.into()),
+                        None => break,
+                    }
+                }
+                _ = sleep(Duration::from_secs(1)) => {
+                    let current = private_memory_bytes().expect("private memory must be measurable");
+                    max_seen = max_seen.max(current);
+                    eprintln!(
+                        "websocket pty stress: frames={} bytes={} current={:.1} MB max={:.1} MB growth={:.1} MB",
+                        received_frames,
+                        received_bytes,
+                        bytes_to_mb(current),
+                        bytes_to_mb(max_seen),
+                        bytes_to_mb(max_seen.saturating_sub(baseline))
+                    );
+                }
+            }
+        }
+
+        ws.send(Message::Text(serde_json::to_string(&WsMessage::Close {
+            connection_id: connection_id.clone(),
+            generation: Some(generation),
+        })?))
+        .await
+        .ok();
+        ws.close(None).await.ok();
+        server_task.abort();
+        manager.close_connection(&connection_id).await.ok();
+
+        let growth = max_seen.saturating_sub(baseline);
+        assert!(
+            growth <= max_growth_mb * 1024 * 1024,
+            "private memory grew by {:.1} MB, expected <= {} MB",
+            bytes_to_mb(growth),
+            max_growth_mb
+        );
+
+        Ok(())
+    }
+
+    async fn wait_for_pty_started(
+        ws: &mut tokio_tungstenite::WebSocketStream<tokio_tungstenite::MaybeTlsStream<TcpStream>>,
+        expected_connection_id: &str,
+    ) -> Result<u64> {
+        let deadline = Instant::now() + Duration::from_secs(10);
+        while Instant::now() < deadline {
+            let Some(msg) = ws.next().await else {
+                break;
+            };
+            match msg? {
+                Message::Text(text) => {
+                    if let WsMessage::PtyStarted {
+                        connection_id,
+                        generation,
+                    } = serde_json::from_str::<WsMessage>(&text)?
+                    {
+                        if connection_id == expected_connection_id {
+                            return Ok(generation);
+                        }
+                    }
+                }
+                Message::Binary(_) => {}
+                _ => {}
+            }
+        }
+        Err(anyhow::anyhow!("timed out waiting for PtyStarted"))
+    }
+
+    fn stress_env_u64(name: &str, default: u64) -> u64 {
+        std::env::var(name)
+            .ok()
+            .and_then(|value| value.parse::<u64>().ok())
+            .unwrap_or(default)
+    }
+
+    fn bytes_to_mb(bytes: u64) -> f64 {
+        bytes as f64 / 1024.0 / 1024.0
+    }
+
+    #[cfg(windows)]
+    fn private_memory_bytes() -> Option<u64> {
+        let output = std::process::Command::new("powershell")
+            .args([
+                "-NoProfile",
+                "-Command",
+                &format!(
+                    "(Get-Process -Id {}).PrivateMemorySize64",
+                    std::process::id()
+                ),
+            ])
+            .output()
+            .ok()?;
+        if !output.status.success() {
+            return None;
+        }
+        String::from_utf8_lossy(&output.stdout).trim().parse().ok()
+    }
+
+    #[cfg(not(windows))]
+    fn private_memory_bytes() -> Option<u64> {
+        let status = std::fs::read_to_string("/proc/self/status").ok()?;
+        for line in status.lines() {
+            if let Some(rest) = line.strip_prefix("VmRSS:") {
+                let kb = rest
+                    .split_whitespace()
+                    .next()
+                    .and_then(|value| value.parse::<u64>().ok())?;
+                return Some(kb * 1024);
+            }
+        }
+        None
     }
 }

--- a/src/__tests__/connection.test.ts
+++ b/src/__tests__/connection.test.ts
@@ -1,12 +1,16 @@
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { invoke } from '@tauri-apps/api/core';
 
-// Test credentials - Replace with your own test server credentials
-const TEST_HOST = 'localhost'; // Replace with your test SSH server
-const TEST_USERNAME = 'testuser'; // Replace with your test username
-const TEST_PASSWORD = 'testpass'; // Replace with your test password
+const RUN_SSH_INTEGRATION = process.env.R_SHELL_RUN_SSH_INTEGRATION === '1';
+const describeSshIntegration = RUN_SSH_INTEGRATION ? describe : describe.skip;
 
-describe('SSH Connection Tests', () => {
+// Test credentials - set R_SHELL_RUN_SSH_INTEGRATION=1 and override these
+// values when running against a real SSH server.
+const TEST_HOST = process.env.R_SHELL_TEST_HOST ?? 'localhost';
+const TEST_USERNAME = process.env.R_SHELL_TEST_USERNAME ?? 'testuser';
+const TEST_PASSWORD = process.env.R_SHELL_TEST_PASSWORD ?? 'testpass';
+
+describeSshIntegration('SSH Connection Tests', () => {
   let connectionId: string;
 
   beforeAll(() => {

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     getSelection = vi.fn(() => '');
     selectAll = vi.fn();
     clear = vi.fn();
+    reset = vi.fn();
     dispose = vi.fn();
   }
 

--- a/src/__tests__/pty-terminal-scrollbar.test.tsx
+++ b/src/__tests__/pty-terminal-scrollbar.test.tsx
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => {
     getSelection = vi.fn(() => '');
     selectAll = vi.fn();
     clear = vi.fn();
+    reset = vi.fn();
     dispose = vi.fn();
   }
 

--- a/src/lib/terminal-group-serializer.ts
+++ b/src/lib/terminal-group-serializer.ts
@@ -52,14 +52,18 @@ export function saveState(state: TerminalGroupState): void {
           }];
         }),
       ),
-      tabToGroupMap: Object.fromEntries(
+    };
+
+    if (state.tabToGroupMap) {
+      filtered.tabToGroupMap = Object.fromEntries(
         Object.entries(state.tabToGroupMap).filter(([tabId]) => {
           const group = state.groups[state.tabToGroupMap[tabId]];
           const tab = group?.tabs.find(t => t.id === tabId);
           return tab?.tabType !== 'editor';
         }),
-      ),
-    };
+      );
+    }
+
     localStorage.setItem(STORAGE_KEY, serialize(filtered));
   } catch (e) {
     console.warn('Failed to save terminal group state to localStorage:', e);

--- a/tools/paramiko_stress_ssh_server.py
+++ b/tools/paramiko_stress_ssh_server.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Local SSH server for PTY output memory stress tests.
+
+The server accepts test/test and starts writing high-volume PTY output after it
+receives a command containing "yes". It is intended for local development only.
+"""
+
+from __future__ import annotations
+
+import argparse
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import paramiko
+
+
+HOST_KEY = paramiko.RSAKey.generate(2048)
+
+
+class StressServer(paramiko.ServerInterface):
+    def __init__(self) -> None:
+        self.shell_ready = threading.Event()
+
+    def check_auth_password(self, username: str, password: str) -> int:
+        if username == "test" and password == "test":
+            return paramiko.AUTH_SUCCESSFUL
+        return paramiko.AUTH_FAILED
+
+    def get_allowed_auths(self, username: str) -> str:
+        return "password"
+
+    def check_channel_request(self, kind: str, chanid: int) -> int:
+        if kind == "session":
+            return paramiko.OPEN_SUCCEEDED
+        return paramiko.OPEN_FAILED_ADMINISTRATIVELY_PROHIBITED
+
+    def check_channel_pty_request(
+        self,
+        channel: paramiko.Channel,
+        term: bytes,
+        width: int,
+        height: int,
+        pixelwidth: int,
+        pixelheight: int,
+        modes: bytes,
+    ) -> bool:
+        return True
+
+    def check_channel_shell_request(self, channel: paramiko.Channel) -> bool:
+        self.shell_ready.set()
+        return True
+
+
+def output_loop(channel: paramiko.Channel, stop: threading.Event) -> None:
+    payload = (b"0123456789abcdefghijklmnopqrstuvwxyz\r\n" * 1024)
+    while not stop.is_set():
+        try:
+            channel.sendall(payload)
+        except Exception:
+            stop.set()
+            return
+
+
+def handle_client(client: socket.socket) -> None:
+    transport = paramiko.Transport(client)
+    transport.add_server_key(HOST_KEY)
+    server = StressServer()
+    stop = threading.Event()
+
+    try:
+        transport.start_server(server=server)
+        channel = transport.accept(20)
+        if channel is None:
+            return
+        if not server.shell_ready.wait(10):
+            return
+
+        channel.settimeout(0.2)
+        received = bytearray()
+        writer: threading.Thread | None = None
+
+        while transport.is_active() and not stop.is_set():
+            try:
+                data = channel.recv(1024)
+            except socket.timeout:
+                continue
+            except Exception:
+                break
+            if not data:
+                break
+
+            received.extend(data)
+            if writer is None and b"yes" in received:
+                writer = threading.Thread(
+                    target=output_loop,
+                    args=(channel, stop),
+                    daemon=True,
+                )
+                writer.start()
+    finally:
+        stop.set()
+        try:
+            transport.close()
+        finally:
+            client.close()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=0)
+    parser.add_argument("--port-file")
+    args = parser.parse_args()
+
+    sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    sock.bind((args.host, args.port))
+    sock.listen(100)
+    host, port = sock.getsockname()
+
+    if args.port_file:
+        Path(args.port_file).write_text(str(port), encoding="utf-8")
+
+    print(f"stress ssh server listening on {host}:{port}", flush=True)
+
+    try:
+        while True:
+            client, _ = sock.accept()
+            threading.Thread(target=handle_client, args=(client,), daemon=True).start()
+    except KeyboardInterrupt:
+        return 0
+    finally:
+        sock.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
﻿Supersedes #27.

## Summary

- Keep the SSH channel output reader draining even when the downstream PTY output queue is full.
- Drop overflow at the SSH output boundary with a bounded queue instead of blocking on `output_tx.send().await`, which could allow russh/internal buffers to grow when frontend output stalls.
- Add ignored local stress tests for both direct PTY backpressure and the full WebSocket PTY stall path.
- Add a local Paramiko SSH stress server used by those ignored tests.
- Fix existing test blockers so the normal test suite can run cleanly: skip hard-coded SSH integration tests unless explicitly enabled, add missing xterm mock `reset()`, and preserve backward compatibility when `tabToGroupMap` is absent during terminal group serialization.
- Apply `cargo fmt` to the Rust workspace.

## Root Cause

The previous main-branch implementation and #27 both focused on bounding downstream WebSocket/frontend output. Real stress testing showed that blocking the PTY/WebSocket reader does not reliably bound process memory. When the downstream path stalls, the SSH channel reader can stop draining `channel.wait()`, and output may still accumulate upstream inside russh/internal buffers.

This PR moves the memory boundary closer to the SSH channel reader: the reader keeps draining remote output and drops overflow before it can accumulate in the SSH stack.

## Validation

- `cargo fmt --check`
- `cargo check`
- `cargo test --lib` — 77 passed, 7 ignored
- direct PTY stress: `test_pty_output_memory_stays_bounded_when_output_is_not_consumed` with local Paramiko SSH server, 60s, max private-memory growth about 3.3 MB
- WebSocket PTY stall stress: `test_websocket_pty_memory_stays_bounded_when_frontend_stalls` with local Paramiko SSH server, 60s, 4 output frames / 149,504 bytes, max private-memory growth about 3.8 MB
- `pnpm exec tsc --noEmit`
- `pnpm test` — 406 passed, 7 skipped
- `pnpm lint` — 0 errors, existing warnings remain
- `pnpm build`
