### PR TITLE
feat(sidebar): add New Connection entry to folder right-click menu

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -60,6 +60,7 @@ function AppContent() {
 
   // Modal states
   const [connectionDialogOpen, setConnectionDialogOpen] = useState(false);
+  const [connectionInitialFolder, setConnectionInitialFolder] = useState<string | undefined>();
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ConnectionConfig | null>(null);
   const [updateCheckSignal, setUpdateCheckSignal] = useState(0);
@@ -670,7 +671,8 @@ function AppContent() {
     }
   }, [state.groups, dispatch]);
 
-  const handleNewTab = useCallback(() => {
+  const handleNewTab = useCallback((folderPath?: string) => {
+    setConnectionInitialFolder(folderPath);
     setConnectionDialogOpen(true);
     setEditingConnection(null);
   }, []);
@@ -1699,9 +1701,13 @@ function AppContent() {
       {/* Modals */}
       <ConnectionDialog
         open={connectionDialogOpen}
-        onOpenChange={setConnectionDialogOpen}
+        onOpenChange={(open) => {
+          setConnectionDialogOpen(open);
+          if (!open) setConnectionInitialFolder(undefined);
+        }}
         onConnect={handleConnectionDialogConnect}
         editingConnection={editingConnection}
+        initialFolder={connectionInitialFolder}
       />
 
       <SettingsModal

--- a/src/__tests__/connection-dialog-folder.test.tsx
+++ b/src/__tests__/connection-dialog-folder.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * Tests for ConnectionDialog folder pre-selection via initialFolder prop:
+ * - Pre-select folder when initialFolder is provided (new connection from folder context menu)
+ * - Ignore initialFolder when editing an existing connection
+ * - Default to 'All Connections' when no initialFolder is set
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { ConnectionDialog } from '../components/connection-dialog';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+const mockFolders = [
+  { path: 'All Connections' },
+  { path: 'Work' },
+  { path: 'Personal' },
+  { path: 'Work/ProjectA' },
+];
+
+vi.mock('../lib/connection-storage', () => ({
+  ConnectionStorageManager: {
+    getValidFolders: vi.fn(() => mockFolders),
+  },
+}));
+
+vi.mock('../lib/connection-profiles', () => ({
+  ConnectionProfileManager: {
+    getProfiles: vi.fn(() => []),
+  },
+}));
+
+const defaultConnection = {
+  name: 'My Server',
+  host: '192.168.1.1',
+  port: 22,
+  username: 'admin',
+  protocol: 'SSH' as const,
+  authMethod: 'password' as const,
+  folder: 'Personal',
+  id: 'conn-1',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+/**
+ * Helper: get the folder select trigger (second combobox - first is protocol).
+ * The dialog has two <Select>s: protocol (SSH/Telnet/...) and folder.
+ * We use getAllByRole('combobox') and take the second one.
+ */
+function getFolderSelect() {
+  const combos = screen.getAllByRole('combobox');
+  // combos[0] = protocol select (shows "SSH"), combos[1] = folder select
+  return combos[1];
+}
+
+describe('ConnectionDialog folder pre-selection', () => {
+  function renderDialog(props: Partial<React.ComponentProps<typeof ConnectionDialog>> = {}) {
+    return render(
+      <ConnectionDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        onConnect={vi.fn()}
+        editingConnection={null}
+        {...props}
+      />,
+    );
+  }
+
+  it('pre-selects the folder when initialFolder is provided', () => {
+    renderDialog({ initialFolder: 'Work' });
+
+    const folderSelect = getFolderSelect();
+    expect(folderSelect.textContent).toContain('Work');
+  });
+
+  it('defaults to "All Connections" when no initialFolder is set', () => {
+    renderDialog({ initialFolder: undefined });
+
+    const folderSelect = getFolderSelect();
+    expect(folderSelect.textContent).toContain('All Connections');
+  });
+
+  it('hides the folder select when editing (initialFolder is ignored gracefully)', () => {
+    renderDialog({
+      initialFolder: 'Work',
+      editingConnection: { ...defaultConnection, folder: 'Personal' },
+    });
+
+    // When editing, saveAsConnection is false, so the folder select is not rendered.
+    // Only the protocol select (combobox) should exist.
+    const combos = screen.getAllByRole('combobox');
+    expect(combos).toHaveLength(1);
+    expect(combos[0].textContent).toContain('SSH');
+  });
+
+  it('uses folder from initialFolder over default "All Connections"', () => {
+    renderDialog({ initialFolder: 'Work/ProjectA' });
+
+    const folderSelect = getFolderSelect();
+    expect(folderSelect.textContent).toContain('Work/ProjectA');
+  });
+});

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -30,6 +30,7 @@ interface ConnectionDialogProps {
   onOpenChange: (open: boolean) => void;
   onConnect: (config: ConnectionConfig) => void;
   editingConnection?: ConnectionConfig | null;
+  initialFolder?: string;
 }
 
 export interface ConnectionConfig {
@@ -72,7 +73,8 @@ export function ConnectionDialog({
   open,
   onOpenChange,
   onConnect,
-  editingConnection
+  editingConnection,
+  initialFolder
 }: ConnectionDialogProps) {
   const defaultConfig: ConnectionConfig = {
     name: '',
@@ -121,6 +123,11 @@ export function ConnectionDialog({
       const folderPaths = folders.map(f => f.path).sort();
       setAvailableFolders(folderPaths);
 
+      // Pre-select folder when initialFolder is provided (new connection from folder context menu)
+      if (initialFolder && !editingConnection) {
+        setConnectionFolder(initialFolder);
+      }
+
       // Load editing connection data into config when dialog opens
       if (editingConnection) {
         setConfig({
@@ -138,7 +145,7 @@ export function ConnectionDialog({
       // Reset connection state when dialog closes
       resetConnectionState();
     }
-  }, [open, editingConnection]);
+  }, [open, editingConnection, initialFolder]);
 
   const _handleSaveProfile = () => {
     try {

--- a/src/components/connection-manager.tsx
+++ b/src/components/connection-manager.tsx
@@ -64,7 +64,7 @@ interface ConnectionManagerProps {
   onConnectionConnect?: (connection: ConnectionNode) => void;
   selectedConnectionId: string | null;
   activeConnections?: Set<string>;
-  onNewConnection?: () => void;
+  onNewConnection?: (folderPath?: string) => void;
   onEditConnection?: (connection: ConnectionNode) => void;
   onDeleteConnection?: (connectionId: string) => void;
   onDuplicateConnection?: (connection: ConnectionNode) => void;
@@ -734,6 +734,13 @@ export function ConnectionManager({
             </ContextMenuTrigger>
             <ContextMenuContent>
               <ContextMenuItem
+                onClick={() => onNewConnection?.(node.path)}
+              >
+                <Plus className="w-4 h-4 mr-2" />
+                {t('connectionManager.newConnection')}
+              </ContextMenuItem>
+              <ContextMenuSeparator />
+              <ContextMenuItem
                 onClick={() => openNewFolderDialog(node.path)}
               >
                 <FolderPlus className="w-4 h-4 mr-2" />
@@ -847,7 +854,7 @@ export function ConnectionManager({
                 <Button
                   variant="ghost"
                   size="sm"
-                  onClick={onNewConnection}
+                  onClick={() => onNewConnection?.()}
                   className="h-6 w-6 p-0"
                 >
                   <Plus className="w-3.5 h-3.5" />
@@ -866,7 +873,7 @@ export function ConnectionManager({
             <div className="flex flex-col items-center justify-center h-full p-4 text-center">
               <p className="text-sm text-muted-foreground mb-4">{t('connectionManager.noConnectionsYet')}</p>
               {onNewConnection && (
-                <Button onClick={onNewConnection} size="sm" variant="outline">
+                <Button onClick={() => onNewConnection?.()} size="sm" variant="outline">
                   <Plus className="w-4 h-4 mr-2" />
                   {t('connectionManager.newConnection')}
                 </Button>


### PR DESCRIPTION
Add a "New Connection" item to the folder right-click context menu in the sidebar. Clicking it opens the connection dialog with that folder pre-selected.

### Changes

- **connection-manager.tsx**: Change `onNewConnection` signature from `() => void` to `(folderPath?: string) => void` (backward-compatible). Add "New Connection" context menu item (with separator) before "New Subfolder" in folder right-click menu. Wrap two `onNewConnection` direct pass-throughs in arrow functions for type compatibility.
- **App.tsx**: Add `connectionInitialFolder` state. Update `handleNewTab` to accept optional `folderPath`. Pass `initialFolder` to `ConnectionDialog` and clear it on dialog close.
- **connection-dialog.tsx**: Add `initialFolder` prop to `ConnectionDialogProps`. Pre-select the folder in `useEffect` when `initialFolder` is provided and not in editing mode.

### Tests

- Add `connection-dialog-folder.test.tsx` (4 tests): folder pre-selection, default fallback, editing mode handling, initialFolder switching