### PR TITLE
fix(connection-dialog): prevent number input default value override on clear

### DIFF
--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -97,6 +97,39 @@ export function ConnectionDialog({
 
   const [config, setConfig] = useState<ConnectionConfig>(defaultConfig);
 
+  // Track number input display values separately from config to allow
+  // the field to be empty while editing — React controlled inputs need
+  // value="" to render empty, but ConnectionConfig uses strict number types.
+  const initialDisplayValues = {
+    port: 22 as number | '',
+    proxyPort: 8080 as number | '',
+    keepAliveInterval: 60 as number | '',
+    serverAliveCountMax: 3 as number | '',
+  };
+  const [displayValues, setDisplayValues] = useState(initialDisplayValues);
+
+  /** Handle onChange for a controlled number input that must allow empty. */
+  const handleNumberInput = (
+    field: keyof typeof initialDisplayValues,
+    rawValue: string,
+    onValid: (n: number) => void,
+  ) => {
+    if (rawValue === '') {
+      setDisplayValues(prev => ({ ...prev, [field]: '' }));
+      return;
+    }
+    const parsed = parseInt(rawValue, 10);
+    if (!Number.isNaN(parsed)) {
+      setDisplayValues(prev => ({ ...prev, [field]: parsed }));
+      onValid(parsed);
+    }
+  };
+
+  /** Sync display values when the form re-opens with new data. */
+  const syncDisplayValues = (config_: typeof initialDisplayValues) => {
+    setDisplayValues(config_);
+  };
+
   const [isConnecting, setIsConnecting] = useState(false);
   const [isCancelling, setIsCancelling] = useState(false);
   const [_savedProfiles, setSavedProfiles] = useState<ConnectionProfile[]>([]);
@@ -127,12 +160,19 @@ export function ConnectionDialog({
           ...defaultConfig,
           ...editingConnection
         });
+        syncDisplayValues({
+          port: editingConnection.port ?? 22,
+          proxyPort: editingConnection.proxyPort ?? 8080,
+          keepAliveInterval: editingConnection.keepAliveInterval ?? 60,
+          serverAliveCountMax: editingConnection.serverAliveCountMax ?? 3,
+        });
         // When editing, don't show "save as connection" since it already exists
         setSaveAsConnection(false);
       } else {
         // Reset to defaults for new connection
         setConfig(defaultConfig);
         setSaveAsConnection(true);
+        syncDisplayValues(initialDisplayValues);
       }
     } else {
       // Reset connection state when dialog closes
@@ -513,12 +553,14 @@ export function ConnectionDialog({
                       onValueChange={(value: ConnectionConfig['protocol']) => {
                         const validAuthMethods = getAuthMethods(value);
                         const currentAuthValid = validAuthMethods.includes(config.authMethod);
+                        const defaultPort = getDefaultPort(value);
                         updateConfig({
                           protocol: value,
-                          port: getDefaultPort(value),
+                          port: defaultPort,
                           ...(!currentAuthValid && { authMethod: validAuthMethods[0] }),
                           ...(value !== 'FTP' && { ftpsEnabled: undefined }),
                         });
+                        setDisplayValues(prev => ({ ...prev, port: defaultPort }));
                       }}
                     >
                       <SelectTrigger>
@@ -553,8 +595,8 @@ export function ConnectionDialog({
                     <Input
                       id="port"
                       type="number"
-                      value={config.port}
-                      onChange={(e) => updateConfig({ port: parseInt(e.target.value) || 22 })}
+                      value={displayValues.port}
+                      onChange={(e) => handleNumberInput('port', e.target.value, (n) => updateConfig({ port: n }))}
                     />
                   </div>
                 </div>
@@ -808,8 +850,8 @@ export function ConnectionDialog({
                         <Input
                           id="proxy-port"
                           type="number"
-                          value={config.proxyPort}
-                          onChange={(e) => updateConfig({ proxyPort: parseInt(e.target.value) || 8080 })}
+                          value={displayValues.proxyPort}
+                          onChange={(e) => handleNumberInput('proxyPort', e.target.value, (n) => updateConfig({ proxyPort: n }))}
                         />
                       </div>
                     </div>
@@ -915,8 +957,8 @@ export function ConnectionDialog({
                                 <Input
                                   id="keep-alive-interval"
                                   type="number"
-                                  value={config.keepAliveInterval}
-                                  onChange={(e) => updateConfig({ keepAliveInterval: parseInt(e.target.value) || 60 })}
+                                  value={displayValues.keepAliveInterval}
+                                  onChange={(e) => handleNumberInput('keepAliveInterval', e.target.value, (n) => updateConfig({ keepAliveInterval: n }))}
                                 />
                               </div>
                               <div className="space-y-2">
@@ -924,8 +966,8 @@ export function ConnectionDialog({
                                 <Input
                                   id="max-count"
                                   type="number"
-                                  value={config.serverAliveCountMax}
-                                  onChange={(e) => updateConfig({ serverAliveCountMax: parseInt(e.target.value) || 3 })}
+                                  value={displayValues.serverAliveCountMax}
+                                  onChange={(e) => handleNumberInput('serverAliveCountMax', e.target.value, (n) => updateConfig({ serverAliveCountMax: n }))}
                                 />
                               </div>
                             </div>


### PR DESCRIPTION
## Summary

When clearing a number input field in the connection dialog (port, proxy port, etc.), the value immediately snaps back to its default (22, 8080, etc.) instead of allowing the user to type a new value.

## Root Cause

In  handlers using the pattern `parseInt(e.target.value) || 22`, clearing the field produces `NaN || 22 = 22`, which `updateConfig()` immediately writes back — React controlled input then renders `22`.

## Changes

- **src/components/connection-dialog.tsx** — Added a unified `displayValues` state object (`number | ''`) that tracks what each number input should visually display, separate from `ConnectionConfig`'s strict `number` type. Introduced a generic `handleNumberInput()` helper to handle all 4 affected inputs (port, proxyPort, keepAliveInterval, serverAliveCountMax) with the same logic.

## Testing

- 494 tests pass, 0 new failures
- Manually verified in real app: clearing port now stays empty, typing a valid number works, protocol switching resets port to default