### PR TITLE
feat(terminal): press R to reconnect disconnected sessions

### DIFF
--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { act, cleanup, render } from '@testing-library/react';
 import { PtyTerminal } from '../components/pty-terminal';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
 
 const mocks = vi.hoisted(() => {
   const terminals: Array<any> = [];
@@ -201,6 +202,7 @@ describe('PtyTerminal activation', () => {
     mocks.terminals.length = 0;
     mocks.fitAddons.length = 0;
     mocks.webSockets.length = 0;
+    localStorage.removeItem(APP_SETTINGS_STORAGE_KEY);
 
     Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
       configurable: true,
@@ -290,6 +292,27 @@ describe('PtyTerminal activation', () => {
     expect(mocks.terminals).toHaveLength(terminalCount);
     expect(mocks.webSockets).toHaveLength(webSocketCount);
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
+  it('stops after a disconnect when automatic reconnect is disabled', async () => {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ autoReconnect: false }));
+    renderTerminal(true);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60);
+    });
+
+    const terminal = mocks.terminals[0];
+    const socket = mocks.webSockets[0];
+    await act(async () => {
+      socket.onmessage?.({
+        data: JSON.stringify({ type: 'Success', message: 'PTY connection started' }),
+      } as MessageEvent);
+      socket.onclose?.();
+      await vi.advanceTimersByTimeAsync(2100);
+    });
+
+    expect(mocks.webSockets).toHaveLength(1);
+    expect(terminal.write).toHaveBeenCalledWith(expect.stringContaining('Press R'));
   });
 
   it('lets xterm handle Ctrl+V paste without duplicate custom send', async () => {

--- a/src/__tests__/terminal-tab-portals.test.tsx
+++ b/src/__tests__/terminal-tab-portals.test.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { TerminalGroupState } from '../lib/terminal-group-types';
 import {
   TerminalTabPortalHost,
@@ -11,6 +11,7 @@ const lifecycle = vi.hoisted(() => ({
   mounted: vi.fn(),
   unmounted: vi.fn(),
   dispatch: vi.fn(),
+  reconnect: vi.fn(),
 }));
 
 let mockState: TerminalGroupState;
@@ -23,7 +24,7 @@ vi.mock('../lib/terminal-group-context', () => ({
 }));
 
 vi.mock('../lib/terminal-callbacks-context', () => ({
-  useTerminalCallbacks: () => ({}),
+  useTerminalCallbacks: () => ({ onReconnectTab: lifecycle.reconnect }),
 }));
 
 vi.mock('../components/pty-terminal', async () => {
@@ -129,6 +130,7 @@ describe('TerminalTabPortalProvider', () => {
     lifecycle.mounted.mockClear();
     lifecycle.unmounted.mockClear();
     lifecycle.dispatch.mockClear();
+    lifecycle.reconnect.mockClear();
     mockState = singleGroupState();
   });
 
@@ -155,5 +157,37 @@ describe('TerminalTabPortalProvider', () => {
     expect(lifecycle.unmounted).toHaveBeenCalledTimes(2);
     expect(lifecycle.unmounted).toHaveBeenCalledWith(tabA.id);
     expect(lifecycle.unmounted).toHaveBeenCalledWith(tabB.id);
+  });
+
+  it('reconnects only the active disconnected terminal on an unmodified R key', () => {
+    const view = render(<PortalHosts split={false} />);
+
+    expect(fireEvent.keyDown(screen.getByTestId('pty-tab-a'), { key: 'r' })).toBe(true);
+    expect(lifecycle.reconnect).not.toHaveBeenCalled();
+
+    mockState = {
+      ...singleGroupState(),
+      groups: {
+        '1': {
+          id: '1',
+          tabs: [
+            { ...tabA, connectionStatus: 'disconnected' },
+            { ...tabB, connectionStatus: 'disconnected' },
+          ],
+          activeTabId: tabA.id,
+        },
+      },
+    };
+    view.rerender(<PortalHosts split={false} />);
+
+    fireEvent.keyDown(screen.getByTestId('pty-tab-b'), { key: 'r' });
+    fireEvent.keyDown(screen.getByTestId('pty-tab-a'), { key: 'r', ctrlKey: true });
+    expect(lifecycle.reconnect).not.toHaveBeenCalled();
+
+    expect(
+      fireEvent.keyDown(screen.getByTestId('pty-tab-a'), { key: 'R', shiftKey: true }),
+    ).toBe(false);
+    expect(lifecycle.reconnect).toHaveBeenCalledOnce();
+    expect(lifecycle.reconnect).toHaveBeenCalledWith(tabA.id);
   });
 });

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -14,6 +14,8 @@ import { TerminalSearchBar } from './terminal/terminal-search-bar';
 import { toast } from 'sonner';
 import { signalReady } from '../lib/restoration-manager';
 import { useTerminalCallbacks } from '../lib/terminal-callbacks-context';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
+import i18n from '../lib/i18n';
 import '@xterm/xterm/css/xterm.css';
 
 interface PtyTerminalProps {
@@ -42,6 +44,17 @@ interface PtyTerminalProps {
  *  prevent V8 heap fragmentation and WebGL texture-cache bloat during
  *  sustained high-throughput output (e.g. `yes`). */
 const SESSION_OUTPUT_LIMIT_BYTES = 2 * 1024 * 1024;
+
+function isAutoReconnectEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (!raw) return true;
+    const settings = JSON.parse(raw) as { autoReconnect?: unknown };
+    return settings.autoReconnect !== false;
+  } catch {
+    return true;
+  }
+}
 
 export function PtyTerminal({
   connectionId,
@@ -603,6 +616,15 @@ export function PtyTerminal({
       ws.onclose = () => {
         console.log('[PTY Terminal] WebSocket closed');
         if (isRunning) {
+          if (!isAutoReconnectEnabled()) {
+            term.write(`\r\n\x1b[31m[${i18n.t('ptyTerminal.connectionClosedManualReconnect')}]\x1b[0m\r\n`);
+            if (connectionStatusRef.current !== 'disconnected') {
+              connectionStatusRef.current = 'disconnected';
+              onConnectionStatusChange?.(connectionId, 'disconnected');
+            }
+            return;
+          }
+
           // If a session was successfully established, a WS drop means the
           // remote shell is gone (e.g. sleep/wake cycle, server timeout).
           // Auto-reconnect with exponential backoff so the user doesn't have
@@ -611,7 +633,7 @@ export function PtyTerminal({
             const dropAttempt = autoReconnectAfterDropRef.current;
             if (dropAttempt >= MAX_AUTO_RECONNECT_AFTER_DROP) {
               // Exhausted auto-reconnect attempts — ask user to act manually.
-              term.write('\r\n\x1b[31m[Connection lost. Auto-reconnect failed after ' + MAX_AUTO_RECONNECT_AFTER_DROP + ' attempts. Use right-click → Reconnect.]\x1b[0m\r\n');
+              term.write(`\r\n\x1b[31m[${i18n.t('ptyTerminal.autoReconnectFailed', { count: MAX_AUTO_RECONNECT_AFTER_DROP })}]\x1b[0m\r\n`);
               if (connectionStatusRef.current !== 'disconnected') {
                 connectionStatusRef.current = 'disconnected';
                 onConnectionStatusChange?.(connectionId, 'disconnected');
@@ -646,7 +668,7 @@ export function PtyTerminal({
           const attempts = reconnectAttemptsRef.current;
           
           if (attempts >= MAX_RECONNECT_ATTEMPTS) {
-            term.write('\r\n\x1b[31m[Connection failed permanently. Use right-click → Reconnect to retry.]\x1b[0m\r\n');
+            term.write(`\r\n\x1b[31m[${i18n.t('ptyTerminal.connectionFailedPermanently')}]\x1b[0m\r\n`);
             if (connectionStatusRef.current !== 'disconnected') {
               connectionStatusRef.current = 'disconnected';
               onConnectionStatusChange?.(connectionId, 'disconnected');

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -68,6 +68,31 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
     dispatch({ type: 'RECONNECT_TAB', tabId: tab.id });
   }, [dispatch, onReconnectTab, tab.id]);
 
+  const handleReconnectKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      const isTerminalTab = tab.tabType === undefined || tab.tabType === 'terminal';
+      if (
+        !isTerminalTab ||
+        !isActive ||
+        tab.connectionStatus !== 'disconnected' ||
+        event.repeat ||
+        event.nativeEvent.isComposing ||
+        event.keyCode === 229 ||
+        event.ctrlKey ||
+        event.altKey ||
+        event.metaKey ||
+        event.key.toLowerCase() !== 'r'
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      event.stopPropagation();
+      handleReconnect();
+    },
+    [handleReconnect, isActive, tab.connectionStatus, tab.tabType],
+  );
+
   const handleConnectionStatusChange = useCallback(
     (
       connectionId: string,
@@ -142,6 +167,7 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
       className="h-full w-full"
       onMouseDownCapture={handleActivateGroup}
       onFocusCapture={handleActivateGroup}
+      onKeyDown={handleReconnectKeyDown}
     >
       {content}
     </div>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -968,6 +968,9 @@
     "copiedToClipboard": "Copied to clipboard",
     "failedToCopyClipboard": "Failed to copy to clipboard",
     "reconnectingTerminal": "Reconnecting terminal…",
+    "connectionClosedManualReconnect": "Connection closed. Press R to reconnect, or use right-click → Reconnect.",
+    "autoReconnectFailed": "Connection lost. Auto-reconnect failed after {{count}} attempts. Press R to reconnect, or use right-click → Reconnect.",
+    "connectionFailedPermanently": "Connection failed permanently. Press R to reconnect, or use right-click → Reconnect.",
     "outputSaved": "Terminal output saved",
     "failedToSaveOutput": "Failed to save output"
   },

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -968,6 +968,9 @@
     "copiedToClipboard": "已复制到剪贴板",
     "failedToCopyClipboard": "复制到剪贴板失败",
     "reconnectingTerminal": "正在重新连接终端…",
+    "connectionClosedManualReconnect": "连接已关闭。按 R 重连，或右键选择“重新连接”。",
+    "autoReconnectFailed": "连接已断开，自动重连 {{count}} 次后仍然失败。按 R 重连，或右键选择“重新连接”。",
+    "connectionFailedPermanently": "连接永久失败。按 R 重连，或右键选择“重新连接”。",
     "outputSaved": "终端输出已保存",
     "failedToSaveOutput": "保存输出失败"
   },


### PR DESCRIPTION
## Summary
- allow `R` / `r` to reconnect only the active disconnected terminal
- keep connected terminal input unchanged and ignore modified, repeated, or IME key events
- honor the existing Auto Reconnect setting when a PTY connection closes
- show localized manual reconnect guidance after automatic reconnect is disabled or exhausted

## Verification
- `pnpm test src/__tests__/pty-terminal-activation.test.tsx src/__tests__/terminal-tab-portals.test.tsx src/__tests__/keyboard-shortcuts-hook.test.tsx src/__tests__/keyboard-shortcuts.test.ts` (40 passed)
- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/components/pty-terminal.tsx src/components/terminal/terminal-tab-portals.tsx --quiet`
- `pnpm i18n:check`
- `pnpm build`

Full `pnpm test`: 476 passed; the 7 existing `src/__tests__/connection.test.ts` cases still require a Tauri runtime and fail in plain Vitest because `window.__TAURI_INTERNALS__.invoke` is unavailable.

Closes #12