### PR TITLE
fix(edit-connection): improve tab sync, credential handling, and save flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -63,6 +63,11 @@ function AppContent() {
   const [connectionInitialFolder, setConnectionInitialFolder] = useState<string | undefined>();
   const [settingsModalOpen, setSettingsModalOpen] = useState(false);
   const [editingConnection, setEditingConnection] = useState<ConnectionConfig | null>(null);
+  // Track whether the edit dialog was opened due to a failed connection attempt (double-click)
+  // vs. direct edit (right-click). When non-null and matches saved config id, auto-connect after save.
+  const [pendingConnectionId, setPendingConnectionId] = useState<string | null>(null);
+  // Incremented after any save/connect dialog close to trigger sidebar refresh
+  const [connectionSaveTrigger, setConnectionSaveTrigger] = useState(0);
   const [updateCheckSignal, setUpdateCheckSignal] = useState(0);
   const [keyboardShortcutSettings, setKeyboardShortcutSettings] = useState<SplitViewShortcutBindings>(
     () => loadKeyboardShortcutSettings(),
@@ -482,12 +487,9 @@ function AppContent() {
     if (connection.type === 'connection') {
       setSelectedConnection(connection);
 
-      // Check if this connection already has a session in ANY group (including active).
-      // If so, we need a unique session ID to avoid sharing the same backend connection.
-      const existsAnywhere = allTabs.some(
-        tab => tab.id === connection.id || tab.originalConnectionId === connection.id
-      );
-
+      // Always use a unique session ID (see sessionId below) to prevent the backend
+      // from reusing a stale session from a previously closed tab that was never
+      // disconnected. This guarantees a fresh TCP connection with the latest config.
       const connectionData = ConnectionStorageManager.getConnection(connection.id);
       if (!connectionData) return;
 
@@ -512,15 +514,23 @@ function AppContent() {
           port: connectionData.port,
           username: connectionData.username,
           authMethod: connectionData.authMethod || 'password',
+          password: connectionData.password,
+          privateKeyPath: connectionData.privateKeyPath,
+          passphrase: connectionData.passphrase,
+          ftpsEnabled: connectionData.ftpsEnabled,
+          domain: connectionData.domain,
+          rdpResolution: connectionData.rdpResolution as ConnectionConfig['rdpResolution'],
+          vncColorDepth: connectionData.vncColorDepth as ConnectionConfig['vncColorDepth'],
         });
+        setPendingConnectionId(connection.id);
         setConnectionDialogOpen(true);
         return;
       }
 
-      // Use a unique session ID if the connection already exists anywhere
-      const sessionId = existsAnywhere
-        ? `${connection.id}-dup-${Date.now()}`
-        : connection.id;
+      // Always use a unique session ID — the backend may still hold a stale
+      // session from a previously closed tab that was never disconnected.
+      // A fresh session ID guarantees a new TCP connection with the latest config.
+      const sessionId = `${connection.id}-dup-${Date.now()}`;
 
       if (isFileBrowser) {
         // SFTP/FTP connect flow
@@ -531,7 +541,7 @@ function AppContent() {
           protocol: connectionData.protocol,
           host: connectionData.host,
           username: connectionData.username,
-          originalConnectionId: existsAnywhere ? connection.id : undefined,
+          originalConnectionId: connection.id,
           connectionStatus: 'connecting',
           reconnectCount: 0,
         };
@@ -573,7 +583,26 @@ function AppContent() {
           });
         }
       } else {
-        // SSH connect flow (existing behavior)
+        // SSH connect flow — create a placeholder tab first (shows "Waiting for
+        // connection..." so the user knows something is happening), then ssh_connect.
+        // Only after ssh_connect succeeds do we switch to 'connecting' status, which
+        // triggers PtyTerminal to mount and establish the WebSocket + PTY session.
+        // This avoids a race where PtyTerminal sends StartPty before the backend
+        // SSH session is fully established.
+        const newTab: TerminalTab = {
+          id: sessionId,
+          name: connectionData.name,
+          protocol: connectionData.protocol,
+          host: connectionData.host,
+          username: connectionData.username,
+          originalConnectionId: connection.id,
+          connectionStatus: 'pending',
+          reconnectCount: 0,
+        };
+        dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+
+        console.debug('[SSH] Connecting:', { id: connectionData.id, host: connectionData.host, port: connectionData.port, authMethod: connectionData.authMethod });
+
         try {
           const result = await invoke<{ success: boolean; error?: string }>(
             'ssh_connect',
@@ -593,21 +622,12 @@ function AppContent() {
 
           if (result.success) {
             ConnectionStorageManager.updateLastConnected(connection.id);
-
-            const newTab: TerminalTab = {
-              id: sessionId,
-              name: connectionData.name,
-              protocol: connectionData.protocol,
-              host: connectionData.host,
-              username: connectionData.username,
-              originalConnectionId: existsAnywhere ? connection.id : undefined,
-              connectionStatus: 'connecting',
-              reconnectCount: 0,
-            };
-
-            dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+            // Switch to 'connecting' — this mounts PtyTerminal which opens WebSocket
+            // and sends StartPty. The backend SSH session is ready by now.
+            dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'connecting' });
           } else {
             console.error('SSH connection failed:', result.error);
+            dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'disconnected' });
             toast.error(t('app.connectionFailed'), {
               description: result.error || 'Unable to connect to the server. Please check your credentials and try again.',
             });
@@ -619,11 +639,16 @@ function AppContent() {
               port: connectionData.port,
               username: connectionData.username,
               authMethod: connectionData.authMethod || 'password',
+              password: connectionData.password,
+              privateKeyPath: connectionData.privateKeyPath,
+              passphrase: connectionData.passphrase,
             });
