### PR TITLE
fix: keep PTY output flow control bounded

### DIFF
--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -222,6 +222,41 @@ async function flushPromises() {
   });
 }
 
+async function mountTerminalWithPty() {
+  renderTerminal(true);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60);
+  });
+
+  const webSocket = mocks.webSockets[0];
+  expect(webSocket?.onmessage).toBeTypeOf('function');
+  webSocket.onmessage({
+    data: JSON.stringify({
+      type: 'PtyStarted',
+      connection_id: 'connection-1',
+      generation: 1,
+    }),
+  } as MessageEvent);
+  return webSocket;
+}
+
+function sendOutputFrame(webSocket: any, payload: Uint8Array) {
+  const connectionId = new TextEncoder().encode('connection-1');
+  const frame = new Uint8Array(3 + connectionId.length + payload.length);
+  frame[0] = 0x01;
+  frame[1] = connectionId.length >> 8;
+  frame[2] = connectionId.length & 0xff;
+  frame.set(connectionId, 3);
+  frame.set(payload, 3 + connectionId.length);
+  webSocket.onmessage({ data: frame.buffer } as MessageEvent);
+}
+
+function sentMessagesOfType(webSocket: any, type: string) {
+  return webSocket.send.mock.calls
+    .map(([data]: [string]) => JSON.parse(data))
+    .filter((message: { type: string }) => message.type === type);
+}
+
 describe('PtyTerminal activation', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -369,6 +404,77 @@ describe('PtyTerminal activation', () => {
       caseSensitive: true,
       regex: false,
     });
+  });
+
+  it('returns exactly one credit after xterm processes one output frame', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    let writeComplete: (() => void) | undefined;
+    terminal.write.mockImplementation((_data: string, callback?: () => void) => {
+      writeComplete = callback;
+    });
+
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(2);
+
+    sendOutputFrame(webSocket, new TextEncoder().encode('output'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(2);
+    writeComplete?.();
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(3);
+  });
+
+  it('returns one credit per output frame batched into the same xterm write', async () => {
+    const webSocket = await mountTerminalWithPty();
+
+    sendOutputFrame(webSocket, new TextEncoder().encode('one'));
+    sendOutputFrame(webSocket, new TextEncoder().encode('two'));
+    sendOutputFrame(webSocket, new TextEncoder().encode('three'));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(5);
+  });
+
+  it('returns credits for UTF-8 output split across frames', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.write.mockClear();
+    const encoded = new TextEncoder().encode('中');
+
+    sendOutputFrame(webSocket, encoded.subarray(0, 1));
+    sendOutputFrame(webSocket, encoded.subarray(1));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+
+    expect(terminal.write).toHaveBeenCalledWith('中', expect.any(Function));
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(4);
+  });
+
+  it('relies on bounded scrollback without resetting after 2 MiB of output', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.clear.mockClear();
+    terminal.reset.mockClear();
+    terminal.write.mockClear();
+    const payload = new Uint8Array(16 * 1024).fill(0x61);
+
+    for (let batch = 0; batch < 65; batch++) {
+      sendOutputFrame(webSocket, payload);
+      sendOutputFrame(webSocket, payload);
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(0);
+      });
+    }
+
+    expect(terminal.write).toHaveBeenCalled();
+    expect(terminal.reset).not.toHaveBeenCalled();
+    expect(terminal.clear).not.toHaveBeenCalled();
+    expect(sentMessagesOfType(webSocket, 'Resume')).toHaveLength(132);
   });
 
   it('lets xterm handle Ctrl+V paste without duplicate custom send', async () => {

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -38,13 +38,6 @@ interface PtyTerminalProps {
  * Communication is done via WebSocket for low-latency bidirectional streaming.
  */
 
-/** Per-session output cap. When cumulative bytes written to xterm exceed this
- *  value the scrollback is cleared automatically so V8 heap stays bounded.
- *  2 MB of decoded text ≈ ~25k typical 80-char terminal lines. Kept low to
- *  prevent V8 heap fragmentation and WebGL texture-cache bloat during
- *  sustained high-throughput output (e.g. `yes`). */
-const SESSION_OUTPUT_LIMIT_BYTES = 2 * 1024 * 1024;
-
 export function PtyTerminal({
   connectionId,
   connectionName,
@@ -100,8 +93,6 @@ export function PtyTerminal({
   const autoReconnectAfterDropRef = React.useRef(0);
   const MAX_AUTO_RECONNECT_AFTER_DROP = 5;
 
-  // Cumulative bytes written to xterm this session — reset on clear.
-  const sessionOutputRef = React.useRef(0);
   const inputEncoderRef = React.useRef(new TextEncoder());
 
   const sendInputToPty = React.useCallback((data: string): boolean => {
@@ -379,9 +370,8 @@ export function PtyTerminal({
 
     // RAF write batching state — lifted to effect scope so cleanup can cancel.
     let writeBuffer = '';
-    let watermark = 0;
+    let bufferedFrameCount = 0;
     let rafId: number | null = null;
-    let creditsGranted = 0;
     
     // CRITICAL: Wait for terminal to have proper dimensions before connecting
     // Hidden terminals (display: none) may have cols=10, rows=5 which breaks PTY
@@ -464,7 +454,7 @@ export function PtyTerminal({
       };
 
       // =========================================================================
-      // RAF-Based Write Batching + Watermark Flow Control
+      // RAF-Based Write Batching + Credit Flow Control
       //
       // Based on xterm.js best practices:
       // - http://xtermjs.org/docs/guides/flowcontrol/
@@ -478,21 +468,8 @@ export function PtyTerminal({
       // Solution:
       // 1. Accumulate all incoming frames in a string buffer.
       // 2. Flush once per requestAnimationFrame (~60 writes/s instead of 100+).
-      // 3. Use watermark-based flow control: send Resume credits only when the
-      //    pending byte count drops below LOW_WATER, avoiding per-frame ACKs.
+      // 3. Return exactly one credit per frame after xterm processes the batch.
       // =========================================================================
-
-      /** High watermark (bytes): above this, the buffer is considered "full" and
-       *  we stop granting credits until xterm drains below LOW_WATER.  128 KB
-       *  keeps the emulator snappy for keystrokes under fast input (xterm guide
-       *  recommends ≤ 500 KB for responsiveness). */
-      const HIGH_WATER = 128 * 1024;
-      /** Low watermark (bytes): below this, we grant a batch of credits to the
-       *  backend so it can send more data. */
-      const LOW_WATER = 16 * 1024;
-      /** How many credits to grant each time watermark drops below LOW_WATER.
-       *  Keeps the pipeline flowing without flooding the WS receive queue. */
-      const CREDIT_BATCH = 4;
 
       const grantCredits = (count: number) => {
         if (ws.readyState === WebSocket.OPEN) {
@@ -501,7 +478,6 @@ export function PtyTerminal({
           for (let i = 0; i < count; i++) {
             ws.send(msg);
           }
-          creditsGranted += count;
         }
       };
 
@@ -510,31 +486,14 @@ export function PtyTerminal({
         if (!writeBuffer) return;
 
         const data = writeBuffer;
+        const frameCount = bufferedFrameCount;
         writeBuffer = '';
-
-        // Enforce per-session memory cap so xterm's scrollback buffer can't
-        // grow without bound on sustained high-throughput output (e.g. `yes`).
-        sessionOutputRef.current += data.length;
-        if (sessionOutputRef.current >= SESSION_OUTPUT_LIMIT_BYTES) {
-          term.reset();
-          term.clear();
-          sessionOutputRef.current = 0;
-          term.writeln(`\x1b[33m${i18n.t('ptyTerminal.outputLimitReached')}\x1b[0m`);
-        }
+        bufferedFrameCount = 0;
 
         // Single write per animation frame — the key optimisation.
         // Reduces term.write() calls from hundreds/s to ~60/s.
         term.write(data, () => {
-          // xterm finished processing this batch — update watermark
-          watermark = Math.max(watermark - data.length, 0);
-
-          // Watermark-based flow control: grant credits only when the
-          // pending buffer has drained below LOW_WATER.  Skip granting
-          // if watermark is still above HIGH_WATER (buffer still full).
-          if (watermark < LOW_WATER && watermark < HIGH_WATER && creditsGranted < CREDIT_BATCH * 2) {
-            grantCredits(CREDIT_BATCH);
-            creditsGranted = 0; // reset counter after granting
-          }
+          grantCredits(frameCount);
         });
 
         // If more data arrived during the write, schedule another flush
@@ -544,8 +503,15 @@ export function PtyTerminal({
       };
 
       const enqueueOutput = (text: string) => {
+        // A streaming decoder can retain an incomplete UTF-8 sequence without
+        // producing text. It has already consumed the frame, so return that
+        // credit immediately to avoid stalling on multi-frame characters.
+        if (!text) {
+          grantCredits(1);
+          return;
+        }
         writeBuffer += text;
-        watermark += text.length;
+        bufferedFrameCount += 1;
         if (rafId === null) {
           rafId = requestAnimationFrame(flushWriteBuffer);
         }
@@ -601,8 +567,7 @@ export function PtyTerminal({
                 signalReady(connectionId);
                 // Credit-based flow control: seed the pipeline with initial
                 // credits so the PTY reader can start sending immediately.
-                // Ongoing credits are managed by the watermark-based flow
-                // control in the flush callback above.
+                // Ongoing credits are returned by the flush callback above.
                 const INITIAL_WINDOW = 2;
                 grantCredits(INITIAL_WINDOW);
               }
@@ -824,7 +789,7 @@ export function PtyTerminal({
         rafId = null;
       }
       writeBuffer = '';
-      watermark = 0;
+      bufferedFrameCount = 0;
 
       // Close PTY connection via WebSocket — include generation so the
       // backend can ignore this close if a newer session already exists.

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1086,7 +1086,6 @@
     "renderer": "Renderer: {{renderer}}",
     "startingShell": "🚀 Starting interactive shell (WebSocket + PTY mode)...",
     "webSocketConnected": "✓ WebSocket connected",
-    "outputLimitReached": "[Output limit reached — scrollback cleared to free memory]",
     "previousSessionLost": "⚠ Previous session lost. New shell session started.",
     "ptyStarted": "✓ PTY connection started",
     "interactiveHint": "You can now use interactive commands: vim, less, more, top, etc.",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1086,7 +1086,6 @@
     "renderer": "渲染器：{{renderer}}",
     "startingShell": "🚀 正在启动交互式 Shell（WebSocket + PTY 模式）...",
     "webSocketConnected": "✓ WebSocket 已连接",
-    "outputLimitReached": "[已达到输出上限 — 已清空回滚缓冲以释放内存]",
     "previousSessionLost": "⚠ 上一个会话已丢失，已启动新的 Shell 会话。",
     "ptyStarted": "✓ PTY 连接已启动",
     "interactiveHint": "现在可以使用交互式命令：vim、less、more、top 等。",


### PR DESCRIPTION
## Summary

- return exactly one PTY output credit for each WebSocket frame after xterm processes its RAF batch
- immediately return credits for frames buffered by the streaming UTF-8 decoder without producing text
- remove the cumulative 2 MiB `reset()` / `clear()` path and rely on the existing bounded xterm scrollback
- add regression coverage for initial credits, single and batched frames, split UTF-8, sustained output, and tab activation

## Root cause

The backend consumes one semaphore permit per output frame, but the frontend replenished a fixed four permits after processing any low-water batch. `creditsGranted` was never decremented when frames arrived and was reset immediately after granting, so a low-rate stream could grow the backend credit window by roughly three permits per frame.

The separate 2 MiB guard counted all decoded output since the last clear, not retained terminal memory. Normal sustained output eventually called both `term.reset()` and `term.clear()` even though xterm scrollback is already bounded by its configured line limit.

After this change, the invariant is: available credits plus frames awaiting xterm completion remain equal to the initial window. An incomplete UTF-8 sequence retains only the decoder's pending bytes and returns that frame credit immediately, avoiding deadlock.

## Related work

- Fixes #60.
- #34 already bounds configurable xterm scrollback; this change relies on that existing mechanism.
- #26 / #27 addressed the downstream WebSocket queue and binary frames.
- #30 targets possible russh-side accumulation when downstream reading stalls. It is related but distinct and is intentionally not included here.

## Validation

Reproduced on current `main` (`547e1bb`) before the fix:

- one processed frame: 6 `Resume` messages instead of 3 total
- three batched frames: 6 instead of 5 total
- split UTF-8 across two frames: 6 instead of 4 total
- sustained output over 2 MiB: `term.reset()` called once

Passing after the fix:

- `pnpm test -- src/__tests__/pty-terminal-activation.test.tsx src/__tests__/terminal-scrollback.test.ts src/__tests__/terminal-tab-portals.test.tsx` - 14 passed
- `pnpm test` - 569 passed
- `pnpm exec tsc --noEmit`
- `pnpm i18n:check` - 950 keys in both locales
- `pnpm build`
- `pnpm exec eslint src/components/pty-terminal.tsx --quiet`
- `git diff --check`

Repository-wide `pnpm lint` remains blocked by the pre-existing `src/components/settings-modal.tsx:308` `no-unnecessary-type-assertion` error; the changed source file passes strict lint. Local `cargo test` reached the unrelated `openssl-sys` build script and exceeded the 304-second validation limit; this PR changes no Rust files, and PR CI runs the Rust suite on Windows, macOS, and Ubuntu.

## Risk / rollback

The change reduces the maximum in-flight output to the existing two-frame window. If xterm stops completing writes, output backpressures instead of accumulating permits. Rollback is the single commit in this PR.