### PR TITLE
fix(terminal): wire Edit menu to active terminal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,6 +34,7 @@ import { ErrorBoundary } from './components/error-boundary';
 import type { TerminalTab } from './lib/terminal-group-types';
 import { Toaster } from './components/ui/sonner';
 import { toast } from 'sonner';
+import { dispatchTerminalCommand, type TerminalCommand } from './lib/terminal-commands';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -123,6 +124,18 @@ function AppContent() {
     () => new Set(allTabs.map(tab => tab.id)),
     [allTabs],
   );
+
+  const activeTerminalId = activeTab
+    && (activeTab.tabType === undefined || activeTab.tabType === 'terminal')
+    && activeTab.connectionStatus !== 'pending'
+    ? activeTab.id
+    : null;
+
+  const runActiveTerminalCommand = useCallback((command: TerminalCommand) => {
+    if (activeTerminalId) {
+      dispatchTerminalCommand(activeTerminalId, command);
+    }
+  }, [activeTerminalId]);
 
   // Apply stored language preference (follows OS locale when set to "auto")
   useEffect(() => {
@@ -1202,6 +1215,12 @@ function AppContent() {
         case 'clone_tab':
           if (activeTab) { handleDuplicateTab(activeTab.id); }
           break;
+        case 'find':
+          runActiveTerminalCommand('find');
+          break;
+        case 'clear_screen':
+          runActiveTerminalCommand('clear-screen');
+          break;
         case 'next_tab':
           if (activeGroup && activeGroup.tabs.length > 1 && activeGroup.activeTabId) {
             const idx = activeGroup.tabs.findIndex(t => t.id === activeGroup.activeTabId);
@@ -1227,7 +1246,7 @@ function AppContent() {
       }
     });
     return () => { unlistenPromise.then(fn => fn()); };
-  }, [activeGroup, activeTab, handleNewTab, handleOpenSettings, handleDuplicateTab, handleCloseActiveTab, dispatch]);
+  }, [activeGroup, activeTab, handleNewTab, handleOpenSettings, handleDuplicateTab, handleCloseActiveTab, runActiveTerminalCommand, dispatch]);
 
   const handleEditConnection = useCallback((connection: ConnectionNode) => {
     if (connection.type === 'connection') {
@@ -1633,13 +1652,21 @@ function AppContent() {
             void handleDuplicateTab(activeTab.id);
           }
         }}
+        onCopy={() => runActiveTerminalCommand('copy')}
+        onPaste={() => runActiveTerminalCommand('paste')}
+        onSelectAll={() => runActiveTerminalCommand('select-all')}
+        onFind={() => runActiveTerminalCommand('find')}
+        onFindNext={() => runActiveTerminalCommand('find-next')}
+        onFindPrevious={() => runActiveTerminalCommand('find-previous')}
+        onClearScreen={() => runActiveTerminalCommand('clear-screen')}
         onOpenSettings={handleOpenSettings}
         onCheckForUpdates={() => setUpdateCheckSignal((current) => current + 1)}
         closeConnectionShortcutLabel={keyboardShortcutSettings.closeTab}
         nextTabShortcutLabel={keyboardShortcutSettings.nextTab}
         previousTabShortcutLabel={keyboardShortcutSettings.prevTab}
         hasActiveConnection={!!activeTab}
-        canPaste={true}
+        hasActiveTerminal={activeTerminalId !== null}
+        canPaste={activeTab?.connectionStatus === 'connected'}
         onToggleLeftSidebar={toggleLeftSidebar}
         onToggleRightSidebar={toggleRightSidebar}
         onToggleBottomPanel={toggleBottomPanel}

--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -195,6 +195,11 @@ describe('IntegratedFileBrowser terminal directory following', () => {
         path: '/home',
       });
     });
