### PR TITLE
fix(terminal): preserve live sessions when moving tabs between groups

### DIFF
--- a/src/__tests__/terminal-tab-portals.test.tsx
+++ b/src/__tests__/terminal-tab-portals.test.tsx
@@ -1,0 +1,167 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { TerminalGroupState } from '../lib/terminal-group-types';
+import {
+  TerminalTabPortalHost,
+  TerminalTabPortalProvider,
+} from '../components/terminal/terminal-tab-portals';
+
+const lifecycle = vi.hoisted(() => ({
+  mounted: vi.fn(),
+  unmounted: vi.fn(),
+  dispatch: vi.fn(),
+}));
+
+let mockState: TerminalGroupState;
+
+vi.mock('../lib/terminal-group-context', () => ({
+  useTerminalGroups: () => ({
+    state: mockState,
+    dispatch: lifecycle.dispatch,
+  }),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => ({}),
+}));
+
+vi.mock('../components/pty-terminal', async () => {
+  const ReactModule = await import('react');
+
+  return {
+    PtyTerminal: ({ connectionId }: { connectionId: string }) => {
+      ReactModule.useEffect(() => {
+        lifecycle.mounted(connectionId);
+        return () => lifecycle.unmounted(connectionId);
+      }, [connectionId]);
+
+      return <div data-testid={`pty-${connectionId}`} />;
+    },
+  };
+});
+
+vi.mock('../components/file-browser-view', () => ({
+  FileBrowserView: () => <div />,
+}));
+
+vi.mock('../components/desktop-viewer', () => ({
+  DesktopViewer: () => <div />,
+}));
+
+vi.mock('../components/file-editor-view', () => ({
+  FileEditorView: () => <div />,
+}));
+
+const tabA = {
+  id: 'tab-a',
+  name: 'Server A',
+  tabType: 'terminal' as const,
+  connectionStatus: 'connected' as const,
+  reconnectCount: 0,
+};
+
+const tabB = {
+  id: 'tab-b',
+  name: 'Server B',
+  tabType: 'terminal' as const,
+  connectionStatus: 'connected' as const,
+  reconnectCount: 0,
+};
+
+function singleGroupState(): TerminalGroupState {
+  return {
+    groups: {
+      '1': { id: '1', tabs: [tabA, tabB], activeTabId: tabA.id },
+    },
+    activeGroupId: '1',
+    gridLayout: { type: 'leaf', groupId: '1' },
+    nextGroupId: 2,
+    tabToGroupMap: {
+      [tabA.id]: '1',
+      [tabB.id]: '1',
+    },
+  };
+}
+
+function splitGroupState(): TerminalGroupState {
+  return {
+    groups: {
+      '1': { id: '1', tabs: [tabB], activeTabId: tabB.id },
+      '2': { id: '2', tabs: [tabA], activeTabId: tabA.id },
+    },
+    activeGroupId: '2',
+    gridLayout: {
+      type: 'branch',
+      direction: 'horizontal',
+      children: [
+        { type: 'leaf', groupId: '1' },
+        { type: 'leaf', groupId: '2' },
+      ],
+      sizes: [50, 50],
+    },
+    nextGroupId: 3,
+    tabToGroupMap: {
+      [tabA.id]: '2',
+      [tabB.id]: '1',
+    },
+  };
+}
+
+function SingleGroupHosts() {
+  return (
+    <TerminalTabPortalProvider>
+      <div data-testid="group-1">
+        <TerminalTabPortalHost tabId={tabA.id} isActive />
+        <TerminalTabPortalHost tabId={tabB.id} isActive={false} />
+      </div>
+    </TerminalTabPortalProvider>
+  );
+}
+
+function SplitGroupHosts() {
+  return (
+    <TerminalTabPortalProvider>
+      <div data-testid="group-1">
+        <TerminalTabPortalHost tabId={tabB.id} isActive />
+      </div>
+      <div data-testid="group-2">
+        <TerminalTabPortalHost tabId={tabA.id} isActive />
+      </div>
+    </TerminalTabPortalProvider>
+  );
+}
+
+describe('TerminalTabPortalProvider', () => {
+  beforeEach(() => {
+    lifecycle.mounted.mockClear();
+    lifecycle.unmounted.mockClear();
+    lifecycle.dispatch.mockClear();
+    mockState = singleGroupState();
+  });
+
+  afterEach(() => cleanup());
+
+  it('keeps live terminal components mounted when a tab moves to a new group', () => {
+    const view = render(<SingleGroupHosts />);
+
+    expect(screen.getByTestId('pty-tab-a')).toBeTruthy();
+    expect(screen.getByTestId('pty-tab-b')).toBeTruthy();
+    expect(lifecycle.mounted).toHaveBeenCalledTimes(2);
+    expect(lifecycle.unmounted).not.toHaveBeenCalled();
+
+    mockState = splitGroupState();
+    view.rerender(<SplitGroupHosts />);
+
+    expect(screen.getByTestId('pty-tab-a')).toBeTruthy();
+    expect(screen.getByTestId('pty-tab-b')).toBeTruthy();
+    expect(lifecycle.mounted).toHaveBeenCalledTimes(2);
+    expect(lifecycle.unmounted).not.toHaveBeenCalled();
+
+    view.unmount();
+
+    expect(lifecycle.unmounted).toHaveBeenCalledTimes(2);
+    expect(lifecycle.unmounted).toHaveBeenCalledWith(tabA.id);
+    expect(lifecycle.unmounted).toHaveBeenCalledWith(tabB.id);
+  });
+});

