### PR TITLE
fix: preserve terminal scrollback history

### DIFF
--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -34,6 +34,7 @@ const mocks = vi.hoisted(() => {
     getSelection = vi.fn(() => '');
     selectAll = vi.fn();
     clear = vi.fn();
+    reset = vi.fn();
     dispose = vi.fn();
   }
 
@@ -88,7 +89,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 
 vi.mock('@xterm/addon-webgl', () => ({
   WebglAddon: vi.fn(function WebglAddon() {
-    return { dispose: vi.fn() };
+    return { dispose: vi.fn(), onContextLoss: vi.fn() };
   }),
 }));
 
@@ -106,16 +107,26 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: {
+    background: '#000000',
+  },
+  terminalThemes: {
+    'vs-code-dark': {
+      background: '#000000',
+    },
+  },
   loadAppearanceSettings: vi.fn(() => ({
     allowTransparency: false,
     backgroundImage: '',
     opacity: 100,
+    theme: 'vs-code-dark',
   })),
   getThemeAwareTerminalOptions: vi.fn(() => ({
     cursorBlink: true,
     cursorStyle: 'block',
     fontFamily: 'monospace',
     fontSize: 14,
+    scrollback: 10000,
     theme: {},
   })),
 }));
@@ -273,7 +284,8 @@ describe('PtyTerminal activation', () => {
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
   });
 