+            setPendingConnectionId(connection.id);
             setConnectionDialogOpen(true);
           }
         } catch (error) {
           console.error('Error connecting to SSH:', error);
+          dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'disconnected' });
           toast.error(t('app.connectionError'), {
             description: error instanceof Error ? error.message : t('app.connectionErrorDesc'),
           });
@@ -635,7 +660,11 @@ function AppContent() {
             port: connectionData.port,
             username: connectionData.username,
             authMethod: connectionData.authMethod || 'password',
+            password: connectionData.password,
+            privateKeyPath: connectionData.privateKeyPath,
+            passphrase: connectionData.passphrase,
           });
+          setPendingConnectionId(connection.id);
           setConnectionDialogOpen(true);
         }
       }
@@ -680,6 +709,7 @@ function AppContent() {
     setConnectionInitialFolder(folderPath);
     setConnectionDialogOpen(true);
     setEditingConnection(null);
+    setPendingConnectionId(null);
   }, []);
 
   const handleDuplicateTab = useCallback(async (tabId: string) => {
@@ -851,7 +881,15 @@ function AppContent() {
         port: connectionData.port,
         username: connectionData.username,
         authMethod: connectionData.authMethod || 'password',
+        password: connectionData.password,
+        privateKeyPath: connectionData.privateKeyPath,
+        passphrase: connectionData.passphrase,
+        ftpsEnabled: connectionData.ftpsEnabled,
+        domain: connectionData.domain,
+        rdpResolution: connectionData.rdpResolution as ConnectionConfig['rdpResolution'],
+        vncColorDepth: connectionData.vncColorDepth as ConnectionConfig['vncColorDepth'],
       });
+      setPendingConnectionId(originalConnectionId);
       setConnectionDialogOpen(true);
       return;
     }
@@ -1274,6 +1312,7 @@ function AppContent() {
           vncColorDepth: connectionData.vncColorDepth as ConnectionConfig['vncColorDepth'],
         });
         setConnectionDialogOpen(true);
+        setPendingConnectionId(null);
       } else {
         toast.error('Connection Not Found', {
           description: 'The connection data could not be loaded.',
@@ -1281,6 +1320,184 @@ function AppContent() {
       }
     }
   }, []);