--- a/src/__tests__/terminal-tab-portals.test.tsx
+++ b/src/__tests__/terminal-tab-portals.test.tsx
@@ -108,26 +108,18 @@ function splitGroupState(): TerminalGroupState {
   };
 }
 
-function SingleGroupHosts() {
+function PortalHosts({ split }: { split: boolean }) {
   return (
     <TerminalTabPortalProvider>
       <div data-testid="group-1">
-        <TerminalTabPortalHost tabId={tabA.id} isActive />
-        <TerminalTabPortalHost tabId={tabB.id} isActive={false} />
+        {!split && <TerminalTabPortalHost tabId={tabA.id} isActive />}
+        <TerminalTabPortalHost tabId={tabB.id} isActive={split} />
       </div>
-    </TerminalTabPortalProvider>
-  );
-}
-
-function SplitGroupHosts() {
-  return (
-    <TerminalTabPortalProvider>
-      <div data-testid="group-1">
-        <TerminalTabPortalHost tabId={tabB.id} isActive />
-      </div>
-      <div data-testid="group-2">
-        <TerminalTabPortalHost tabId={tabA.id} isActive />
-      </div>
+      {split && (
+        <div data-testid="group-2">
+          <TerminalTabPortalHost tabId={tabA.id} isActive />
+        </div>
+      )}
     </TerminalTabPortalProvider>
   );
 }
@@ -143,7 +135,7 @@ describe('TerminalTabPortalProvider', () => {
   afterEach(() => cleanup());
 
   it('keeps live terminal components mounted when a tab moves to a new group', () => {
-    const view = render(<SingleGroupHosts />);
+    const view = render(<PortalHosts split={false} />);
 
     expect(screen.getByTestId('pty-tab-a')).toBeTruthy();
     expect(screen.getByTestId('pty-tab-b')).toBeTruthy();
@@ -151,7 +143,7 @@ describe('TerminalTabPortalProvider', () => {
     expect(lifecycle.unmounted).not.toHaveBeenCalled();
 
     mockState = splitGroupState();
-    view.rerender(<SplitGroupHosts />);
+    view.rerender(<PortalHosts split />);
 
     expect(screen.getByTestId('pty-tab-a')).toBeTruthy();
     expect(screen.getByTestId('pty-tab-b')).toBeTruthy();

--- a/src/components/terminal/grid-renderer.tsx
+++ b/src/components/terminal/grid-renderer.tsx
@@ -3,6 +3,7 @@ import type { GridNode } from '../../lib/terminal-group-types';
 import { useTerminalGroups } from '../../lib/terminal-group-context';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
 import { TerminalGroupView } from './terminal-group-view';
+import { TerminalTabPortalProvider } from './terminal-tab-portals';
 
 interface GridRendererProps {
   node: GridNode;
@@ -11,14 +12,10 @@ interface GridRendererProps {
 
 /** Derive a stable React key from a GridNode.
  *
- *  The key must survive tree restructuring so that React can reconcile
- *  existing components instead of unmounting/remounting them (which
- *  would tear down live WebSocket + PTY connections).
- *
- *  Strategy: use the smallest (i.e. oldest) leaf groupId in the subtree.
- *  When a leaf is split into a branch, the original group (which always
- *  has a smaller numeric id than the newly created group) stays in the
- *  subtree, so the key remains the same regardless of split direction.
+ * The key keeps existing panel instances and their resize state stable while the
+ * tree is restructured. Live tab content is kept mounted separately by
+ * TerminalTabPortalProvider, because React keys cannot preserve a component that
+ * moves across different parents in the recursive layout tree.
  */
 function getStableKey(node: GridNode): string {
   return `grid-${minLeafGroupId(node)}`;
@@ -36,7 +33,15 @@ function minLeafGroupId(node: GridNode): string {
   return min;
 }
 
-export function GridRenderer({ node, path }: GridRendererProps) {
+export function GridRenderer(props: GridRendererProps) {
+  return (
+    <TerminalTabPortalProvider>
+      <GridRendererNode {...props} />
+    </TerminalTabPortalProvider>
+  );
+}
+
+function GridRendererNode({ node, path }: GridRendererProps) {
   const { dispatch } = useTerminalGroups();
 
   const handleLayout = useCallback(
@@ -96,7 +101,7 @@ function GridRendererChild({ child, index, path, defaultSize, isLast, onHandleDo
   return (
     <>
       <ResizablePanel id={panelId} order={index} defaultSize={defaultSize} minSize={10}>
-        <GridRenderer node={child} path={childPath} />
+        <GridRendererNode node={child} path={childPath} />
       </ResizablePanel>
       {!isLast && <ResizableHandle onDoubleClick={onHandleDoubleClick} />}
     </>

--- a/src/components/terminal/terminal-group-view.tsx
+++ b/src/components/terminal/terminal-group-view.tsx
@@ -1,39 +1,12 @@
-import { useCallback, useState, useEffect } from 'react';
+import { useCallback, type KeyboardEvent } from 'react';
 import { useTerminalGroups } from '../../lib/terminal-group-context';
 import { useTerminalCallbacks } from '../../lib/terminal-callbacks-context';
 import { GroupTabBar } from './group-tab-bar';
-import { PtyTerminal } from '../pty-terminal';
-import { FileBrowserView } from '../file-browser-view';
-import { DesktopViewer } from '../desktop-viewer';
-import { FileEditorView } from '../file-editor-view';
+import { TerminalTabPortalHost } from './terminal-tab-portals';
 import { WelcomeScreen } from '../welcome-screen';
 
 interface TerminalGroupViewProps {
   groupId: string;
-}
-
-function useThemeKey(): number {
-  const [themeKey, setThemeKey] = useState(0);
-
-  useEffect(() => {
-    const observer = new MutationObserver((mutations) => {
-      for (const mutation of mutations) {
-        if (mutation.attributeName === 'class') {
-          setThemeKey((k) => k + 1);
-          break;
-        }
-      }
-    });
-
-    observer.observe(document.documentElement, {
-      attributes: true,
-      attributeFilter: ['class'],
-    });
-
-    return () => observer.disconnect();
-  }, []);
-
-  return themeKey;
 }
 
 export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
@@ -41,7 +14,6 @@ export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
   const { onDuplicateTab, onNewTab, onReconnectTab } = useTerminalCallbacks();
   const group = state.groups[groupId];
   const isActive = state.activeGroupId === groupId;
-  const themeKey = useThemeKey();
 
   const handleMouseDown = useCallback(() => {
     if (!isActive) {
@@ -63,15 +35,8 @@ export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
     [dispatch, onReconnectTab],
   );
 
-  const handleConnectionStatusChange = useCallback(
-    (connectionId: string, status: 'connected' | 'connecting' | 'disconnected' | 'pending') => {
-      dispatch({ type: 'UPDATE_TAB_STATUS', tabId: connectionId, status });
-    },
-    [dispatch],
-  );
-
   const handleKeyDown = useCallback(
-    (e: React.KeyboardEvent) => {
+    (e: KeyboardEvent) => {
       // Don't intercept keys that originate from within the terminal.
       // xterm.js uses a hidden <textarea> for keyboard input; calling
       // preventDefault() here would block the character from reaching
@@ -88,7 +53,7 @@ export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
         handleMouseDown();
       }
     },
-    [handleMouseDown]
+    [handleMouseDown],
   );
 
   if (!group) return null;
@@ -122,55 +87,11 @@ export function TerminalGroupView({ groupId }: TerminalGroupViewProps) {
           <WelcomeScreen onNewConnection={() => {}} onOpenSettings={() => {}} />
         ) : (
           group.tabs.map((tab) => (
-            <div
+            <TerminalTabPortalHost
               key={tab.id}
-              className="absolute inset-0"
-              style={{ display: tab.id === group.activeTabId ? 'block' : 'none' }}
-            >
-              {tab.tabType === 'desktop' ? (
-                <DesktopViewer
-                  connectionId={tab.id}
-                  connectionName={tab.name}
-                  host={tab.host}
-                  protocol={tab.protocol}
-                  isConnected={tab.connectionStatus === 'connected'}
-                  onReconnect={() => handleReconnect(tab.id)}
-                />
-              ) : tab.tabType === 'file-browser' ? (
-                <FileBrowserView
-                  connectionId={tab.id}
-                  connectionName={tab.name}
-                  host={tab.host}
-                  protocol={tab.protocol}
-                  isConnected={tab.connectionStatus === 'connected'}
-                  onReconnect={() => handleReconnect(tab.id)}
-                />
-              ) : tab.tabType === 'editor' && tab.editorFilePath && tab.editorConnectionId ? (
-                <FileEditorView
-                  connectionId={tab.editorConnectionId}
-                  filePath={tab.editorFilePath}
-                  fileName={tab.name}
-                  isConnected={tab.connectionStatus === 'connected'}
-                />
-              ) : tab.connectionStatus !== 'pending' ? (
-                <PtyTerminal
-                  key={`${tab.id}-${tab.reconnectCount}`}
-                  connectionId={tab.id}
-                  connectionName={tab.name}
-                  host={tab.host}
-                  username={tab.username}
-                  themeKey={themeKey}
-                  isActive={isActive && tab.id === group.activeTabId}
-                  onConnectionStatusChange={handleConnectionStatusChange}
-                />
-              ) : (
-                <div className="h-full w-full flex items-center justify-center bg-muted/30">
-                  <div className="text-center text-muted-foreground">
-                    <div className="animate-pulse">Waiting for connection...</div>
-                  </div>
-                </div>
-              )}
-            </div>
+              tabId={tab.id}
+              isActive={tab.id === group.activeTabId}
+            />
           ))
         )}
       </div>

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -157,7 +157,7 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
  */
 export function TerminalTabPortalProvider({ children }: { children: React.ReactNode }) {
   const { state } = useTerminalGroups();
-  const portalNodesRef = useRef(new Map<string, HTMLDivElement>());
+  const [portalNodes] = useState(() => new Map<string, HTMLDivElement>());
   const themeKey = useThemeKey();
 
   const allTabs = useMemo(
@@ -166,25 +166,25 @@ export function TerminalTabPortalProvider({ children }: { children: React.ReactN
   );
 
   const getPortalNode = useCallback((tabId: string): HTMLDivElement => {
-    const existing = portalNodesRef.current.get(tabId);
+    const existing = portalNodes.get(tabId);
     if (existing) return existing;
 
     const node = document.createElement('div');
     node.className = 'h-full w-full';
     node.dataset.terminalTabPortal = tabId;
-    portalNodesRef.current.set(tabId, node);
+    portalNodes.set(tabId, node);
     return node;
-  }, []);
+  }, [portalNodes]);
 
   useEffect(() => {
     const liveTabIds = new Set(allTabs.map((tab) => tab.id));
-    for (const [tabId, node] of portalNodesRef.current) {
+    for (const [tabId, node] of portalNodes) {
       if (!liveTabIds.has(tabId)) {
         node.remove();
-        portalNodesRef.current.delete(tabId);
+        portalNodes.delete(tabId);
       }
     }
-  }, [allTabs]);
+  }, [allTabs, portalNodes]);
 
   const contextValue = useMemo(() => ({ getPortalNode }), [getPortalNode]);
 

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -54,6 +54,12 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
   const group = groupId ? state.groups[groupId] : undefined;
   const isActive = groupId === state.activeGroupId && group?.activeTabId === tab.id;
 
+  const handleActivateGroup = useCallback(() => {
+    if (groupId && state.activeGroupId !== groupId) {
+      dispatch({ type: 'ACTIVATE_GROUP', groupId });
+    }
+  }, [dispatch, groupId, state.activeGroupId]);
+
   const handleReconnect = useCallback(() => {
     if (onReconnectTab) {
       void onReconnectTab(tab.id);
@@ -72,8 +78,10 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
     [dispatch],
   );
 
+  let content: React.ReactNode;
+
   if (tab.tabType === 'desktop') {
-    return (
+    content = (
       <DesktopViewer
         connectionId={tab.id}
         connectionName={tab.name}
@@ -83,10 +91,8 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
         onReconnect={handleReconnect}
       />
     );
-  }
-
-  if (tab.tabType === 'file-browser') {
-    return (
+  } else if (tab.tabType === 'file-browser') {
+    content = (
       <FileBrowserView
         connectionId={tab.id}
         connectionName={tab.name}
@@ -96,10 +102,8 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
         onReconnect={handleReconnect}
       />
     );
-  }
-
-  if (tab.tabType === 'editor' && tab.editorFilePath && tab.editorConnectionId) {
-    return (
+  } else if (tab.tabType === 'editor' && tab.editorFilePath && tab.editorConnectionId) {
+    content = (
       <FileEditorView
         connectionId={tab.editorConnectionId}
         filePath={tab.editorFilePath}
@@ -107,29 +111,40 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
         isConnected={tab.connectionStatus === 'connected'}
       />
     );
-  }
-
-  if (tab.connectionStatus === 'pending') {
-    return (
+  } else if (tab.connectionStatus === 'pending') {
+    content = (
       <div className="h-full w-full flex items-center justify-center bg-muted/30">
         <div className="text-center text-muted-foreground">
           <div className="animate-pulse">Waiting for connection...</div>
         </div>
       </div>
     );
+  } else {
+    content = (
+      <PtyTerminal
+        key={`${tab.id}-${tab.reconnectCount}`}
+        connectionId={tab.id}
+        connectionName={tab.name}
+        host={tab.host}
+        username={tab.username}
+        themeKey={themeKey}
+        isActive={isActive}
+        onConnectionStatusChange={handleConnectionStatusChange}
+      />
+    );
   }
 
+  // Portal events follow the React owner tree rather than the host's DOM ancestry.
+  // Activate the owning group here so clicking/focusing portal content retains the
+  // same behaviour that TerminalGroupView previously provided.
   return (
-    <PtyTerminal
-      key={`${tab.id}-${tab.reconnectCount}`}
-      connectionId={tab.id}
-      connectionName={tab.name}
-      host={tab.host}
-      username={tab.username}
-      themeKey={themeKey}
-      isActive={isActive}
-      onConnectionStatusChange={handleConnectionStatusChange}
-    />
+    <div
+      className="h-full w-full"
+      onMouseDownCapture={handleActivateGroup}
+      onFocusCapture={handleActivateGroup}
+    >
+      {content}
+    </div>
   );
 }
 

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -1,0 +1,229 @@
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
+import { createPortal } from 'react-dom';
+import { useTerminalGroups } from '../../lib/terminal-group-context';
+import { useTerminalCallbacks } from '../../lib/terminal-callbacks-context';
+import type { TerminalTab } from '../../lib/terminal-group-types';
+import { PtyTerminal } from '../pty-terminal';
+import { FileBrowserView } from '../file-browser-view';
+import { DesktopViewer } from '../desktop-viewer';
+import { FileEditorView } from '../file-editor-view';
+
+interface TerminalTabPortalContextValue {
+  getPortalNode: (tabId: string) => HTMLDivElement;
+}
+
+const TerminalTabPortalContext = createContext<TerminalTabPortalContextValue | null>(null);
+
+function useThemeKey(): number {
+  const [themeKey, setThemeKey] = useState(0);
+
+  useEffect(() => {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        if (mutation.attributeName === 'class') {
+          setThemeKey((key) => key + 1);
+          break;
+        }
+      }
+    });
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    });
+
+    return () => observer.disconnect();
+  }, []);
+
+  return themeKey;
+}
+
+function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: number }) {
+  const { state, dispatch } = useTerminalGroups();
+  const { onReconnectTab } = useTerminalCallbacks();
+  const groupId = state.tabToGroupMap[tab.id];
+  const group = groupId ? state.groups[groupId] : undefined;
+  const isActive = groupId === state.activeGroupId && group?.activeTabId === tab.id;
+
+  const handleReconnect = useCallback(() => {
+    if (onReconnectTab) {
+      void onReconnectTab(tab.id);
+      return;
+    }
+    dispatch({ type: 'RECONNECT_TAB', tabId: tab.id });
+  }, [dispatch, onReconnectTab, tab.id]);
+
+  const handleConnectionStatusChange = useCallback(
+    (
+      connectionId: string,
+      status: 'connected' | 'connecting' | 'disconnected' | 'pending',
+    ) => {
+      dispatch({ type: 'UPDATE_TAB_STATUS', tabId: connectionId, status });
+    },
+    [dispatch],
+  );
+
+  if (tab.tabType === 'desktop') {
+    return (
+      <DesktopViewer
+        connectionId={tab.id}
+        connectionName={tab.name}
+        host={tab.host}
+        protocol={tab.protocol}
+        isConnected={tab.connectionStatus === 'connected'}
+        onReconnect={handleReconnect}
+      />
+    );
+  }
+
+  if (tab.tabType === 'file-browser') {
+    return (
+      <FileBrowserView
+        connectionId={tab.id}
+        connectionName={tab.name}
+        host={tab.host}
+        protocol={tab.protocol}
+        isConnected={tab.connectionStatus === 'connected'}
+        onReconnect={handleReconnect}
+      />
+    );
+  }
+
+  if (tab.tabType === 'editor' && tab.editorFilePath && tab.editorConnectionId) {
+    return (
+      <FileEditorView
+        connectionId={tab.editorConnectionId}
+        filePath={tab.editorFilePath}
+        fileName={tab.name}
+        isConnected={tab.connectionStatus === 'connected'}
+      />
+    );
+  }
+
+  if (tab.connectionStatus === 'pending') {
+    return (
+      <div className="h-full w-full flex items-center justify-center bg-muted/30">
+        <div className="text-center text-muted-foreground">
+          <div className="animate-pulse">Waiting for connection...</div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <PtyTerminal
+      key={`${tab.id}-${tab.reconnectCount}`}
+      connectionId={tab.id}
+      connectionName={tab.name}
+      host={tab.host}
+      username={tab.username}
+      themeKey={themeKey}
+      isActive={isActive}
+      onConnectionStatusChange={handleConnectionStatusChange}
+    />
+  );
+}
+
+/**
+ * Owns one stable DOM container per tab and renders the live tab content into it.
+ *
+ * The recursive grid is free to remount or reparent lightweight portal hosts while
+ * the actual terminal component remains mounted in the same portal container.
+ * This prevents layout-only operations from closing WebSocket and PTY sessions.
+ */
+export function TerminalTabPortalProvider({ children }: { children: React.ReactNode }) {
+  const { state } = useTerminalGroups();
+  const portalNodesRef = useRef(new Map<string, HTMLDivElement>());
+  const themeKey = useThemeKey();
+
+  const allTabs = useMemo(
+    () => Object.values(state.groups).flatMap((group) => group.tabs),
+    [state.groups],
+  );
+
+  const getPortalNode = useCallback((tabId: string): HTMLDivElement => {
+    const existing = portalNodesRef.current.get(tabId);
+    if (existing) return existing;
+
+    const node = document.createElement('div');
+    node.className = 'h-full w-full';
+    node.dataset.terminalTabPortal = tabId;
+    portalNodesRef.current.set(tabId, node);
+    return node;
+  }, []);
+
+  useEffect(() => {
+    const liveTabIds = new Set(allTabs.map((tab) => tab.id));
+    for (const [tabId, node] of portalNodesRef.current) {
+      if (!liveTabIds.has(tabId)) {
+        node.remove();
+        portalNodesRef.current.delete(tabId);
+      }
+    }
+  }, [allTabs]);
+
+  const contextValue = useMemo(() => ({ getPortalNode }), [getPortalNode]);
+
+  return (
+    <TerminalTabPortalContext.Provider value={contextValue}>
+      {children}
+      {allTabs.map((tab) =>
+        createPortal(
+          <TerminalTabContent tab={tab} themeKey={themeKey} />,
+          getPortalNode(tab.id),
+          tab.id,
+        ),
+      )}
+    </TerminalTabPortalContext.Provider>
+  );
+}
+
+export function TerminalTabPortalHost({
+  tabId,
+  isActive,
+}: {
+  tabId: string;
+  isActive: boolean;
+}) {
+  const context = useContext(TerminalTabPortalContext);
+  const hostRef = useRef<HTMLDivElement>(null);
+
+  if (!context) {
+    throw new Error('TerminalTabPortalHost must be used within TerminalTabPortalProvider');
+  }
+
+  const { getPortalNode } = context;
+
+  useLayoutEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+
+    const portalNode = getPortalNode(tabId);
+    host.appendChild(portalNode);
+
+    return () => {
+      if (portalNode.parentElement === host) {
+        host.removeChild(portalNode);
+      }
+    };
+  }, [getPortalNode, tabId]);
+
+  return (
+    <div
+      ref={hostRef}
+      data-terminal-tab-host={tabId}
+      className="absolute inset-0"
+      style={{ display: isActive ? 'block' : 'none' }}
+      aria-hidden={!isActive}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

- keep live tab content mounted in stable per-tab portal containers
- let the recursive grid move lightweight portal hosts instead of remounting terminals
- preserve active-group behavior, active-tab visibility, reconnect behavior, and normal cleanup when a tab is actually closed
- add a regression test that moves a live terminal tab into a new group without mounting or unmounting either terminal again

## Root cause

`MOVE_TAB_TO_NEW_GROUP` replaces a grid leaf with a branch. React consequently unmounts the old `TerminalGroupView`, which previously owned every live `PtyTerminal` in the source group. The cleanup closes each WebSocket and backend PTY, and the replacement layout starts new shells.

Stable keys cannot preserve components that move across different parents or whose parent hierarchy changes, so this separates live tab ownership from the layout tree.

## User impact

Moving or splitting tabs now changes only their layout. Existing xterm instances, WebSocket connections, PTY sessions, terminal history, and running foreground commands stay alive.

## Testing

- `pnpm test -- src/__tests__/terminal-tab-portals.test.tsx src/__tests__/grid-renderer.test.tsx` ? 2 files, 5 tests passed
- `pnpm build` ? passed
- scoped ESLint for the three changed terminal components ? passed with one pre-existing `grid-renderer.tsx` warning
- full Vitest run ? 31 files / 467 tests passed; 14 pre-existing environment/mock failures remain in `connection.test.ts`, `pty-terminal-activation.test.tsx`, and `pty-terminal-scrollbar.test.tsx`
- full ESLint remains blocked by the pre-existing `settings-modal.tsx:293` error

Fixes #46
Related to #7