-  it('pastes clipboard text into the PTY with Ctrl+V', async () => {
+  it('lets xterm handle Ctrl+V paste without duplicate custom send', async () => {
+    const readText = vi.fn().mockResolvedValue('pasted text');
     Object.defineProperty(navigator, 'platform', {
       configurable: true,
       value: 'Win32',
@@ -281,7 +293,7 @@ describe('PtyTerminal activation', () => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
-        readText: vi.fn().mockResolvedValue('pasted text'),
+        readText,
       },
     });
     renderTerminal(true);
@@ -291,6 +303,7 @@ describe('PtyTerminal activation', () => {
 
     const preventDefault = vi.fn();
     const handled = getCustomKeyHandler()({
+      type: 'keydown',
       key: 'v',
       ctrlKey: true,
       metaKey: false,
@@ -298,16 +311,13 @@ describe('PtyTerminal activation', () => {
     } as unknown as KeyboardEvent);
     await flushPromises();
 
-    expect(handled).toBe(false);
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(mocks.webSockets[0].send).toHaveBeenCalledWith(JSON.stringify({
-      type: 'Input',
-      connection_id: 'connection-1',
-      data: Array.from(new TextEncoder().encode('pasted text')),
-    }));
+    expect(handled).toBe(true);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(readText).not.toHaveBeenCalled();
   });
 
-  it('pastes clipboard text into the PTY with Command+V on macOS', async () => {
+  it('lets xterm handle Command+V paste without duplicate custom send on macOS', async () => {
+    const readText = vi.fn().mockResolvedValue('mac paste');
     Object.defineProperty(navigator, 'platform', {
       configurable: true,
       value: 'MacIntel',
@@ -315,7 +325,7 @@ describe('PtyTerminal activation', () => {
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
       value: {
-        readText: vi.fn().mockResolvedValue('mac paste'),
+        readText,
       },
     });
     renderTerminal(true);
@@ -325,6 +335,7 @@ describe('PtyTerminal activation', () => {
 
     const preventDefault = vi.fn();
     const handled = getCustomKeyHandler()({
+      type: 'keydown',
       key: 'v',
       ctrlKey: false,
       metaKey: true,
@@ -332,12 +343,8 @@ describe('PtyTerminal activation', () => {
     } as unknown as KeyboardEvent);
     await flushPromises();
 
-    expect(handled).toBe(false);
-    expect(preventDefault).toHaveBeenCalledOnce();
-    expect(mocks.webSockets[0].send).toHaveBeenCalledWith(JSON.stringify({
-      type: 'Input',
-      connection_id: 'connection-1',
-      data: Array.from(new TextEncoder().encode('mac paste')),
-    }));
+    expect(handled).toBe(true);
+    expect(preventDefault).not.toHaveBeenCalled();
+    expect(readText).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/pty-terminal-scrollbar.test.tsx
+++ b/src/__tests__/pty-terminal-scrollbar.test.tsx
@@ -36,6 +36,7 @@ const mocks = vi.hoisted(() => {
     getSelection = vi.fn(() => '');
     selectAll = vi.fn();
     clear = vi.fn();
+    reset = vi.fn();
     dispose = vi.fn();
   }
 
@@ -81,7 +82,7 @@ vi.mock('@xterm/addon-web-links', () => ({
 
 vi.mock('@xterm/addon-webgl', () => ({
   WebglAddon: vi.fn(function WebglAddon() {
-    return { dispose: vi.fn() };
+    return { dispose: vi.fn(), onContextLoss: vi.fn() };
   }),
 }));
 
@@ -99,16 +100,26 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: {
+    background: '#000000',
+  },
+  terminalThemes: {
+    'vs-code-dark': {
+      background: '#000000',
+    },
+  },
   loadAppearanceSettings: vi.fn(() => ({
     allowTransparency: false,
     backgroundImage: '',
     opacity: 100,
+    theme: 'vs-code-dark',
   })),
   getThemeAwareTerminalOptions: vi.fn(() => ({
     cursorBlink: true,
     cursorStyle: 'block',
     fontFamily: 'monospace',
     fontSize: 14,
+    scrollback: 10000,
     theme: {},
   })),
 }));

--- a/src/__tests__/terminal-group-serializer.test.ts
+++ b/src/__tests__/terminal-group-serializer.test.ts
@@ -28,6 +28,7 @@ function makeState(): TerminalGroupState {
       '1': { id: '1', tabs: [makeTab('t1')], activeTabId: 't1' },
     },
     activeGroupId: '1',
+    tabToGroupMap: { t1: '1' },
     gridLayout: { type: 'leaf', groupId: '1' },
     nextGroupId: 2,
   };

--- a/src/__tests__/terminal-scrollback.test.ts
+++ b/src/__tests__/terminal-scrollback.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import { Terminal } from '@xterm/xterm';
+import {
+  defaultAppearanceSettings,
+  defaultTerminalOptions,
+  getTerminalOptions,
+  loadAppearanceSettings,
+} from '../lib/terminal-config';
+
+describe('terminal scrollback configuration', () => {
+  beforeEach(() => {
+    localStorage.removeItem('terminalAppearance');
+  });
+
+  afterEach(() => {
+    localStorage.removeItem('terminalAppearance');
+  });
+
+  it('keeps at least 10000 lines in the default xterm scrollback buffer', async () => {
+    const term = new Terminal({
+      ...defaultTerminalOptions,
+      cols: 80,
+      rows: 24,
+    });
+
+    for (let i = 1; i <= 20000; i += 1) {
+      term.writeln(String(i));
+    }
+
+    await new Promise<void>((resolve) => term.write('', () => resolve()));
+
+    expect(term.options.scrollback).toBe(10000);
+    expect(term.buffer.active.length).toBeGreaterThanOrEqual(10000);
+
+    term.dispose();
+  });
+
+  it('migrates the regressed 500-line saved scrollback value back to the default', () => {
+    localStorage.setItem(
+      'terminalAppearance',
+      JSON.stringify({
+        ...defaultAppearanceSettings,
+        scrollback: 500,
+      }),
+    );
+
+    expect(loadAppearanceSettings().scrollback).toBe(10000);
+    expect(getTerminalOptions(loadAppearanceSettings()).scrollback).toBe(10000);
+  });
+});

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -829,6 +829,7 @@ export function PtyTerminal({
     term.options.fontFamily = opts.fontFamily;
     term.options.cursorStyle = opts.cursorStyle;
     term.options.cursorBlink = opts.cursorBlink;
+    term.options.scrollback = opts.scrollback;
     // Refit so any font-size change propagates as a PTY resize.
     fitRef.current?.fit();
   }, [themeKey, appearanceKey]);

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -26,7 +26,9 @@ import {
   defaultAppearanceSettings, 
   loadAppearanceSettings,
   saveAppearanceSettings,
-  terminalThemes 
+  terminalThemes,
+  MIN_TERMINAL_SCROLLBACK,
+  MAX_TERMINAL_SCROLLBACK,
 } from '../lib/terminal-config';
 import {
   APP_SETTINGS_CHANGED_EVENT,
@@ -356,8 +358,8 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange }: Settin
                   <Slider
                     value={[terminalAppearance.scrollback]}
                     onValueChange={([value]) => updateTerminalAppearance('scrollback', value)}
-                    min={1000}
-                    max={100000}
+                    min={MIN_TERMINAL_SCROLLBACK}
+                    max={MAX_TERMINAL_SCROLLBACK}
                     step={1000}
                   />
                 </div>

--- a/src/lib/terminal-config.ts
+++ b/src/lib/terminal-config.ts
@@ -31,6 +31,29 @@ export interface TerminalAppearanceSettings {
   backgroundImagePosition: 'cover' | 'contain' | 'center' | 'tile';
 }
 
+export const DEFAULT_TERMINAL_SCROLLBACK = 10000;
+export const MIN_TERMINAL_SCROLLBACK = 1000;
+export const MAX_TERMINAL_SCROLLBACK = 50000;
+
+export function normalizeScrollbackLines(value: unknown): number {
+  const numericValue = typeof value === 'number' ? value : Number(value);
+
+  if (!Number.isFinite(numericValue) || numericValue < MIN_TERMINAL_SCROLLBACK) {
+    return DEFAULT_TERMINAL_SCROLLBACK;
+  }
+
+  return Math.min(Math.round(numericValue), MAX_TERMINAL_SCROLLBACK);
+}
+
+export function normalizeAppearanceSettings(
+  settings: TerminalAppearanceSettings,
+): TerminalAppearanceSettings {
+  return {
+    ...settings,
+    scrollback: normalizeScrollbackLines(settings.scrollback),
+  };
+}
+
 export const defaultTerminalTheme: ITheme = {
   foreground: '#d4d4d4',
   background: '#1e1e1e',
@@ -293,7 +316,7 @@ export const defaultAppearanceSettings: TerminalAppearanceSettings = {
   cursorStyle: 'block',
   cursorBlink: true,
   theme: 'vs-code-dark',
-  scrollback: 500,
+  scrollback: DEFAULT_TERMINAL_SCROLLBACK,
   allowTransparency: false,
   opacity: 100,
   // Background image defaults
@@ -313,7 +336,7 @@ export const defaultTerminalOptions: ITerminalOptions = {
   theme: defaultTerminalTheme,
   allowProposedApi: true,
   convertEol: true,
-  scrollback: 500,
+  scrollback: DEFAULT_TERMINAL_SCROLLBACK,
   tabStopWidth: 8,
   allowTransparency: false,
   scrollSensitivity: 1,
@@ -333,7 +356,7 @@ export function getTerminalOptions(appearance: TerminalAppearanceSettings): ITer
     letterSpacing: appearance.letterSpacing,
     cursorStyle: appearance.cursorStyle,
     cursorBlink: appearance.cursorBlink,
-    scrollback: appearance.scrollback,
+    scrollback: normalizeScrollbackLines(appearance.scrollback),
     allowTransparency: needsTransparency,
     theme: needsTransparency ? {
       ...theme,
@@ -346,8 +369,13 @@ export function loadAppearanceSettings(): TerminalAppearanceSettings {
   try {
     const saved = localStorage.getItem('terminalAppearance');
     if (saved) {
-      const parsed = JSON.parse(saved);
-      return { ...defaultAppearanceSettings, ...parsed };
+      const parsed = JSON.parse(saved) as unknown;
+      if (parsed && typeof parsed === 'object') {
+        return normalizeAppearanceSettings({
+          ...defaultAppearanceSettings,
+          ...(parsed as Partial<TerminalAppearanceSettings>),
+        });
+      }
     }
   } catch (e) {
     console.error('Failed to load terminal appearance settings:', e);
@@ -357,7 +385,7 @@ export function loadAppearanceSettings(): TerminalAppearanceSettings {
 
 export function saveAppearanceSettings(settings: TerminalAppearanceSettings): void {
   try {
-    localStorage.setItem('terminalAppearance', JSON.stringify(settings));
+    localStorage.setItem('terminalAppearance', JSON.stringify(normalizeAppearanceSettings(settings)));
   } catch (e) {
     console.error('Failed to save terminal appearance settings:', e);
   }
@@ -453,7 +481,7 @@ export function getThemeAwareTerminalOptions(appearance: TerminalAppearanceSetti
     letterSpacing: appearance.letterSpacing,
     cursorStyle: appearance.cursorStyle,
     cursorBlink: appearance.cursorBlink,
-    scrollback: appearance.scrollback,
+    scrollback: normalizeScrollbackLines(appearance.scrollback),
     allowTransparency: needsTransparency,
     theme: needsTransparency ? {
       ...theme,


### PR DESCRIPTION
﻿## Problem
Long terminal output cannot be scrolled back far enough. After commands like `seq 1 20000`, early output becomes unreachable and the terminal appears to stop around a few hundred lines of history.

## Root cause
Commit `95bd715` lowered the default xterm.js scrollback from `10000` to `500` to reduce memory usage. xterm's visible buffer is roughly `scrollback + viewport rows`, so a 500-line scrollback with a ~90-row terminal shows up as about 590 reachable lines. Saved `terminalAppearance.scrollback` values from that regression could also keep overriding future defaults.

## Fix
- Restore the default xterm scrollback to `10000` lines.
- Add scrollback normalization constants: min `1000`, default `10000`, max `50000`.
- Migrate invalid or too-small saved scrollback values, including the regressed `500`, back to the default.
- Clamp saved settings so users can raise scrollback up to `50000` without unbounded growth.
- Apply `term.options.scrollback` in-place when terminal appearance settings change, without recreating or disposing the terminal.
- Add a regression test using real xterm.js that writes `20000` lines and verifies the default buffer keeps at least `10000` lines.
- Update stale terminal test mocks for the current `PtyTerminal` dependencies and paste behavior.

## Validation
- PASS: `pnpm test -- src/__tests__/terminal-scrollback.test.ts`
- PASS: `pnpm test -- src/__tests__/terminal-scrollback.test.ts src/__tests__/pty-terminal-scrollbar.test.tsx src/__tests__/pty-terminal-activation.test.tsx`
- PASS: `pnpm test -- src/__tests__/terminal-scrollback.test.ts src/__tests__/terminal-group-serializer.test.ts`
- PASS: `pnpm lint` (0 errors, existing warnings remain)
- PASS: `pnpm build`
- PARTIAL: `pnpm test` runs 425/432 tests successfully, but `src/__tests__/connection.test.ts` still fails because it calls Tauri `invoke` in jsdom where `window.__TAURI_INTERNALS__` is unavailable. That failure is unrelated to this change and exists outside the terminal scrollback path.
- PARTIAL: `cargo test` was attempted from `src-tauri` but exceeded the local 184s timeout before producing a final result.

## Risk
This increases the default in-memory terminal history from 500 to 10000 lines, so per-terminal memory usage can increase. The history remains bounded by xterm.js' scrollback ring buffer; this is not infinite DOM appending and does not render output into ordinary divs. User-configured scrollback is capped at `50000` lines. Existing PTY/WebSocket output flow-control and output-limit behavior is left in place.

## Manual test
```sh
yes "scrollback-test" | head -n 20000
seq 1 20000
```

Expected:
- With default settings, output completion should allow scrolling back through at least the most recent 10000 lines.
- With scrollback configured to 50000, the full 20000-line manual test output should be reachable.
- Switching tabs and resizing the browser/app window should not clear the terminal buffer.