+
+  const handleSaveConnection = useCallback(async (config: ConnectionConfig) => {
+    if (!config.id) return;
+
+    // Update any open tab name for this connection
+    for (const group of Object.values(state.groups)) {
+      for (const tab of group.tabs) {
+        if (tab.id === config.id || tab.originalConnectionId === config.id) {
+          dispatch({ type: 'UPDATE_TAB_NAME', tabId: tab.id, name: config.name });
+        }
+      }
+    }
+
+    const wasPendingConnect = pendingConnectionId === config.id;
+    if (wasPendingConnect) {
+      setPendingConnectionId(null);
+
+      // Reuse the existing disconnected/pending tab (created by the initial failed
+      // connection attempt) instead of creating a new one. This avoids leaving a
+      // dead tab behind after the user saves a fix and auto-connects.
+      const pendingTab = allTabs.find(tab =>
+        tab.originalConnectionId === config.id &&
+        (tab.connectionStatus === 'disconnected' || tab.connectionStatus === 'pending')
+      );
+      const sessionId = pendingTab ? pendingTab.id : `${config.id}-dup-${Date.now()}`;
+
+      const isSftp = config.protocol === 'SFTP';
+      const isFtp = config.protocol === 'FTP';
+      const isFileBrowser = isSftp || isFtp;
+      const isDesktop = isDesktopProtocol(config.protocol);
+
+      if (isDesktop) {
+        if (!pendingTab) {
+          const newTab: TerminalTab = {
+            id: sessionId,
+            name: config.name,
+            tabType: 'desktop',
+            protocol: config.protocol,
+            host: config.host,
+            username: config.username,
+            originalConnectionId: config.id,
+            connectionStatus: 'connecting',
+            reconnectCount: 0,
+          };
+          dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+        } else {
+          dispatch({ type: 'UPDATE_TAB_NAME', tabId: sessionId, name: config.name });
+          dispatch({ type: 'RECONNECT_TAB', tabId: sessionId });
+        }
+
+        try {
+          await invoke('desktop_connect', {
+            request: {
+              connection_id: sessionId,
+              host: config.host,
+              port: config.port || (config.protocol === 'RDP' ? 3389 : 5900),
+              protocol: config.protocol.toLowerCase(),
+              username: config.username || '',
+              password: config.password || '',
+              domain: config.domain || null,
+              resolution: config.rdpResolution || '1920x1080',
+              color_depth: config.vncColorDepth ? parseInt(config.vncColorDepth) : 24,
+            }
+          });
+          ConnectionStorageManager.updateLastConnected(config.id);
+          dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'connected' });
+        } catch (error) {
+          dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'disconnected' });
+          toast.error(t('app.connectionFailed'), {
+            description: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } else if (isFileBrowser) {
+        if (!pendingTab) {
+          const newTab: TerminalTab = {
+            id: sessionId,
+            name: config.name,
+            tabType: 'file-browser',
+            protocol: config.protocol,
+            host: config.host,
+            username: config.username,
+            originalConnectionId: config.id,
+            connectionStatus: 'connecting',
+            reconnectCount: 0,
+          };
+          dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+        } else {
+          dispatch({ type: 'UPDATE_TAB_NAME', tabId: sessionId, name: config.name });
+          dispatch({ type: 'RECONNECT_TAB', tabId: sessionId });
+        }
+
+        try {
+          if (isSftp) {
+            await invoke('sftp_connect', {
+              request: {
+                connection_id: sessionId,
+                host: config.host,
+                port: config.port || 22,
+                username: config.username,
+                auth_method: config.authMethod || 'password',
+                password: config.password || '',
+                key_path: config.privateKeyPath || null,
+                passphrase: config.passphrase || null,
+              }
+            });
+          } else {
+            await invoke('ftp_connect', {
+              request: {
+                connection_id: sessionId,
+                host: config.host,
+                port: config.port || 21,
+                username: config.username || '',
+                password: config.password || '',
+                ftps_enabled: config.ftpsEnabled ?? false,
+                anonymous: config.authMethod === 'anonymous',
+              }
+            });
+          }
+          ConnectionStorageManager.updateLastConnected(config.id);
+          dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'connected' });
+        } catch (error) {
+          dispatch({ type: 'UPDATE_TAB_STATUS', tabId: sessionId, status: 'disconnected' });
+          toast.error(t('app.connectionFailed'), {
+            description: error instanceof Error ? error.message : String(error),
+          });
+        }
+      } else {
+        // SSH / Telnet / Raw — connect then create/reuse tab
+        try {
+          const result = await invoke<{ success: boolean; error?: string }>('ssh_connect', {
+            request: {
+              connection_id: sessionId,
+              host: config.host,
+              port: config.port || 22,
+              username: config.username,
+              auth_method: config.authMethod || 'password',
+              password: config.password || '',
+              key_path: config.privateKeyPath || null,
+              passphrase: config.passphrase || null,
+            }
+          });
+
+          if (result.success) {
+            ConnectionStorageManager.updateLastConnected(config.id);
+            if (pendingTab) {
+              // Reuse existing tab — RECONNECT_TAB increments reconnectCount so
+              // PtyTerminal's React key changes, forcing a remount with a fresh
+              // WebSocket + StartPty session. (UPDATE_TAB_STATUS alone would leave
+              // the old terminal content showing.)
+              dispatch({ type: 'UPDATE_TAB_NAME', tabId: sessionId, name: config.name });
+              dispatch({ type: 'RECONNECT_TAB', tabId: sessionId });
+            } else {
+              // No existing tab — create a new one
+              const newTab: TerminalTab = {
+                id: sessionId,
+                name: config.name,
+                protocol: config.protocol,
+                host: config.host,
+                username: config.username,
+                originalConnectionId: config.id,
+                connectionStatus: 'connecting',
+                reconnectCount: 0,
+              };
+              dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+            }
+          } else {
+            toast.error(t('app.connectionFailed'), {
+              description: result.error || 'Unable to connect to the server. Please check your credentials and try again.',
+            });
+          }
+        } catch (error) {
+          toast.error(t('app.connectionError'), {
+            description: error instanceof Error ? error.message : t('app.connectionErrorDesc'),
+          });
+        }
+      }
+    }
+  }, [state.groups, state.activeGroupId, allTabs, dispatch, t, pendingConnectionId]);
 
   // Get recent connections for quick connect
   const recentConnections = useMemo(() => {
@@ -1332,7 +1549,15 @@ function AppContent() {
         port: connectionData.port,
         username: connectionData.username,
         authMethod: connectionData.authMethod || 'password',
+        password: connectionData.password,
+        privateKeyPath: connectionData.privateKeyPath,
+        passphrase: connectionData.passphrase,
+        ftpsEnabled: connectionData.ftpsEnabled,
+        domain: connectionData.domain,
+        rdpResolution: connectionData.rdpResolution as ConnectionConfig['rdpResolution'],
+        vncColorDepth: connectionData.vncColorDepth as ConnectionConfig['vncColorDepth'],
       });
+      setPendingConnectionId(connectionData.id);
       setConnectionDialogOpen(true);
       return;
     }