+    // Wait for the Home navigation to fully commit (breadcrumb renders '/home')
+    // before bumping the terminal sequence. Otherwise the follow effect can still
+    // see committedPathRef === '/srv/app' and skip reloading, making this test
+    // order-dependent on async timing.
+    await screen.findByTitle('/home');
 
     rerender(
       <IntegratedFileBrowser

--- a/src/__tests__/menu-bar-terminal-commands.test.tsx
+++ b/src/__tests__/menu-bar-terminal-commands.test.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MenuBar } from '../components/menu-bar';
+
+function openEditMenu() {
+  fireEvent.pointerDown(screen.getByRole('button', { name: 'Edit' }), {
+    button: 0,
+    ctrlKey: false,
+  });
+}
+
+describe('MenuBar terminal commands', () => {
+  const originalPlatform = navigator.platform;
+
+  beforeEach(() => {
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: 'Win32',
+    });
+  });
+
+  afterEach(() => {
+    cleanup();
+    Object.defineProperty(navigator, 'platform', {
+      configurable: true,
+      value: originalPlatform,
+    });
+  });
+
+  it('disables terminal actions that have no implementation callback', () => {
+    render(<MenuBar hasActiveConnection />);
+
+    openEditMenu();
+
+    expect(screen.getByRole('menuitem', { name: /^Copy/ }).hasAttribute('data-disabled')).toBe(true);
+    expect(screen.getByRole('menuitem', { name: /^Cut/ }).hasAttribute('data-disabled')).toBe(true);
+    expect(screen.getByRole('menuitem', { name: /^Find\.\.\./ }).hasAttribute('data-disabled')).toBe(true);
+  });
+
+  it('invokes every implemented terminal action', () => {
+    const actions = [
+      { name: /^Copy/, callback: vi.fn(), prop: 'onCopy' },
+      { name: /^Paste/, callback: vi.fn(), prop: 'onPaste' },
+      { name: /^Select All/, callback: vi.fn(), prop: 'onSelectAll' },
+      { name: /^Find\.\.\./, callback: vi.fn(), prop: 'onFind' },
+      { name: /^Find Next/, callback: vi.fn(), prop: 'onFindNext' },
+      { name: /^Find Previous/, callback: vi.fn(), prop: 'onFindPrevious' },
+      { name: /^Clear Screen/, callback: vi.fn(), prop: 'onClearScreen' },
+    ] as const;
+    const props = Object.fromEntries(actions.map(({ prop, callback }) => [prop, callback]));
+
+    render(<MenuBar hasActiveConnection hasActiveTerminal {...props} />);
+
+    for (const { name, callback } of actions) {
+      openEditMenu();
+      fireEvent.click(screen.getByRole('menuitem', { name }));
+      expect(callback).toHaveBeenCalledOnce();
+    }
+
+    openEditMenu();
+    expect(screen.getByRole('menuitem', { name: /^Cut/ }).hasAttribute('data-disabled')).toBe(true);
+  });
+
+  it('disables terminal actions for non-terminal tabs', () => {
+    render(<MenuBar hasActiveConnection hasActiveTerminal={false} onFind={vi.fn()} />);
+
+    openEditMenu();
+
+    expect(screen.getByRole('menuitem', { name: /^Find\.\.\./ }).hasAttribute('data-disabled')).toBe(true);
+  });
+});

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -1,11 +1,14 @@
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { act, cleanup, render } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import { PtyTerminal } from '../components/pty-terminal';
+import { MenuBar } from '../components/menu-bar';
+import { dispatchTerminalCommand } from '../lib/terminal-commands';
 
 const mocks = vi.hoisted(() => {
   const terminals: Array<any> = [];
   const fitAddons: Array<any> = [];
+  const searchAddons: Array<any> = [];
   const webSockets: Array<any> = [];
   const terminalCallbacks = {
     onWorkingDirectoryChange: vi.fn(),
@@ -80,7 +83,7 @@ const mocks = vi.hoisted(() => {
     return terminal;
   });
 
-  return { terminals, fitAddons, webSockets, terminalCallbacks, Terminal, MockFitAddon, MockWebSocket };
+  return { terminals, fitAddons, searchAddons, webSockets, terminalCallbacks, Terminal, MockFitAddon, MockWebSocket };
 });
 
 vi.mock('@xterm/xterm', () => ({
@@ -105,10 +108,12 @@ vi.mock('@xterm/addon-webgl', () => ({
 
 vi.mock('@xterm/addon-search', () => ({
   SearchAddon: vi.fn(function SearchAddon() {
-    return {
+    const addon = {
       findNext: vi.fn(),
       findPrevious: vi.fn(),
     };
+    mocks.searchAddons.push(addon);
+    return addon;
   }),
 }));
 
@@ -154,7 +159,20 @@ vi.mock('../components/terminal/terminal-context-menu', () => ({
 }));
 
 vi.mock('../components/terminal/terminal-search-bar', () => ({
-  TerminalSearchBar: () => null,
+  TerminalSearchBar: ({
+    visible,
+    onSearchStateChange,
+  }: {
+    visible: boolean;
+    onSearchStateChange?: (state: { query: string; caseSensitive: boolean; regex: boolean }) => void;
+  }) => {
+    React.useEffect(() => {
+      if (visible) {
+        onSearchStateChange?.({ query: 'needle', caseSensitive: true, regex: false });
+      }
+    }, [onSearchStateChange, visible]);
+    return visible ? <div data-testid="terminal-search-bar" /> : null;
+  },
 }));
 
 vi.mock('../lib/restoration-manager', () => ({
@@ -210,6 +228,7 @@ describe('PtyTerminal activation', () => {
     vi.clearAllMocks();
     mocks.terminals.length = 0;
     mocks.fitAddons.length = 0;
+    mocks.searchAddons.length = 0;
     mocks.webSockets.length = 0;
     mocks.terminalCallbacks.onWorkingDirectoryChange.mockClear();
 
@@ -309,6 +328,47 @@ describe('PtyTerminal activation', () => {
     expect(mocks.terminals).toHaveLength(terminalCount);
     expect(mocks.webSockets).toHaveLength(webSocketCount);
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
+  it('routes Edit menu commands only to the addressed active terminal', () => {
+    render(
+      <>
+        <div data-testid="terminal-one">
+          <PtyTerminal connectionId="connection-1" connectionName="Server 1" isActive={false} />
+        </div>
+        <div data-testid="terminal-two">
+          <PtyTerminal connectionId="connection-2" connectionName="Server 2" isActive />
+        </div>
+        <MenuBar
+          hasActiveConnection
+          hasActiveTerminal
+          onSelectAll={() => dispatchTerminalCommand('connection-2', 'select-all')}
+          onFind={() => dispatchTerminalCommand('connection-2', 'find')}
+          onFindNext={() => dispatchTerminalCommand('connection-2', 'find-next')}
+        />
+      </>,
+    );
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Edit' }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Select All/ }));
+
+    expect(mocks.terminals[0].selectAll).not.toHaveBeenCalled();
+    expect(mocks.terminals[1].selectAll).toHaveBeenCalledOnce();
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Edit' }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Find\.\.\./ }));
+
+    expect(within(screen.getByTestId('terminal-one')).queryByTestId('terminal-search-bar')).toBeNull();
+    expect(within(screen.getByTestId('terminal-two')).getByTestId('terminal-search-bar')).toBeTruthy();
+
+    fireEvent.pointerDown(screen.getByRole('button', { name: 'Edit' }), { button: 0, ctrlKey: false });
+    fireEvent.click(screen.getByRole('menuitem', { name: /^Find Next/ }));
+
+    expect(mocks.searchAddons[0].findNext).not.toHaveBeenCalled();
+    expect(mocks.searchAddons[1].findNext).toHaveBeenCalledWith('needle', {
+      caseSensitive: true,
+      regex: false,
+    });
   });
 
   it('lets xterm handle Ctrl+V paste without duplicate custom send', async () => {

--- a/src/components/menu-bar.tsx
+++ b/src/components/menu-bar.tsx
@@ -51,6 +51,9 @@ interface MenuBarProps {
   onPaste?: () => void;
   onSelectAll?: () => void;
   onFind?: () => void;
+  onFindNext?: () => void;
+  onFindPrevious?: () => void;
+  onClearScreen?: () => void;
   onToggleConnectionManager?: () => void;
   onToggleSystemMonitor?: () => void;
   onToggleFullscreen?: () => void;
@@ -66,6 +69,7 @@ interface MenuBarProps {
   previousTabShortcutLabel?: string;
   onRecentConnectionSelect?: (connection: ConnectionData) => void;
   hasActiveConnection?: boolean;
+  hasActiveTerminal?: boolean;
   canPaste?: boolean;
   // Layout controls (VS Code-style, right-aligned)
   onToggleLeftSidebar?: () => void;
@@ -88,6 +92,9 @@ export function MenuBar({
   onPaste,
   onSelectAll,
   onFind,
+  onFindNext,
+  onFindPrevious,
+  onClearScreen,
   onToggleConnectionManager: _onToggleConnectionManager,
   onToggleSystemMonitor: _onToggleSystemMonitor,
   onToggleFullscreen: _onToggleFullscreen,
@@ -103,6 +110,7 @@ export function MenuBar({
   previousTabShortcutLabel,
   onRecentConnectionSelect,
   hasActiveConnection = false,
+  hasActiveTerminal,
   canPaste = true,
   onToggleLeftSidebar,
   onToggleRightSidebar,
@@ -117,6 +125,7 @@ export function MenuBar({
   const { t } = useTranslation();
   const isMac = navigator.platform.toUpperCase().indexOf('MAC') >= 0;
   const formatShortcut = (shortcut: string) => formatKeyboardShortcut(shortcut, isMac);
+  const terminalActionsAvailable = hasActiveTerminal ?? hasActiveConnection;
 
   // Load recent connections
   const [recentConnections, setRecentConnections] = useState<ConnectionData[]>([]);
@@ -227,44 +236,44 @@ export function MenuBar({
           <Button variant="ghost" size="sm">{t('menuBar.edit')}</Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start">
-          <DropdownMenuItem onClick={onCopy} disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onCopy} disabled={!terminalActionsAvailable || !onCopy}>
             <Copy className="mr-2 h-4 w-4" />
             {t('menuBar.copy')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+C')}</DropdownMenuShortcut>
           </DropdownMenuItem>
-          <DropdownMenuItem onClick={onPaste} disabled={!hasActiveConnection || !canPaste}>
+          <DropdownMenuItem onClick={onPaste} disabled={!terminalActionsAvailable || !canPaste || !onPaste}>
             <Clipboard className="mr-2 h-4 w-4" />
             {t('menuBar.paste')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+V')}</DropdownMenuShortcut>
           </DropdownMenuItem>
-          <DropdownMenuItem disabled={!hasActiveConnection}>
+          <DropdownMenuItem disabled>
             <Scissors className="mr-2 h-4 w-4" />
             {t('menuBar.cut')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+X')}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={onSelectAll} disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onSelectAll} disabled={!terminalActionsAvailable || !onSelectAll}>
             {t('menuBar.selectAll')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+A')}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem onClick={onFind} disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onFind} disabled={!terminalActionsAvailable || !onFind}>
             <Search className="mr-2 h-4 w-4" />
             {t('menuBar.find')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+F')}</DropdownMenuShortcut>
           </DropdownMenuItem>
-          <DropdownMenuItem disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onFindNext} disabled={!terminalActionsAvailable || !onFindNext}>
             <Search className="mr-2 h-4 w-4" />
             {t('menuBar.findNext')}
             <DropdownMenuShortcut>F3</DropdownMenuShortcut>
           </DropdownMenuItem>
-          <DropdownMenuItem disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onFindPrevious} disabled={!terminalActionsAvailable || !onFindPrevious}>
             <Search className="mr-2 h-4 w-4" />
             {t('menuBar.findPrevious')}
             <DropdownMenuShortcut>{formatShortcut('Shift+F3')}</DropdownMenuShortcut>
           </DropdownMenuItem>
           <DropdownMenuSeparator />
-          <DropdownMenuItem disabled={!hasActiveConnection}>
+          <DropdownMenuItem onClick={onClearScreen} disabled={!terminalActionsAvailable || !onClearScreen}>
             <RefreshCw className="mr-2 h-4 w-4" />
             {t('menuBar.clearScreen')}
             <DropdownMenuShortcut>{formatShortcut('Ctrl+L')}</DropdownMenuShortcut>

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -10,11 +10,12 @@ import { invoke } from '@tauri-apps/api/core';
 import { readText as readClipboardText, writeText as writeClipboardText } from '@tauri-apps/plugin-clipboard-manager';
 import { loadAppearanceSettings, getThemeAwareTerminalOptions, getThemeAwareTerminalTheme, terminalThemes, defaultTerminalTheme } from '../lib/terminal-config';
 import { TerminalContextMenu } from './terminal/terminal-context-menu';
-import { TerminalSearchBar } from './terminal/terminal-search-bar';
+import { TerminalSearchBar, type TerminalSearchState } from './terminal/terminal-search-bar';
 import { toast } from 'sonner';
 import { signalReady } from '../lib/restoration-manager';
 import { useTerminalCallbacks } from '../lib/terminal-callbacks-context';
 import { registerTerminalWorkingDirectoryHandler } from '../lib/terminal-working-directory';
+import { TERMINAL_COMMAND_EVENT, type TerminalCommandDetail } from '../lib/terminal-commands';
 import '@xterm/xterm/css/xterm.css';
 
 interface PtyTerminalProps {
@@ -71,6 +72,7 @@ export function PtyTerminal({
   // Search bar state
   const [searchVisible, setSearchVisible] = React.useState(false);
   const [searchFocusTrigger, setSearchFocusTrigger] = React.useState(0);
+  const searchStateRef = React.useRef<TerminalSearchState>({ query: '', caseSensitive: false, regex: false });
   const [hasSelection, setHasSelection] = React.useState(false);
 
   // Scrollbar visibility — only show when buffer overflows the visible rows
@@ -290,12 +292,16 @@ export function PtyTerminal({
       if (event.key === 'F3') {
         event.preventDefault();
         const search = searchRef.current;
-        if (search) {
+        const { query, caseSensitive, regex } = searchStateRef.current;
+        if (search && query) {
           if (event.shiftKey) {
-            search.findPrevious('', { caseSensitive: false, regex: false });
+            search.findPrevious(query, { caseSensitive, regex });
           } else {
-            search.findNext('', { caseSensitive: false, regex: false });
+            search.findNext(query, { caseSensitive, regex });
           }
+        } else {
+          setSearchVisible(true);
+          setSearchFocusTrigger(prev => prev + 1);
         }
         return false;
       }
@@ -968,22 +974,51 @@ export function PtyTerminal({
 
   const handleFindNext = React.useCallback(() => {
     const search = searchRef.current;
-    if (search) {
-      // Search addon will use the last search query
-      search.findNext('', { caseSensitive: false, regex: false });
+    const { query, caseSensitive, regex } = searchStateRef.current;
+    if (search && query) {
+      search.findNext(query, { caseSensitive, regex });
+    } else {
+      handleSearch();
     }
-  }, []);
+  }, [handleSearch]);
 
   const handleFindPrevious = React.useCallback(() => {
     const search = searchRef.current;
-    if (search) {
-      search.findPrevious('', { caseSensitive: false, regex: false });
+    const { query, caseSensitive, regex } = searchStateRef.current;
+    if (search && query) {
+      search.findPrevious(query, { caseSensitive, regex });
+    } else {
+      handleSearch();
     }
-  }, []);
+  }, [handleSearch]);
 
   const handleSelectAll = React.useCallback(() => {
     xtermRef.current?.selectAll();
   }, []);
+
+  const handleSearchStateChange = React.useCallback((state: TerminalSearchState) => {
+    searchStateRef.current = state;
+  }, []);
+
+  React.useEffect(() => {
+    const handleTerminalCommand = (event: Event) => {
+      const { tabId, command } = (event as CustomEvent<TerminalCommandDetail>).detail;
+      if (tabId !== connectionId) return;
+
+      switch (command) {
+        case 'copy': handleCopy(); break;
+        case 'paste': void handlePaste(); break;
+        case 'select-all': handleSelectAll(); break;
+        case 'find': handleSearch(); break;
+        case 'find-next': handleFindNext(); break;
+        case 'find-previous': handleFindPrevious(); break;
+        case 'clear-screen': handleClear(); break;
+      }
+    };
+
+    window.addEventListener(TERMINAL_COMMAND_EVENT, handleTerminalCommand);
+    return () => window.removeEventListener(TERMINAL_COMMAND_EVENT, handleTerminalCommand);
+  }, [connectionId, handleClear, handleCopy, handleFindNext, handleFindPrevious, handlePaste, handleSearch, handleSelectAll]);
 
   const handleReconnect = React.useCallback(() => {
     if (onReconnectTab) {
@@ -1092,6 +1127,7 @@ export function PtyTerminal({
           visible={searchVisible}
           focusTrigger={searchFocusTrigger}
           onClose={() => setSearchVisible(false)}
+          onSearchStateChange={handleSearchStateChange}
         />
       )}
       

--- a/src/components/terminal/terminal-search-bar.tsx
+++ b/src/components/terminal/terminal-search-bar.tsx
@@ -11,9 +11,16 @@ interface TerminalSearchBarProps {
   visible: boolean;
   focusTrigger: number;
   onClose: () => void;
+  onSearchStateChange?: (state: TerminalSearchState) => void;
 }
 
-export function TerminalSearchBar({ searchAddon, visible, focusTrigger, onClose }: TerminalSearchBarProps) {
+export interface TerminalSearchState {
+  query: string;
+  caseSensitive: boolean;
+  regex: boolean;
+}
+
+export function TerminalSearchBar({ searchAddon, visible, focusTrigger, onClose, onSearchStateChange }: TerminalSearchBarProps) {
   const { t } = useTranslation();
   const [query, setQuery] = useState('');
   const [caseSensitive, setCaseSensitive] = useState(false);
@@ -21,6 +28,10 @@ export function TerminalSearchBar({ searchAddon, visible, focusTrigger, onClose 
   const [_currentIndex, _setCurrentIndex] = useState(0);
   const [_totalMatches, _setTotalMatches] = useState(0);
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    onSearchStateChange?.({ query, caseSensitive, regex: useRegex });
+  }, [caseSensitive, onSearchStateChange, query, useRegex]);
 
   // Focus input when search bar becomes visible or when focus trigger changes
   useEffect(() => {

--- a/src/lib/terminal-commands.ts
+++ b/src/lib/terminal-commands.ts
@@ -1,0 +1,21 @@
+export const TERMINAL_COMMAND_EVENT = 'rshell-terminal-command';
+
+export type TerminalCommand =
+  | 'copy'
+  | 'paste'
+  | 'select-all'
+  | 'find'
+  | 'find-next'
+  | 'find-previous'
+  | 'clear-screen';
+
+export interface TerminalCommandDetail {
+  tabId: string;
+  command: TerminalCommand;
+}
+
+export function dispatchTerminalCommand(tabId: string, command: TerminalCommand): void {
+  window.dispatchEvent(new CustomEvent<TerminalCommandDetail>(TERMINAL_COMMAND_EVENT, {
+    detail: { tabId, command },
+  }));
+}


### PR DESCRIPTION
## Root cause

The web `MenuBar` exposed optional Edit callbacks, but `App.tsx` never supplied them. The terminal implementations therefore existed only inside each `PtyTerminal`, so menu clicks closed the menu without reaching the active split/tab. Find Next/Previous also discarded the search bar's current query.

## Fix

- Route Edit commands through a tab-id-scoped terminal event so only the active terminal responds.
- Wire Copy, Paste, Select All, Find, Find Next, Find Previous, and Clear Screen.
- Keep unsupported Cut disabled; disable terminal actions for non-terminal tabs and Paste while disconnected.
- Reuse the search bar's actual query/options for Find Next/Previous.
- Cover disabled states, every menu callback, split-view targeting, Find focus/display, and current-query navigation.

## Duplicate check

No duplicate issue or PR was found.

Related but distinct:
- #11 covers mouse/context-menu copy and paste and was addressed separately by commit `a0d1545`.
- #48 covers clipboard permission denial preventing later paste.

## Verification

- `pnpm test` — 36 files, 498 tests passed.
- `pnpm build` — passed.
- `pnpm exec tsc --noEmit` — passed.
- `pnpm i18n:check` — passed, 945 keys in both locales.
- Changed source files: `eslint --quiet` — passed.
- Full `pnpm lint` remains blocked by the existing unrelated `src/components/settings-modal.tsx:308` unnecessary assertion error.

Closes #56

## Notes for reviewers

- Second commit `fix(test): stabilize file-browser follow test` fixes a pre-existing flaky test (`integrated-file-browser-keyboard.test.tsx`) that intermittently failed ubuntu CI on this PR. Unrelated to the Edit-menu change; it waits for the Home navigation to commit before bumping the terminal sequence, removing an async race.