### PR TITLE
fix: connections cannot be dragged into folders on macOS

### DIFF
--- a/src/__tests__/connection-drag.test.ts
+++ b/src/__tests__/connection-drag.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Regression tests for connection drag payloads on WebKit (macOS WKWebView).
+ *
+ * Closes: connections cannot be dragged into folders on macOS.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import {
+  applyConnectionDragData,
+  readConnectionDragId,
+  CONNECTION_DRAG_MIME,
+} from '@/lib/connection-drag';
+
+/** Minimal DataTransfer stand-in — jsdom does not implement one. */
+function makeDataTransfer() {
+  const store = new Map<string, string>();
+  const dt = {
+    effectAllowed: 'none',
+    dropEffect: 'none',
+    types: [] as string[],
+    setData: vi.fn((format: string, data: string) => {
+      store.set(format, data);
+      dt.types = [...store.keys()];
+    }),
+    getData: vi.fn((format: string) => store.get(format) ?? ''),
+  };
+  return dt as unknown as DataTransfer & { types: string[] };
+}
+
+const node = { id: 'c1', name: 'mt01' };
+
+describe('connection drag payload — WebKit compatibility', () => {
+  it('puts at least one item on the dataTransfer, or WebKit aborts the drag', () => {
+    const dt = makeDataTransfer();
+    applyConnectionDragData(dt, node);
+    expect(dt.types.length).toBeGreaterThan(0);
+  });
+
+  it('sets the text/plain fallback WebKit actually checks for', () => {
+    const dt = makeDataTransfer();
+    applyConnectionDragData(dt, node);
+    expect(dt.getData('text/plain')).toBe('mt01');
+  });
+
+  it('carries the connection id under a private MIME', () => {
+    const dt = makeDataTransfer();
+    applyConnectionDragData(dt, node);
+    expect(dt.getData(CONNECTION_DRAG_MIME)).toBe('c1');
+  });
+
+  it('still marks the drag as a move', () => {
+    const dt = makeDataTransfer();
+    applyConnectionDragData(dt, node);
+    expect(dt.effectAllowed).toBe('move');
+  });
+
+  it('round-trips the id back out on drop', () => {
+    const dt = makeDataTransfer();
+    applyConnectionDragData(dt, node);
+    expect(readConnectionDragId(dt)).toBe('c1');
+  });
+
+  it('returns null for drags that did not come from the tree', () => {
+    const dt = makeDataTransfer();
+    expect(readConnectionDragId(dt)).toBeNull();
+  });
+});

--- a/src/components/connection-manager.tsx
+++ b/src/components/connection-manager.tsx
@@ -42,6 +42,7 @@ import {
   ContextMenuTrigger,
 } from './ui/context-menu';
 import { toast } from 'sonner';
+import { applyConnectionDragData } from '@/lib/connection-drag';
 
 interface ConnectionNode {
   id: string;
@@ -272,7 +273,7 @@ export function ConnectionManager({
   // Drag and drop handlers
   const handleDragStart = (e: React.DragEvent, node: ConnectionNode) => {
     setDraggedItem({ node, type: node.type });
-    e.dataTransfer.effectAllowed = 'move';
+    applyConnectionDragData(e.dataTransfer, node);
   };
 
   const handleDragOver = (e: React.DragEvent) => {

--- a/src/lib/connection-drag.ts
+++ b/src/lib/connection-drag.ts
@@ -1,0 +1,31 @@
+/**
+ * Drag payload helpers for the connection tree.
+ *
+ * WebKit (WKWebView, which Tauri uses on macOS) aborts a drag whose
+ * `dataTransfer` carries no items, so `dragover`/`drop` never fire and the node
+ * snaps back. Chromium (WebView2 on Windows) starts the drag regardless, which
+ * is why this only reproduces on macOS. Always seed at least `text/plain`.
+ */
+
+export const CONNECTION_DRAG_MIME = 'application/x-r-shell-connection';
+
+export interface DraggableConnectionNode {
+  id: string;
+  name: string;
+}
+
+/** Populate a dragstart dataTransfer so the drag survives on WebKit. */
+export function applyConnectionDragData(
+  dataTransfer: DataTransfer,
+  node: DraggableConnectionNode,
+): void {
+  dataTransfer.effectAllowed = 'move';
+  dataTransfer.setData(CONNECTION_DRAG_MIME, node.id);
+  // text/plain is the format WebKit actually checks for.
+  dataTransfer.setData('text/plain', node.name);
+}
+
+/** Read back the dragged connection id, if this drag originated in the tree. */
+export function readConnectionDragId(dataTransfer: DataTransfer): string | null {
+  return dataTransfer.getData(CONNECTION_DRAG_MIME) || null;
+}


### PR DESCRIPTION
### Environment
macOS (Apple Silicon), r-shell v2.5.0 (Homebrew cask), Tauri 2 → WKWebView

### Steps to reproduce
1. Create a folder and a connection in the Connections tree
2. Try to drag the connection into the folder
3. The node never lifts, no drop indicator appears, it snaps back

Expected: the connection moves into the folder.
Actual: nothing happens. Works on Windows.

## Root cause

`handleDragStart` in `connection-manager.tsx` set `effectAllowed` but never
called `dataTransfer.setData()`. WebKit aborts a drag whose `dataTransfer`
carries no items, so `dragover`/`drop` never fired and the node snapped back.
Chromium-based WebView2 on Windows starts the drag regardless, which is why
this did not reproduce for maintainers. Tauri uses the system webview, so the
platforms diverge here: WKWebView on macOS, WebView2 on Windows.

The other two DnD implementations in the codebase are unaffected:
- `file-panel.tsx` calls `dataTransfer.setData(DRAG_MIME, payload)`
- `group-tab-bar.tsx` opts out of native DnD (`draggable={false}`)
- `connection-manager.tsx` was the only native DnD without a payload

`ConnectionStorageManager.moveConnection()` is correct; control never reached it.

## Fix

Seed `dataTransfer` on dragstart with `text/plain` (the format WebKit checks)
plus a private MIME carrying the connection id.

Payload logic lives in `src/lib/connection-drag.ts`, mirroring the
`src/lib/upload-paths.ts` split from #24, so it is unit-testable:
`ConnectionManager` cannot currently mount under jsdom — it dies with
"Maximum update depth exceeded" inside `@radix-ui/react-compose-refs`
(Radix `ContextMenuTrigger asChild` + React 19).

## Verification

- RED: `pnpm test src/__tests__/connection-drag.test.ts` fails before the change
  (`@/lib/connection-drag` does not exist)
- GREEN: 6/6 pass
- `pnpm exec tsc --noEmit` — clean
- `pnpm build` — clean
- `pnpm i18n:check` — passed (939 keys, no new strings)
- `pnpm lint` — 0 errors on touched files (2 pre-existing exhaustive-deps warnings)
- `pnpm vitest run` — 480/487; the 7 failures are the pre-existing
  `connection.test.ts` suite requiring a Tauri runtime, as noted in #18 and #24