@@ -1409,7 +1634,11 @@ function AppContent() {
             port: connectionData.port,
             username: connectionData.username,
             authMethod: connectionData.authMethod || 'password',
+            password: connectionData.password,
+            privateKeyPath: connectionData.privateKeyPath,
+            passphrase: connectionData.passphrase,
           });
+          setPendingConnectionId(connectionData.id);
           setConnectionDialogOpen(true);
         }
       } catch (error) {
@@ -1586,6 +1815,7 @@ function AppContent() {
                   onConnectionConnect={handleConnectionConnect}
                   selectedConnectionId={selectedConnection?.id || null}
                   activeConnections={activeConnectionIds}
+                  refreshTrigger={connectionSaveTrigger}
                   onNewConnection={handleNewTab}
                   onEditConnection={handleEditConnection}
                   recentConnections={recentConnections}
@@ -1708,9 +1938,14 @@ function AppContent() {
         open={connectionDialogOpen}
         onOpenChange={(open) => {
           setConnectionDialogOpen(open);
-          if (!open) setConnectionInitialFolder(undefined);
+          if (!open) {
+            setConnectionInitialFolder(undefined);
+            setEditingConnection(null);
+            setConnectionSaveTrigger(t => t + 1);
+          }
         }}
         onConnect={handleConnectionDialogConnect}
+        onSave={handleSaveConnection}
         editingConnection={editingConnection}
         initialFolder={connectionInitialFolder}
       />

--- a/src/__tests__/terminal-group-reducer.test.ts
+++ b/src/__tests__/terminal-group-reducer.test.ts
@@ -480,6 +480,30 @@ describe('UPDATE_TAB_STATUS', () => {
   });
 });
 
+// ── Reducer: UPDATE_TAB_NAME ──
+
+describe('UPDATE_TAB_NAME', () => {
+  it('updates tab name across groups', () => {
+    const state = stateWithTabs('1', [makeTab('t1', 'Old Name')]);
+    const next = terminalGroupReducer(state, {
+      type: 'UPDATE_TAB_NAME',
+      tabId: 't1',
+      name: 'New Name',
+    });
+    expect(next.groups['1'].tabs[0].name).toBe('New Name');
+  });
+
+  it('returns same state if tab not found', () => {
+    const state = createDefaultState();
+    const next = terminalGroupReducer(state, {
+      type: 'UPDATE_TAB_NAME',
+      tabId: 'nope',
+      name: 'Whatever',
+    });
+    expect(next).toBe(state);
+  });
+});
+
 // ── Reducer: UPDATE_GRID_SIZES ──
 
 describe('UPDATE_GRID_SIZES', () => {

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -29,6 +29,7 @@ interface ConnectionDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   onConnect: (config: ConnectionConfig) => void;
+  onSave?: (config: ConnectionConfig) => void;
   editingConnection?: ConnectionConfig | null;
   initialFolder?: string;
 }
@@ -73,6 +74,7 @@ export function ConnectionDialog({
   open,
   onOpenChange,
   onConnect,
+  onSave,
   editingConnection,
   initialFolder
 }: ConnectionDialogProps) {
@@ -340,95 +342,99 @@ export function ConnectionDialog({
       return;
     }
 
-    // SSH / Telnet / Raw / Serial — connect via ssh_connect
-    try {
-      const result = await invoke<{ success: boolean; error?: string }>(
-        'ssh_connect',
-        {
-          request: {
-            connection_id: connectionId,
-            host: config.host,
-            port: config.port || 22,
-            username: config.username,
-            auth_method: config.authMethod || 'password',
-            password: config.password || '',
-            key_path: config.privateKeyPath || null,
-            passphrase: config.passphrase || null,
-          }
-        }
-      );
+	    // SSH / Telnet / Raw / Serial — connect via ssh_connect
+	    // Save connection config FIRST (consistent with SFTP/FTP/Desktop),
+	    // so the config is preserved even if the remote server is temporarily unreachable.
+	    let connectionSaved = false;
+	    if (editingConnection?.id) {
+	      ConnectionStorageManager.updateConnection(editingConnection.id, {
+	        name: config.name,
+	        host: config.host,
+	        port: config.port || 22,
+	        username: config.username,
+	        protocol: config.protocol,
+	        authMethod: config.authMethod,
+	        password: config.password,
+	        privateKeyPath: config.privateKeyPath,
+	        passphrase: config.passphrase,
+	        lastConnected: new Date().toISOString(),
+	      });
+	      connectionSaved = true;
+	    } else if (saveAsConnection) {
+	      ConnectionStorageManager.saveConnectionWithId(connectionId, {
+	        name: config.name,
+	        host: config.host,
+	        port: config.port || 22,
+	        username: config.username,
+	        protocol: config.protocol,
+	        folder: connectionFolder,
+	        authMethod: config.authMethod,
+	        password: config.password,
+	        privateKeyPath: config.privateKeyPath,
+	        passphrase: config.passphrase,
+	      });
+	      connectionSaved = true;
+	    }
 
-      if (result.success) {
-        // Save or update connection based on whether we're editing or creating new
-        if (editingConnection?.id) {
-          // Update existing connection with new connection details
-          ConnectionStorageManager.updateConnection(editingConnection.id, {
-            name: config.name,
-            host: config.host,
-            port: config.port || 22,
-            username: config.username,
-            protocol: config.protocol,
-            authMethod: config.authMethod,
-            password: config.password,
-            privateKeyPath: config.privateKeyPath,
-            passphrase: config.passphrase,
-            lastConnected: new Date().toISOString(),
-          });
-        } else if (saveAsConnection) {
-          // Save new connection with the same ID used for the SSH connection
-          // This ensures the tab ID matches the connection ID in storage
-          ConnectionStorageManager.saveConnectionWithId(connectionId, {
-            name: config.name,
-            host: config.host,
-            port: config.port || 22,
-            username: config.username,
-            protocol: config.protocol,
-            folder: connectionFolder,
-            authMethod: config.authMethod,
-            password: config.password,
-            privateKeyPath: config.privateKeyPath,
-            passphrase: config.passphrase,
-          });
-        }
+	    try {
+	      const result = await invoke<{ success: boolean; error?: string }>(
+	        'ssh_connect',
+	        {
+	          request: {
+	            connection_id: connectionId,
+	            host: config.host,
+	            port: config.port || 22,
+	            username: config.username,
+	            auth_method: config.authMethod || 'password',
+	            password: config.password || '',
+	            key_path: config.privateKeyPath || null,
+	            passphrase: config.passphrase || null,
+	          }
+	        }
+	      );
 
-        onConnect({
-          ...config,
-          id: connectionId
-        });
-        onOpenChange(false);
+	      if (result.success) {
+	        onConnect({
+	          ...config,
+	          id: connectionId
+	        });
+	        if (!editingConnection) {
+	          setConfig(defaultConfig);
+	        }
+	      } else {
+	        // Connection failed — config was already saved above, user can retry from sidebar
+	        console.error('Connection failed:', result.error);
+	        if (cancelRequestedRef.current && result.error?.toLowerCase().includes('cancelled')) {
+	          toast.info(t('connectionDialog.toast.connectionCancelled'));
+	        } else {
+	          toast.error(t('connectionDialog.toast.connectionFailed'), {
+	            description: result.error || t('connectionDialog.toast.connectionFailedDesc'),
+	            duration: 5000,
+	          });
+	        }
+	      }
+	    } catch (error) {
+	      console.error('Connection error:', error);
+	      if (cancelRequestedRef.current) {
+	        toast.info(t('connectionDialog.toast.connectionCancelled'));
+	      } else {
+	        toast.error(t('connectionDialog.toast.connectionError'), {
+	          description: error instanceof Error ? error.message : t('connectionDialog.toast.connectionErrorDesc'),
+	          duration: 5000,
+	        });
+	      }
+	    } finally {
+	      // Close dialog — config is already saved if connectionSaved is true
+	      onOpenChange(false);
+	      if (!editingConnection) {
+	        setConfig(defaultConfig);
+	      }
+	      resetConnectionState();
+	    }
 
-        // Reset form if creating new connection
-        if (!editingConnection) {
-          setConfig(defaultConfig);
-        }
-      } else {
-        // Show error toast
-        console.error('Connection failed:', result.error);
-        if (cancelRequestedRef.current && result.error?.toLowerCase().includes('cancelled')) {
-          toast.info(t('connectionDialog.toast.connectionCancelled'));
-        } else {
-          toast.error(t('connectionDialog.toast.connectionFailed'), {
-            description: result.error || t('connectionDialog.toast.connectionFailedDesc'),
-            duration: 5000,
-          });
-        }
-      }
-    } catch (error) {
-      console.error('Connection error:', error);
-      if (cancelRequestedRef.current) {
-        toast.info(t('connectionDialog.toast.connectionCancelled'));
-      } else {
-        toast.error(t('connectionDialog.toast.connectionError'), {
-          description: error instanceof Error ? error.message : t('connectionDialog.toast.connectionErrorDesc'),
-          duration: 5000,
-        });
-      }
-    } finally {
-      resetConnectionState();
-    }
-  };
+	  }
 
-  const handleCancelConnectionAttempt = async () => {
+const handleCancelConnectionAttempt = async () => {
     if (!isConnecting) {
       onOpenChange(false);
       return;
@@ -463,6 +469,37 @@ export function ConnectionDialog({
       // Always reset the state when user requests cancel
       resetConnectionState();
     }
+  };
+
+  const handleSave = async () => {
+    if (!editingConnection?.id) return;
+
+    // Save updated connection to storage
+    ConnectionStorageManager.updateConnection(editingConnection.id, {
+      name: config.name,
+      host: config.host,
+      port: config.port || 22,
+      username: config.username,
+      protocol: config.protocol,
+      authMethod: config.authMethod,
+      password: config.password,
+      privateKeyPath: config.privateKeyPath,
+      passphrase: config.passphrase,
+      ftpsEnabled: config.ftpsEnabled,
+      domain: config.domain,
+      rdpResolution: config.rdpResolution,
+      vncColorDepth: config.vncColorDepth,
+    });
+
+    // Notify parent to update tab display info (e.g. tab title)
+    // May also trigger a connection attempt if there's no open tab
+    await onSave?.({
+      ...config,
+      id: editingConnection.id,
+    });
+
+    onOpenChange(false);
+    resetConnectionState();
   };
 
   const updateConfig = (updates: Partial<ConnectionConfig>) => {
@@ -1036,9 +1073,15 @@ export function ConnectionDialog({
               >
                 {isConnecting ? (isCancelling ? t('connectionDialog.button.cancelling') : t('connectionDialog.button.stop')) : t('connectionDialog.button.cancel')}
               </Button>
-              <Button onClick={handleConnect} disabled={isConnecting || isCancelling} className="min-w-[140px]">
-                {isConnecting ? t('connectionDialog.button.connecting') : editingConnection ? t('connectionDialog.button.updateAndConnect') : t('connectionDialog.button.connect')}
-              </Button>
+              {editingConnection ? (
+                <Button onClick={handleSave} className="min-w-[140px]">
+                  {t('connectionDialog.button.save')}
+                </Button>
+              ) : (
+                <Button onClick={handleConnect} disabled={isConnecting || isCancelling} className="min-w-[140px]">
+                  {isConnecting ? t('connectionDialog.button.connecting') : t('connectionDialog.button.connect')}
+                </Button>
+              )}
             </div>
           </div>
         </DialogFooter>

--- a/src/components/connection-manager.tsx
+++ b/src/components/connection-manager.tsx
@@ -64,6 +64,7 @@ interface ConnectionManagerProps {
   onConnectionConnect?: (connection: ConnectionNode) => void;
   selectedConnectionId: string | null;
   activeConnections?: Set<string>;
+  refreshTrigger?: number;
   onNewConnection?: (folderPath?: string) => void;
   onEditConnection?: (connection: ConnectionNode) => void;
   onDeleteConnection?: (connectionId: string) => void;
@@ -80,6 +81,7 @@ export function ConnectionManager({
   onConnectionConnect,
   selectedConnectionId,
   activeConnections = new Set(),
+  refreshTrigger = 0,
   onNewConnection,
   onEditConnection,
   onDeleteConnection,
@@ -113,7 +115,8 @@ export function ConnectionManager({
   const suppressClickRef = useRef(false);
   const treeContainerRef = useRef<HTMLDivElement>(null);
 
-  // Reload connections when active connections change, preserving expand state
+  // Reload connections when active connections or refreshTrigger changes,
+  // preserving expand state across tree rebuilds.
   useEffect(() => {
     const newTree = loadConnections();
     setConnections(prev => {
@@ -134,7 +137,7 @@ export function ConnectionManager({
         });
       return mergeExpanded(newTree);
     });
-  }, [activeConnections]);
+  }, [activeConnections, refreshTrigger]);
 
   // Handle connection deletion
   const handleDelete = (connectionId: string) => {

--- a/src/components/log-monitor.tsx
+++ b/src/components/log-monitor.tsx
@@ -284,15 +284,27 @@ export function LogMonitor({ connectionId, externalLogPath, externalLogPathKey }
         if (result.sources.length === 0) {
           toast.info(t('logMonitor.noSourcesDiscovered'));
         }
+      } else if (result.error && (
+        result.error.includes('Connection not found') ||
+        result.error.includes('Session not found')
+      )) {
+        // Transient: the SSH session was just created and may not be fully
+        // initialized yet. Silently skip — the user can rediscover later.
+        console.debug('[LogMonitor] Session not ready yet, skipping source discovery:', result.error);
       } else {
         toast.error(t('logMonitor.failedToDiscoverSources'), {
           description: result.error,
         });
       }
     } catch (err) {
-      toast.error(t('logMonitor.failedToDiscoverSources'), {
-        description: err instanceof Error ? err.message : String(err),
-      });
+      const msg = err instanceof Error ? err.message : String(err);
+      if (msg.includes('Connection not found') || msg.includes('Session not found')) {
+        console.debug('[LogMonitor] Session not ready yet, skipping source discovery:', msg);
+      } else {
+        toast.error(t('logMonitor.failedToDiscoverSources'), {
+          description: msg,
+        });
+      }
     } finally {
       setIsDiscovering(false);
     }

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -868,12 +868,14 @@ export function PtyTerminal({
       term.reset(); // clear scrollback + viewport so GC can reclaim xterm buffers sooner
       term.dispose();
     };
-  }, [connectionId, connectionName, host, username, terminalKey, reconnectKey, sendInputToPty]);
-  // NOTE: themeKey and appearanceKey are intentionally NOT in the deps above.
-  // Including them would tear down the WebSocket + PTY session on every theme
-  // change (e.g. macOS auto Dark/Light switch), killing any running remote
-  // processes such as nvitop. Theme/appearance updates are handled in-place
-  // by the effect below without any connection disruption.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [connectionId, host, username, terminalKey, reconnectKey, sendInputToPty]);
+  // NOTE: themeKey, appearanceKey, and connectionName are intentionally NOT
+  // in the deps above. Including them would tear down the WebSocket + PTY
+  // session on every theme change (e.g. macOS auto Dark/Light switch), killing
+  // any running remote processes. Including connectionName would do the same
+  // when the user renames the connection via edit dialog — the tab title
+  // already updates via UPDATE_TAB_NAME without reconnecting.
 
   // Update terminal colors and font in-place when theme or appearance changes.
   React.useEffect(() => {

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -8,6 +8,7 @@ import React, {
   useRef,
   useState,
 } from 'react';
+import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
 import { useTerminalGroups } from '../../lib/terminal-group-context';
 import { useTerminalCallbacks } from '../../lib/terminal-callbacks-context';
@@ -48,6 +49,7 @@ function useThemeKey(): number {
 }
 
 function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: number }) {
+  const { t } = useTranslation();
   const { state, dispatch } = useTerminalGroups();
   const { onReconnectTab } = useTerminalCallbacks();
   const groupId = state.tabToGroupMap[tab.id];
@@ -115,7 +117,7 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
     content = (
       <div className="h-full w-full flex items-center justify-center bg-muted/30">
         <div className="text-center text-muted-foreground">
-          <div className="animate-pulse">Waiting for connection...</div>
+          <div className="animate-pulse">{t('app.waitingForConnection')}</div>
         </div>
       </div>
     );

--- a/src/lib/terminal-group-reducer.ts
+++ b/src/lib/terminal-group-reducer.ts
@@ -511,6 +511,29 @@ export function terminalGroupReducer(
       };
     }
 
+    case 'UPDATE_TAB_NAME': {
+      const { tabId, name } = action;
+      const groupId = state.tabToGroupMap[tabId];
+      if (!groupId) return state;
+
+      const group = state.groups[groupId];
+      if (!group) return state;
+
+      const tabIndex = group.tabs.findIndex((t) => t.id === tabId);
+      if (tabIndex === -1) return state;
+
+      const newTabs = [...group.tabs];
+      newTabs[tabIndex] = { ...newTabs[tabIndex], name };
+
+      return {
+        ...state,
+        groups: {
+          ...state.groups,
+          [groupId]: { ...group, tabs: newTabs },
+        },
+      };
+    }
+
     case 'RECONNECT_TAB': {
       const { tabId } = action;
       const groupId = state.tabToGroupMap[tabId];

--- a/src/lib/terminal-group-types.ts
+++ b/src/lib/terminal-group-types.ts
@@ -55,6 +55,7 @@ export type TerminalGroupAction =
   | { type: 'CLOSE_TABS_TO_LEFT'; groupId: string; tabId: string }
   | { type: 'MOVE_TAB_TO_NEW_GROUP'; groupId: string; tabId: string; direction: SplitDirection }
   | { type: 'UPDATE_TAB_STATUS'; tabId: string; status: 'connected' | 'connecting' | 'disconnected' | 'pending' }
+  | { type: 'UPDATE_TAB_NAME'; tabId: string; name: string }
   | { type: 'RECONNECT_TAB'; tabId: string }
   | { type: 'UPDATE_GRID_SIZES'; path: number[]; sizes: number[] }
   | { type: 'RESET_LAYOUT' }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -50,6 +50,7 @@
     "connectionFailed": "Connection Failed",
     "connectionError": "Connection Error",
     "connectionErrorDesc": "An unexpected error occurred while connecting.",
+    "waitingForConnection": "Waiting for connection...",
     "cannotDuplicate": "Cannot Duplicate Tab",
     "cannotDuplicateDesc": "Connection data not found. Please create a new connection.",
     "cannotReconnect": "Cannot Reconnect",
@@ -184,6 +185,7 @@
     "allConnections": "All Connections",
     "button": {
       "cancel": "Cancel",
+      "save": "Save",
       "stop": "Stop",
       "cancelling": "Cancelling...",
       "connecting": "Connecting...",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -50,6 +50,7 @@
     "connectionFailed": "连接失败",
     "connectionError": "连接错误",
     "connectionErrorDesc": "连接时发生意外错误。",
+    "waitingForConnection": "等待连接...",
     "cannotDuplicate": "无法复制标签页",
     "cannotDuplicateDesc": "未找到连接数据，请创建新连接。",
     "cannotReconnect": "无法重新连接",
@@ -184,6 +185,7 @@
     "allConnections": "所有连接",
     "button": {
       "cancel": "取消",
+      "save": "保存",
       "stop": "停止",
       "cancelling": "取消中...",
       "connecting": "连接中...",
@@ -889,6 +891,7 @@
     "clearCompleted": "清除已完成",
     "retry": "重试",
     "cancel": "取消",
+      "save": "保存",
     "retryAll": "全部重试",
     "cancelAll": "全部取消",
     "upload": "上传",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -891,7 +891,6 @@
     "clearCompleted": "清除已完成",
     "retry": "重试",
     "cancel": "取消",
-      "save": "保存",
     "retryAll": "全部重试",
     "cancelAll": "全部取消",
     "upload": "上传",


### PR DESCRIPTION
## Summary

Improves the edit-connection experience: tab titles now update after a rename, credentials are preserved when the edit dialog opens from a failed connection, and the "Update & Connect" button becomes "Save" to avoid unnecessary reconnection.

## Changes

### Edit-connection flow
- **`UPDATE_TAB_NAME` reducer action** — tab title updates live after saving a renamed connection
- **`handleSave` replaces `handleConnect` in edit mode** — the button now says "Save" and doesn't trigger a reconnect
- **`pendingConnectionId` tracking** — when the edit dialog was opened from a failed double-click (e.g. wrong port), saving the fix auto-retries the connection
- **Existing tab reuse** — the auto-retry reuses the previously failed tab instead of opening a duplicate
- **6 `setEditingConnection` calls now include credentials** — `password`, `privateKeyPath`, and `passphrase` are no longer lost when a connection error opens the edit dialog

### New-connection / general
- **SSH config saved before connecting** — aligns with SFTP/FTP/Desktop behavior, so a config is preserved even if the server is temporarily unreachable
- **Unique session IDs for each SSH attempt** — prevents stale backend sessions from interfering with updated connection parameters
- **Sidebar refresh after dialog close** — `ConnectionManager` now refreshes its tree when the dialog closes, so saved changes appear immediately

### Stability
- **`PtyTerminal` effect no longer depends on `connectionName`** — renaming a connection no longer tears down the WebSocket + PTY session
- **`UPDATE_TAB_NAME` + `RECONNECT_TAB` reducer tests added**

## Testing

- 510 tests pass (37 test files)
- TypeScript compiles cleanly
- Tauri build succeeds