### PR TITLE
fix(file-browser): resolve SSH file list corruption on non-GNU hosts

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -331,7 +331,7 @@ pub async fn list_files(
     connection_id: String,
     path: String,
     state: State<'_, Arc<ConnectionManager>>,
-) -> Result<String, String> {
+) -> Result<Vec<FileEntry>, String> {
     let connection = state
         .get_connection(&connection_id)
         .await
@@ -341,10 +341,21 @@ pub async fn list_files(
     let os_info = get_os_info(&connection_id, &client, state.inner()).await;
     let command = os_info.list_files_cmd(&path);
 
-    match client.execute_command(&command).await {
-        Ok(output) => Ok(output),
-        Err(e) => Err(e.to_string()),
-    }
+    let output = client
+        .execute_command(&command)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Parse the `ls -l` output on the backend so the frontend never has to
+    // guess the column layout. Supports GNU `--time-style=long-iso` (used when
+    // GNU coreutils are detected) and the BusyBox/BSD default layout, plus
+    // ACL/SELinux/no-group variants. See `ls_parser` for details.
+    let entries = output
+        .lines()
+        .filter_map(crate::ls_parser::parse_ls_long_line)
+        .collect::<Vec<_>>();
+
+    Ok(entries)
 }
 
 #[derive(Debug, Serialize, Deserialize)]

--- a/src-tauri/src/ftp_client.rs
+++ b/src-tauri/src/ftp_client.rs
@@ -272,31 +272,37 @@ impl FtpClient {
     }
 }
 
-/// Parse a single line from the FTP LIST command (Unix format).
-/// Example: `drwxr-xr-x   2 user group  4096 Jan 01 12:00 dirname`
+/// Parse a single line from the FTP LIST command (Unix `ls -l` format).
+///
+/// Supports the common variants encountered in the wild:
+///   - `perms links owner group size mon day time name`            (9 tokens)
+///   - `perms links owner size mon day time name`                  (8 tokens, busybox)
+///   - `perms[+/.] ... system_u:object_r:... size mon day time name` (10+ tokens, ACL/SELinux)
+///   - numeric or symbolic owner/group
+///
+/// The key invariant used to locate fields: the date triple (`Mon DD HH:MM` or
+/// `Mon DD YYYY`) always sits immediately to the left of the file name, and
+/// the size is the rightmost numeric token to the left of the date. Everything
+/// after the date triple is the file name (preserving embedded spaces).
 fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
     let line = line.trim();
     if line.is_empty() {
         return None;
     }
 
-    // Unix-style listing
-    let parts: Vec<&str> = line.splitn(9, char::is_whitespace).collect();
-    if parts.len() < 9 {
-        // Try to at least get the name
-        if let Some(last) = line.split_whitespace().last() {
-            return Some(FileEntry {
-                name: last.to_string(),
-                size: 0,
-                modified: None,
-                permissions: None,
-                file_type: FileEntryType::File,
-            });
-        }
+    // `ls -l` emits a "total NNN" summary as its first line — never a file entry.
+    // Reject it explicitly so it doesn't get misparsed as a weird file.
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+    if tokens.len() >= 2 && tokens[0].eq_ignore_ascii_case("total") {
         return None;
     }
 
-    let perms_str = parts[0];
+    // Must start with a perms-like token (d/l/- followed by rwx/-).
+    let perms_str = tokens.first()?;
+    if !is_perms_token(perms_str) {
+        return None;
+    }
+
     let file_type = if perms_str.starts_with('d') {
         FileEntryType::Directory
     } else if perms_str.starts_with('l') {
@@ -305,32 +311,42 @@ fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
         FileEntryType::File
     };
 
-    // Filter out empty parts from whitespace splitting
-    let tokens: Vec<&str> = line.split_whitespace().collect();
-    if tokens.len() < 9 {
-        let name = tokens.last().unwrap_or(&"").to_string();
-        return Some(FileEntry {
-            name,
-            size: 0,
-            modified: None,
-            permissions: Some(perms_str.to_string()),
-            file_type,
-        });
+    // Locate the date triple by scanning for a recognised month abbreviation.
+    // Layout to the right of `month_idx`: [month, day, time_or_year, name...].
+    // We need at least 4 tokens from `month_idx` onward (month + day + date + name).
+    let month_idx = (0..tokens.len().saturating_sub(3)).find(|&i| {
+        is_month_abbr(tokens[i]) && is_day(tokens.get(i + 1)) && is_date_field(tokens.get(i + 2))
+    })?;
+
+    let month = tokens[month_idx];
+    let day = tokens[month_idx + 1];
+    let time_or_year = tokens[month_idx + 2];
+    let modified = parse_ftp_modified(month, day, time_or_year);
+
+    // Name is everything after the date triple (preserves embedded spaces).
+    let name_raw = tokens[month_idx + 3..].join(" ");
+    // For symlinks, strip the " -> target" suffix.
+    let name = if matches!(file_type, FileEntryType::Symlink) {
+        name_raw
+            .split(" -> ")
+            .next()
+            .unwrap_or(&name_raw)
+            .to_string()
+    } else {
+        name_raw
+    };
+
+    if name.is_empty() {
+        return None;
     }
 
-    let size = tokens[4].parse::<u64>().unwrap_or(0);
-    let month = tokens[5];
-    let day = tokens[6];
-    let time_or_year = tokens[7];
-    let modified = parse_ftp_modified(month, day, time_or_year);
-    // Name is everything after the 8th token (handles spaces in names)
-    let name = tokens[8..].join(" ");
-    // For symlinks, strip the " -> target" part from the name
-    let name = if matches!(file_type, FileEntryType::Symlink) {
-        name.split(" -> ").next().unwrap_or(&name).to_string()
-    } else {
-        name
-    };
+    // Size is the rightmost numeric token strictly left of the date triple.
+    // (Falls back to 0 for listings without a size column — e.g. some minimal daemons.)
+    let size = tokens[..month_idx]
+        .iter()
+        .rev()
+        .find_map(|t| t.parse::<u64>().ok())
+        .unwrap_or(0);
 
     Some(FileEntry {
         name,
@@ -339,6 +355,67 @@ fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
         permissions: Some(perms_str.to_string()),
         file_type,
     })
+}
+
+/// True for a Unix permission string like `drwxr-xr-x`, `-rw-r--r--`,
+/// `lrwxrwxrwx`, optionally with an ACL (`+`) or SELinux-context (`.`) suffix.
+fn is_perms_token(s: &str) -> bool {
+    // Bare perms are 10 chars: 1 type char (`d`/`l`/`-`) + 9 rwx/- chars.
+    // An ACL (`+`) or SELinux-context (`.`) suffix adds one more char → 11.
+    let bytes = s.as_bytes();
+    let body_len = bytes.len();
+    if !(10..=11).contains(&body_len) {
+        return false;
+    }
+    if !matches!(bytes[0], b'd' | b'l' | b'-') {
+        return false;
+    }
+    // Positions 1..=9 (9 chars) must all be r/w/x/-.
+    bytes[1..10]
+        .iter()
+        .all(|&b| matches!(b, b'r' | b'w' | b'x' | b'-'))
+}
+
+fn is_month_abbr(s: &str) -> bool {
+    matches!(
+        s,
+        "Jan"
+            | "Feb"
+            | "Mar"
+            | "Apr"
+            | "May"
+            | "Jun"
+            | "Jul"
+            | "Aug"
+            | "Sep"
+            | "Oct"
+            | "Nov"
+            | "Dec"
+    )
+}
+
+/// True for a day-of-month token: 1–2 digits, optionally with a trailing
+/// non-digit (some locales pad with `_` etc.).
+fn is_day(s: Option<&&str>) -> bool {
+    let Some(s) = s else { return false };
+    s.trim_end_matches(|c: char| !c.is_ascii_digit())
+        .parse::<u32>()
+        .map(|d| (1..=31).contains(&d))
+        .unwrap_or(false)
+}
+
+/// True for the third date column: either `HH:MM` (recent file) or `YYYY` (older).
+fn is_date_field(s: Option<&&str>) -> bool {
+    let Some(s) = s else { return false };
+    if s.contains(':') {
+        // HH:MM — two colon-separated numeric parts.
+        let parts: Vec<&str> = s.split(':').collect();
+        parts.len() == 2
+            && parts.iter().all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    } else {
+        // YYYY — a 4-digit year.
+        s.len() == 4 && s.bytes().all(|b| b.is_ascii_digit())
+    }
 }
 
 /// Parse FTP `ls` date fields ("Mon DD HH:MM" or "Mon DD YYYY") into "yyyy-mm-dd hh:mm:ss".
@@ -644,6 +721,150 @@ mod tests {
         let line = "drwxr-xr-x   2 user group  4096 Jan 01 00:00 .";
         let entry = parse_ftp_list_line(line).expect("should parse");
         assert_eq!(entry.name, ".");
+    }
+
+    // ---- Regression tests for variable-column LIST formats ----
+    //
+    // The original parser used fixed indices `tokens[4..8]` which only worked
+    // for the strict 9-token "perms links owner group size mon day time name"
+    // layout. Real-world FTP servers (notably embedded / arcade-style boxes
+    // running busybox or SELinux-enabled distros) emit:
+    //   - 8-token lines (no `group` column)        → silently lost metadata
+    //   - 10+ token lines (SELinux context / ACL)  → name leaked time tokens,
+    //     producing the exact "12:32 dev" / "2000 Pacman" corruption users saw.
+    //
+    // These tests lock in the robust from-the-right parsing behaviour.
+
+    #[test]
+    fn test_parse_ftp_list_line_selinux_context_dir() {
+        // 10 tokens — the bug that produced "12:32 dev" in the file name.
+        let line = "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jan 15 12:32 dev";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert!(matches!(entry.file_type, FileEntryType::Directory));
+        assert_eq!(entry.size, 4096);
+        // Time-format date must keep its time-of-day, not bleed into the name.
+        assert!(
+            entry.modified.as_deref().unwrap_or("").ends_with(" 12:32:00"),
+            "modified should keep 12:32:00, got: {:?}",
+            entry.modified
+        );
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_selinux_context_file_year() {
+        // 11 tokens — the bug that produced "2000 Pacman" / "2000 gamelist.xml".
+        let line =
+            "-rw-r--r--. 1 root root system_u:object_r:default_t 85234 Nov 09  2000 gamelist.xml";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert!(matches!(entry.file_type, FileEntryType::File));
+        assert_eq!(entry.size, 85234);
+        assert_eq!(entry.modified.as_deref(), Some("2000-11-09 00:00:00"));
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_acl_extended() {
+        // ACL `+` suffix on perms — extra columns must not corrupt parsing.
+        let line = "drwxr-xr-x+  3 root root  4096 Feb 28  2024 with spaces in name";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "with spaces in name");
+        assert_eq!(entry.size, 4096);
+        assert_eq!(entry.modified.as_deref(), Some("2024-02-28 00:00:00"));
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_no_group_busybox() {
+        // busybox/embedded omit the `group` column → 8 tokens. Must still
+        // recover size + modified + permissions rather than falling back.
+        let line = "-rw-r--r--   1 root  85234 Jul 27 12:46 gamelist.xml";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert_eq!(entry.size, 85234);
+        assert_eq!(entry.permissions.as_deref(), Some("-rw-r--r--"));
+        assert!(
+            entry.modified.is_some(),
+            "modified should be parsed, got None"
+        );
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_no_group_dir() {
+        let line = "drwxr-xr-x   2 root  4096 Jan 15 12:32 dev";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert!(matches!(entry.file_type, FileEntryType::Directory));
+        assert_eq!(entry.size, 4096);
+        assert!(entry.modified.is_some());
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_numeric_owner_group() {
+        let line = "drwxr-xr-x 2 1000 1000 4096 Mar 01 09:15 shared";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "shared");
+        assert_eq!(entry.size, 4096);
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_symlink_with_extra_columns() {
+        let line =
+            "lrwxrwxrwx. 1 root root system_u:object_r:default_t 10 Mar 01 00:00 link -> target";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "link");
+        assert!(matches!(entry.file_type, FileEntryType::Symlink));
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_name_with_spaces_extra_columns() {
+        // Spaces in the filename PLUS a SELinux context column.
+        let line =
+            "-rw-r--r--. 1 root root system_u:object_r:default_t 100 Dec 25 23:59 my file name.txt";
+        let entry = parse_ftp_list_line(line).expect("should parse");
+        assert_eq!(entry.name, "my file name.txt");
+        assert_eq!(entry.size, 100);
+    }
+
+    #[test]
+    fn test_parse_ftp_list_line_total_line_ignored() {
+        // `ls -l` prepends a "total NNN" summary line — must not be parsed as an entry.
+        assert!(parse_ftp_list_line("total 123").is_none());
+        assert!(parse_ftp_list_line("total 0").is_none());
+    }
+
+    /// End-to-end regression test reproducing the exact user-reported symptoms
+    /// on an arcade/emulator FTP server (MAME dirs: Pacman, SEGA, Taito, ...).
+    ///
+    /// Before the fix, SELinux-context listings produced:
+    ///   - name = "12:32 dev", "2000 Pacman", "2000 gamelist.xml"
+    ///   - modified = bogus dates parsed from misaligned size/perms tokens
+    /// After the fix, every field is correctly extracted.
+    #[test]
+    fn test_parse_ftp_list_line_user_scenario_arcade_box() {
+        let lines = [
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jan 15 12:32 dev",
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jan 15 12:32 proc",
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jan 15 12:32 sys",
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jul 25 12:46 Pacman",
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jul 25 12:46 SEGA",
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jul 25 12:46 Taito",
+            "-rw-r--r--. 1 root root system_u:object_r:default_t 85234 Nov 09  2000 gamelist.xml",
+        ];
+
+        let dev = parse_ftp_list_line(lines[0]).expect("dev must parse");
+        assert_eq!(dev.name, "dev");
+        assert!(matches!(dev.file_type, FileEntryType::Directory));
+        assert_eq!(dev.size, 4096);
+
+        let pacman = parse_ftp_list_line(lines[3]).expect("Pacman must parse");
+        assert_eq!(pacman.name, "Pacman");
+        assert!(matches!(pacman.file_type, FileEntryType::Directory));
+
+        let gamelist = parse_ftp_list_line(lines[6]).expect("gamelist.xml must parse");
+        assert_eq!(gamelist.name, "gamelist.xml");
+        assert!(matches!(gamelist.file_type, FileEntryType::File));
+        assert_eq!(gamelist.size, 85234);
+        assert_eq!(gamelist.modified.as_deref(), Some("2000-11-09 00:00:00"));
     }
 
     // ---- Task 5.4: Additional unit tests ----

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -2,6 +2,7 @@ mod commands;
 mod connection_manager;
 mod desktop_protocol;
 mod ftp_client;
+mod ls_parser;
 mod os_detect;
 mod rdp_client;
 mod sftp_client;

--- a/src-tauri/src/ls_parser.rs
+++ b/src-tauri/src/ls_parser.rs
@@ -1,0 +1,488 @@
+//! Parser for `ls -l`-style directory listings.
+//!
+//! Supports the formats emitted by the major `ls` implementations we encounter
+//! when browsing remote filesystems:
+//!
+//! | Source | Time column | Example |
+//! |--------|-------------|---------|
+//! | GNU coreutils (`--time-style=long-iso`) | `YYYY-MM-DD HH:MM` (2 tokens) | `drwxr-xr-x 5 root root 4096 2025-01-15 12:32 dev` |
+//! | BusyBox / BSD / default `ls` (recent file) | `Mon DD HH:MM` (3 tokens) | `drwxr-xr-x 5 root root 4096 Jan 15 12:32 dev` |
+//! | BusyBox / BSD / default `ls` (older file) | `Mon DD YYYY` (3 tokens) | `-rw-r--r-- 1 root root 85234 Nov 09 2000 gamelist.xml` |
+//!
+//! Plus the common real-world variants:
+//!   - ACL (`+`) or SELinux-context (`.`) suffix on the perms token
+//!   - Optional `group` column (busybox-embedded listings sometimes omit it)
+//!   - Numeric or symbolic `owner` / `group`
+//!   - SELinux security context as an extra column
+//!   - Symlink targets (`name -> target`)
+//!
+//! The parser is column-count agnostic: it locates the date field by pattern
+//! and treats everything to its right as the filename, so adding or removing
+//! an owner/group/context column does not corrupt the result.
+
+use crate::sftp_client::{FileEntry, FileEntryType};
+
+/// Parse a single line from an `ls -l`-style listing into a [`FileEntry`].
+///
+/// Returns `None` for blank lines, `total NNN` summary lines, or lines that
+/// don't match any recognised layout.
+pub fn parse_ls_long_line(line: &str) -> Option<FileEntry> {
+    let line = line.trim();
+    if line.is_empty() {
+        return None;
+    }
+
+    let tokens: Vec<&str> = line.split_whitespace().collect();
+
+    // `ls -l` emits a "total NNN" summary as its first line — never a file entry.
+    if tokens.len() >= 2 && tokens[0].eq_ignore_ascii_case("total") {
+        return None;
+    }
+
+    // Must start with a perms-like token (`d`/`l`/`-` + 9 rwx/- chars, optional `+`/`.`).
+    let perms_str = tokens.first()?;
+    if !is_perms_token(perms_str) {
+        return None;
+    }
+
+    let file_type = if perms_str.starts_with('d') {
+        FileEntryType::Directory
+    } else if perms_str.starts_with('l') {
+        FileEntryType::Symlink
+    } else {
+        FileEntryType::File
+    };
+
+    // Locate the date field and figure out how many trailing tokens belong to it.
+    // `date_len` is the number of tokens occupied by the date/time columns.
+    let (date_start, date_len, modified) = locate_date(&tokens)?;
+
+    // Name is everything after the date columns (preserves embedded spaces).
+    let name_end = date_start + date_len;
+    if name_end >= tokens.len() {
+        return None;
+    }
+    let name_raw = tokens[name_end..].join(" ");
+    // For symlinks, strip the " -> target" suffix.
+    let name = if matches!(file_type, FileEntryType::Symlink) {
+        name_raw
+            .split(" -> ")
+            .next()
+            .unwrap_or(&name_raw)
+            .to_string()
+    } else {
+        name_raw
+    };
+
+    if name.is_empty() || name == "." || name == ".." {
+        // Caller filters `.`/`..` too, but be defensive.
+        if name == "." || name == ".." {
+            return None;
+        }
+        return None;
+    }
+
+    // Size is the rightmost numeric token strictly left of the date columns.
+    let size = tokens[..date_start]
+        .iter()
+        .rev()
+        .find_map(|t| t.parse::<u64>().ok())
+        .unwrap_or(0);
+
+    Some(FileEntry {
+        name,
+        size,
+        modified,
+        permissions: Some(perms_str.to_string()),
+        file_type,
+    })
+}
+
+/// True for a Unix permission string like `drwxr-xr-x`, `-rw-r--r--`,
+/// `lrwxrwxrwx`, optionally with an ACL (`+`) or SELinux-context (`.`) suffix.
+fn is_perms_token(s: &str) -> bool {
+    // Bare perms are 10 chars: 1 type char (`d`/`l`/`-`) + 9 rwx/- chars.
+    // An ACL (`+`) or SELinux-context (`.`) suffix adds one more char → 11.
+    let bytes = s.as_bytes();
+    let body_len = bytes.len();
+    if !(10..=11).contains(&body_len) {
+        return false;
+    }
+    if !matches!(bytes[0], b'd' | b'l' | b'-') {
+        return false;
+    }
+    // Positions 1..=9 (9 chars) must all be r/w/x/-.
+    bytes[1..10]
+        .iter()
+        .all(|&b| matches!(b, b'r' | b'w' | b'x' | b'-'))
+}
+
+/// Locate the date columns inside `tokens` and return
+/// `(start_index, token_count, parsed_modified_string)`.
+///
+/// Tries the GNU long-iso layout first (`YYYY-MM-DD` followed by `HH:MM`),
+/// then the BusyBox/BSD layout (`Mon DD HH:MM` or `Mon DD YYYY`).
+fn locate_date(tokens: &[&str]) -> Option<(usize, usize, Option<String>)> {
+    if let Some(idx) = find_long_iso_date(tokens) {
+        // GNU long-iso: date(1) + time(1) = 2 tokens, then filename.
+        let date_str = tokens[idx];
+        let time_str = tokens[idx + 1];
+        Some((idx, 2, Some(format!("{} {}", date_str, time_str))))
+    } else if let Some(idx) = find_month_date(tokens) {
+        // BusyBox/BSD: month + day + time_or_year = 3 tokens, then filename.
+        let month = tokens[idx];
+        let day = tokens[idx + 1];
+        let time_or_year = tokens[idx + 2];
+        Some((idx, 3, parse_month_style_date(month, day, time_or_year)))
+    } else {
+        None
+    }
+}
+
+/// Find a GNU long-iso date pair (`YYYY-MM-DD` at `i`, `HH:MM` at `i+1`).
+fn find_long_iso_date(tokens: &[&str]) -> Option<usize> {
+    // Need at least: [.., date, time, name] → 1 token after the pair.
+    let upper = tokens.len().saturating_sub(2);
+    (0..upper).find(|&i| {
+        is_long_iso_date(tokens[i]) && is_hh_mm(tokens.get(i + 1).copied())
+    })
+}
+
+/// Find a BusyBox/BSD date triple (`Mon` at `i`, day at `i+1`, time/year at `i+2`).
+fn find_month_date(tokens: &[&str]) -> Option<usize> {
+    let upper = tokens.len().saturating_sub(3);
+    (0..upper).find(|&i| {
+        is_month_abbr(tokens[i])
+            && is_day_token(tokens.get(i + 1).copied())
+            && is_time_or_year_token(tokens.get(i + 2).copied())
+    })
+}
+
+fn is_long_iso_date(s: &str) -> bool {
+    // `YYYY-MM-DD` — 10 chars: 4 digits, '-', 2 digits, '-', 2 digits.
+    let bytes = s.as_bytes();
+    if bytes.len() != 10 {
+        return false;
+    }
+    bytes[0..4].iter().all(|b| b.is_ascii_digit())
+        && bytes[4] == b'-'
+        && bytes[5..7].iter().all(|b| b.is_ascii_digit())
+        && bytes[7] == b'-'
+        && bytes[8..10].iter().all(|b| b.is_ascii_digit())
+}
+
+fn is_hh_mm(s: Option<&str>) -> bool {
+    let Some(s) = s else { return false };
+    let bytes = s.as_bytes();
+    if bytes.len() != 5 || bytes[2] != b':' {
+        return false;
+    }
+    bytes[0..2].iter().all(|b| b.is_ascii_digit())
+        && bytes[3..5].iter().all(|b| b.is_ascii_digit())
+}
+
+fn is_month_abbr(s: &str) -> bool {
+    matches!(
+        s,
+        "Jan"
+            | "Feb"
+            | "Mar"
+            | "Apr"
+            | "May"
+            | "Jun"
+            | "Jul"
+            | "Aug"
+            | "Sep"
+            | "Oct"
+            | "Nov"
+            | "Dec"
+    )
+}
+
+fn is_day_token(s: Option<&str>) -> bool {
+    let Some(s) = s else { return false };
+    s.trim_end_matches(|c: char| !c.is_ascii_digit())
+        .parse::<u32>()
+        .map(|d| (1..=31).contains(&d))
+        .unwrap_or(false)
+}
+
+fn is_time_or_year_token(s: Option<&str>) -> bool {
+    let Some(s) = s else { return false };
+    if s.contains(':') {
+        // HH:MM
+        let parts: Vec<&str> = s.split(':').collect();
+        parts.len() == 2
+            && parts.iter().all(|p| !p.is_empty() && p.bytes().all(|b| b.is_ascii_digit()))
+    } else {
+        // YYYY — 4-digit year.
+        s.len() == 4 && s.bytes().all(|b| b.is_ascii_digit())
+    }
+}
+
+/// Convert a BusyBox/BSD date triple (`Mon DD HH:MM` or `Mon DD YYYY`) into an
+/// ISO-style `"YYYY-MM-DD HH:MM:SS"` string. Returns `None` if the month is
+/// unrecognised. For recent files (`HH:MM`), the current year is used because
+/// `ls` deliberately omits it.
+fn parse_month_style_date(month: &str, day: &str, time_or_year: &str) -> Option<String> {
+    let month_num = match month {
+        "Jan" => 1u32,
+        "Feb" => 2,
+        "Mar" => 3,
+        "Apr" => 4,
+        "May" => 5,
+        "Jun" => 6,
+        "Jul" => 7,
+        "Aug" => 8,
+        "Sep" => 9,
+        "Oct" => 10,
+        "Nov" => 11,
+        "Dec" => 12,
+        _ => return None,
+    };
+    let day: u32 = day.parse().unwrap_or(1);
+
+    if time_or_year.contains(':') {
+        // Recent file: "HH:MM" — use current year, seconds = 00.
+        let parts: Vec<&str> = time_or_year.splitn(2, ':').collect();
+        let hh: u32 = parts.first().and_then(|s| s.parse().ok()).unwrap_or(0);
+        let mm: u32 = parts.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+        let current_year = current_year();
+        Some(format!(
+            "{:04}-{:02}-{:02} {:02}:{:02}:00",
+            current_year, month_num, day, hh, mm
+        ))
+    } else {
+        // Older file: "YYYY" — time is 00:00:00.
+        let year: u32 = time_or_year.parse().unwrap_or(1970);
+        Some(format!("{:04}-{:02}-{:02} 00:00:00", year, month_num, day))
+    }
+}
+
+fn current_year() -> u32 {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_secs();
+    let days = now / 86400;
+    let mut y = 1970i64;
+    let mut rem = days as i64;
+    loop {
+        let dy = if is_leap_year(y) { 366 } else { 365 };
+        if rem < dy {
+            break;
+        }
+        rem -= dy;
+        y += 1;
+    }
+    y as u32
+}
+
+fn is_leap_year(y: i64) -> bool {
+    (y % 4 == 0 && y % 100 != 0) || (y % 400 == 0)
+}
+
+// =============================================================================
+// Unit tests
+// =============================================================================
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ---- GNU long-iso format (SSH with --time-style=long-iso) ----
+
+    #[test]
+    fn test_gnu_long_iso_directory() {
+        let line = "drwxr-xr-x  5 root root  4096 2025-01-15 12:32 dev";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert!(matches!(entry.file_type, FileEntryType::Directory));
+        assert_eq!(entry.size, 4096);
+        assert_eq!(entry.modified.as_deref(), Some("2025-01-15 12:32"));
+        assert_eq!(entry.permissions.as_deref(), Some("drwxr-xr-x"));
+    }
+
+    #[test]
+    fn test_gnu_long_iso_file() {
+        let line = "-rw-r--r--  1 root root 85234 2000-11-09 00:00 gamelist.xml";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert!(matches!(entry.file_type, FileEntryType::File));
+        assert_eq!(entry.size, 85234);
+        assert_eq!(entry.modified.as_deref(), Some("2000-11-09 00:00"));
+    }
+
+    #[test]
+    fn test_gnu_long_iso_name_with_spaces() {
+        let line = "-rw-r--r--  1 root root  100 2024-12-25 23:59 my report.pdf";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "my report.pdf");
+        assert_eq!(entry.size, 100);
+        assert_eq!(entry.modified.as_deref(), Some("2024-12-25 23:59"));
+    }
+
+    #[test]
+    fn test_gnu_long_iso_symlink() {
+        let line = "lrwxrwxrwx  1 root root    10 2024-03-01 09:00 link -> target";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "link");
+        assert!(matches!(entry.file_type, FileEntryType::Symlink));
+    }
+
+    // ---- BusyBox / default ls format (SSH without --time-style) ----
+
+    #[test]
+    fn test_busybox_recent_directory() {
+        // The exact line that produced the user-reported "12:32 dev" bug.
+        let line = "drwxr-xr-x  5 root root  4096 Jan 15 12:32 dev";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert!(matches!(entry.file_type, FileEntryType::Directory));
+        assert_eq!(entry.size, 4096);
+        // Recent file → current year, time preserved.
+        assert!(
+            entry.modified.as_deref().unwrap_or("").ends_with("-01-15 12:32:00"),
+            "modified should preserve Jan 15 12:32, got: {:?}",
+            entry.modified
+        );
+    }
+
+    #[test]
+    fn test_busybox_recent_file() {
+        let line = "drwxr-xr-x  2 root root  4096 Jul 25 12:46 Pacman";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "Pacman");
+        assert_eq!(entry.size, 4096);
+    }
+
+    #[test]
+    fn test_busybox_old_file_year() {
+        // Older file → year shown instead of time.
+        let line = "-rw-r--r--  1 root root 85234 Nov  9  2000 gamelist.xml";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert_eq!(entry.size, 85234);
+        assert_eq!(entry.modified.as_deref(), Some("2000-11-09 00:00:00"));
+    }
+
+    #[test]
+    fn test_busybox_padded_day_double_space() {
+        // GNU/BSD pad single-digit days with a leading space → two spaces in output.
+        let line = "-rw-r--r-- 1 root root 85234 Nov 09  2000 gamelist.xml";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert_eq!(entry.modified.as_deref(), Some("2000-11-09 00:00:00"));
+    }
+
+    // ---- Real-world column variants ----
+
+    #[test]
+    fn test_no_group_column_busybox() {
+        // Embedded BusyBox sometimes omits the group column entirely.
+        let line = "-rw-r--r-- 1 root 85234 Jan 15 12:32 gamelist.xml";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "gamelist.xml");
+        assert_eq!(entry.size, 85234);
+        assert!(entry.modified.is_some());
+    }
+
+    #[test]
+    fn test_acl_plus_suffix() {
+        let line = "drwxr-xr-x+ 3 root root 4096 Feb 28  2024 with spaces in name";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "with spaces in name");
+        assert_eq!(entry.size, 4096);
+        assert_eq!(entry.modified.as_deref(), Some("2024-02-28 00:00:00"));
+    }
+
+    #[test]
+    fn test_selinux_context_suffix() {
+        let line = "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 Jan 15 12:32 dev";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert_eq!(entry.size, 4096);
+    }
+
+    #[test]
+    fn test_numeric_owner_group() {
+        let line = "drwxr-xr-x 2 1000 1000 4096 Mar 01 09:15 shared";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "shared");
+        assert_eq!(entry.size, 4096);
+    }
+
+    #[test]
+    fn test_selinux_context_with_long_iso() {
+        // SELinux context column + GNU long-iso date.
+        let line =
+            "drwxr-xr-x. 2 root root system_u:object_r:default_t 4096 2025-01-15 12:32 dev";
+        let entry = parse_ls_long_line(line).expect("should parse");
+        assert_eq!(entry.name, "dev");
+        assert_eq!(entry.size, 4096);
+        assert_eq!(entry.modified.as_deref(), Some("2025-01-15 12:32"));
+    }
+
+    // ---- Edge cases ----
+
+    #[test]
+    fn test_empty_line() {
+        assert!(parse_ls_long_line("").is_none());
+        assert!(parse_ls_long_line("   ").is_none());
+    }
+
+    #[test]
+    fn test_total_line_ignored() {
+        assert!(parse_ls_long_line("total 123").is_none());
+        assert!(parse_ls_long_line("total 0").is_none());
+    }
+
+    #[test]
+    fn test_dot_entries_filtered() {
+        assert!(parse_ls_long_line("drwxr-xr-x 2 root root 4096 Jan 01 00:00 .").is_none());
+        assert!(parse_ls_long_line("drwxr-xr-x 2 root root 4096 Jan 01 00:00 ..").is_none());
+    }
+
+    #[test]
+    fn test_non_ls_line_ignored() {
+        // Random shell output that doesn't look like an ls entry.
+        assert!(parse_ls_long_line("drwxr-xr-x").is_none()); // too few tokens
+        assert!(parse_ls_long_line("hello world foo bar").is_none()); // no perms
+    }
+
+    /// End-to-end regression test reproducing the user-reported symptoms on a
+    /// MAME/arcade-style SSH host whose `ls` is BusyBox (no `--time-style`).
+    #[test]
+    fn test_user_scenario_arcade_box_busybox() {
+        let lines = [
+            "drwxr-xr-x 2 root root 4096 Jan 15 12:32 dev",
+            "drwxr-xr-x 2 root root 4096 Jan 15 12:32 proc",
+            "drwxr-xr-x 2 root root 4096 Jan 15 12:32 sys",
+            "drwxr-xr-x 2 root root 4096 Jul 25 12:46 Pacman",
+            "drwxr-xr-x 2 root root 4096 Jul 25 12:46 SEGA",
+            "drwxr-xr-x 2 root root 4096 Jul 25 12:46 Taito",
+            "-rw-r--r-- 1 root root 85234 Nov 09  2000 gamelist.xml",
+        ];
+
+        for (i, line) in lines.iter().enumerate() {
+            let entry = parse_ls_long_line(line)
+                .unwrap_or_else(|| panic!("line {} should parse: {}", i, line));
+            // The buggy old parser produced names like "12:32 dev", "2000 gamelist.xml".
+            assert!(
+                !entry.name.starts_with('1') && !entry.name.starts_with('2'),
+                "name should not leak time/year token, got: {:?}",
+                entry.name
+            );
+        }
+
+        let dev = parse_ls_long_line(lines[0]).unwrap();
+        assert_eq!(dev.name, "dev");
+
+        let pacman = parse_ls_long_line(lines[3]).unwrap();
+        assert_eq!(pacman.name, "Pacman");
+
+        let gamelist = parse_ls_long_line(lines[6]).unwrap();
+        assert_eq!(gamelist.name, "gamelist.xml");
+        assert_eq!(gamelist.size, 85234);
+        assert_eq!(gamelist.modified.as_deref(), Some("2000-11-09 00:00:00"));
+    }
+}

--- a/src-tauri/src/ls_parser.rs
+++ b/src-tauri/src/ls_parser.rs
@@ -485,4 +485,45 @@ mod tests {
         assert_eq!(gamelist.size, 85234);
         assert_eq!(gamelist.modified.as_deref(), Some("2000-11-09 00:00:00"));
     }
+
+    /// OpenWrt ships BusyBox `ls` by default, so the backend runs plain
+    /// `ls -la` (no `--time-style`). This reproduces the exact failure the user
+    /// saw on their OpenWrt router: right-aligned, space-padded columns and the
+    /// default `Mon DD HH:MM` / `Mon DD YYYY` date layout.
+    #[test]
+    fn test_user_scenario_openwrt_busybox() {
+        let lines = [
+            "drwxr-xr-x    1 root     root           104 Jan 15 12:32 dev",
+            "drwxr-xr-x    1 root     root             0 Jan 15 12:32 proc",
+            "drwxr-xr-x    1 root     root             0 Jan 15 12:32 sys",
+            "drwxr-xr-x    2 root     root          4096 Jul 25 12:46 Pacman",
+            "drwxr-xr-x    2 root     root          4096 Jul 25 12:46 SEGA",
+            "-rw-r--r--    1 root     root         85234 Nov  9  2000 gamelist.xml",
+            "lrwxrwxrwx    1 root     root            11 Jan 15 12:32 sbin -> usr/sbin",
+        ];
+
+        let dev = parse_ls_long_line(lines[0]).expect("dev must parse");
+        assert_eq!(dev.name, "dev");
+        assert_eq!(dev.size, 104);
+        assert!(matches!(dev.file_type, FileEntryType::Directory));
+
+        let proc_entry = parse_ls_long_line(lines[1]).expect("proc must parse");
+        assert_eq!(proc_entry.name, "proc");
+        assert_eq!(proc_entry.size, 0);
+
+        let pacman = parse_ls_long_line(lines[3]).expect("Pacman must parse");
+        assert_eq!(pacman.name, "Pacman");
+        assert_eq!(pacman.size, 4096);
+
+        // Older file → year is shown; time defaults to 00:00:00.
+        let gamelist = parse_ls_long_line(lines[5]).expect("gamelist.xml must parse");
+        assert_eq!(gamelist.name, "gamelist.xml");
+        assert_eq!(gamelist.size, 85234);
+        assert_eq!(gamelist.modified.as_deref(), Some("2000-11-09 00:00:00"));
+
+        // Symlink target must be stripped from the name.
+        let sbin = parse_ls_long_line(lines[6]).expect("sbin symlink must parse");
+        assert_eq!(sbin.name, "sbin");
+        assert!(matches!(sbin.file_type, FileEntryType::Symlink));
+    }
 }

--- a/src/__tests__/connection.test.ts
+++ b/src/__tests__/connection.test.ts
@@ -104,24 +104,26 @@ describe('SSH Connection Tests', () => {
   }, 5000);
 
   it('should list files in home directory', async () => {
-    const result = await invoke<{ 
-      success: boolean; 
-      files?: Array<{
-        name: string;
-        size: number;
-        is_dir: boolean;
-        modified: string;
-        permissions: string;
-      }>; 
-      error?: string 
-    }>('list_files', {
+    const result = await invoke<Array<{
+      name: string;
+      size: number;
+      modified: string | null;
+      permissions: string | null;
+      file_type: 'File' | 'Directory' | 'Symlink';
+    }>>('list_files', {
       connection_id: connectionId,
       path: '~'
     });
 
-    expect(result.success).toBe(true);
-    expect(result.files).toBeDefined();
-    expect(Array.isArray(result.files)).toBe(true);
+    expect(Array.isArray(result)).toBe(true);
+    // Every entry must have a non-empty name that does not leak time/date
+    // tokens (the regression we fixed for non-GNU ls output).
+    for (const entry of result) {
+      expect(typeof entry.name).toBe('string');
+      expect(entry.name.length).toBeGreaterThan(0);
+      expect(entry.name).not.toBe('.');
+      expect(entry.name).not.toBe('..');
+    }
   }, 5000);
 
   it('should fail with invalid credentials', async () => {

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -464,18 +464,14 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   const loadSSHDirectories = useCallback(async (path: string): Promise<string[]> => {
     if (!connectionId || !isConnected) return [];
     try {
-      const output = await invoke<string>('list_files', { connectionId, path });
-      if (!output) return [];
-      const lines = output.split('\n').filter(l => l.trim() && !l.startsWith('total'));
-      const dirs: string[] = [];
-      for (const line of lines) {
-        const parts = line.trim().split(/\s+/);
-        if (parts.length >= 8 && parts[0].startsWith('d')) {
-          const name = parts.slice(7).join(' ');
-          if (name && name !== '.' && name !== '..') dirs.push(name);
-        }
-      }
-      return dirs;
+      const entries = await invoke<Array<{ name: string; file_type: 'File' | 'Directory' | 'Symlink' }>>(
+        'list_files',
+        { connectionId, path },
+      );
+      // Backend already filters `.`/`..` and returns structured types.
+      return entries
+        .filter((e) => e.file_type === 'Directory')
+        .map((e) => e.name);
     } catch {
       return [];
     }
@@ -537,59 +533,43 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
       // successful await, so stale calls from a previous connection are
       // discarded without showing an error toast.  maxRetries=2 means up
       // to 3 total attempts with 1 s → 2 s backoff.
-      const output = await withRetry(
-        () => invoke<string>('list_files', { connectionId, path: targetPath }),
+      const entries = await withRetry(
+        () => invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink' }>>(
+          'list_files',
+          { connectionId, path: targetPath },
+        ),
         isCancelled,
         { maxRetries: 2, baseDelayMs: 1000 },
       );
-      
-      if (output && output.trim()) {
-        // Parse ls -la --time-style=long-iso output to FileItem format
-        // Format: perms links owner group size date time filename
-        // Example: drwxr-xr-x  5 root root 72 2025-09-17 03:38 giga-sls
-        const lines = output.split('\n').filter(l => l.trim() && !l.startsWith('total'));
-        
-        const parsedFiles: FileItem[] = lines.map(line => {
-          const parts = line.trim().split(/\s+/);
-          
-          if (parts.length < 8) {
-            return null;
-          }
-          
-          const permissions = parts[0];
-          const owner = parts[2];
-          const group = parts[3];
-          const size = parseInt(parts[4]) || 0;
-          // parts[5] is date (YYYY-MM-DD), parts[6] is time (HH:MM), parts[7+] is filename
-          const dateStr = parts[5];
-          const timeStr = parts[6];
-          const name = parts.slice(7).join(' ');
-          const type: 'directory' | 'file' = permissions.startsWith('d') ? 'directory' : 'file';
-          
-          // Parse the modification date from ls output
+
+      if (entries && entries.length > 0) {
+        // The backend now returns structured FileEntry values (parsed in Rust),
+        // so we no longer need to interpret the `ls -l` column layout here.
+        // The Rust `ls_parser` handles GNU long-iso, BusyBox/BSD default,
+        // ACL/SELinux/no-group variants — see src-tauri/src/ls_parser.rs.
+        const parsedFiles: FileItem[] = entries.map((entry) => {
+          const type: 'directory' | 'file' =
+            entry.file_type === 'Directory' ? 'directory' : 'file';
+          // `modified` is either null or an ISO-style string from the backend
+          // ("YYYY-MM-DD HH:MM" or "YYYY-MM-DD HH:MM:SS"). Replace the space
+          // with "T" so Date parses it as local time, not UTC.
           let modifiedDate = new Date();
-          if (dateStr && timeStr) {
-            // Combine date and time: "2025-01-15 14:30" -> "2025-01-15T14:30"
-            modifiedDate = new Date(`${dateStr}T${timeStr}`);
+          if (entry.modified) {
+            const parsed = new Date(entry.modified.replace(' ', 'T'));
+            if (!isNaN(parsed.getTime())) modifiedDate = parsed;
           }
-          
-          // Skip . and .. entries
-          if (name === '.' || name === '..') {
-            return null;
-          }
-          
           return {
-            name,
+            name: entry.name,
             type,
-            size,
+            size: entry.size,
             modified: modifiedDate,
-            permissions,
-            owner,
-            group,
-            path: targetPath === '/' ? `/${name}` : `${targetPath}/${name}`
+            permissions: entry.permissions ?? '',
+            owner: '-',
+            group: '-',
+            path: targetPath === '/' ? `/${entry.name}` : `${targetPath}/${entry.name}`,
           };
-        }).filter(f => f !== null);
-        
+        });
+
         // Add parent directory navigation
         if (targetPath !== '/') {
           parsedFiles.unshift({

--- a/src/components/sftp-panel.tsx
+++ b/src/components/sftp-panel.tsx
@@ -84,39 +84,35 @@ export function SFTPPanel({
   // Load files from remote server
   const loadRemoteFiles = async (path: string) => {
     if (!connectionId) return;
-    
+
     try {
       setLoading(true);
-      const output = await invoke<string>(
+      const entries = await invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink' }>>(
         'list_files',
         { connection_id: connectionId, path }
       );
-      
-      if (output) {
-        // Parse ls -la output to FileItem format
-        const lines = output.split('\n').filter(l => l.trim() && !l.startsWith('total'));
-        const parsedFiles: FileItem[] = lines.map(line => {
-          const parts = line.trim().split(/\s+/);
-          if (parts.length < 9) return null;
-          
-          const permissions = parts[0];
-          const owner = parts[2];
-          const group = parts[3];
-          const size = parseInt(parts[4]) || 0;
-          const name = parts.slice(8).join(' ');
-          const type: 'directory' | 'file' = permissions.startsWith('d') ? 'directory' : 'file';
-          
+
+      if (entries) {
+        // Backend returns structured FileEntry values; no ls column parsing here.
+        const parsedFiles: FileItem[] = entries.map((entry) => {
+          const type: 'directory' | 'file' =
+            entry.file_type === 'Directory' ? 'directory' : 'file';
+          let modified = new Date();
+          if (entry.modified) {
+            const parsed = new Date(entry.modified.replace(' ', 'T'));
+            if (!isNaN(parsed.getTime())) modified = parsed;
+          }
           return {
-            name,
+            name: entry.name,
             type,
-            size,
-            modified: new Date(),
-            permissions,
-            owner,
-            group
+            size: entry.size,
+            modified,
+            permissions: entry.permissions ?? '',
+            owner: '-',
+            group: '-',
           };
-        }).filter(f => f !== null);
-        
+        });
+
         // Add parent directory navigation
         if (path !== '/') {
           parsedFiles.unshift({
@@ -129,7 +125,7 @@ export function SFTPPanel({
             group: '-'
           });
         }
-        
+
         setFiles(parsedFiles);
       }
     } catch (error) {


### PR DESCRIPTION
## Summary

Fixes #63 — “很奇怪的 远程展示”

After connecting to an SSH host whose `ls` is BusyBox/BSD (arcade/emulator boxes, embedded Linux, macOS), the file browser rendered corrupted entries:

- Directories: `12:32 dev`, `12:32 proc`, `12:32 sys` (time token leaked into name)
- Files: `2025 Pacman`, `12:46 amelist xml` (should be `gamelist.xml`)
- Modified column: bogus dates like `2000-11-09 00:00:00`

## Root cause

`list_files` returned the raw `ls -l` string to the frontend, which parsed it with **fixed indices** assuming the GNU `--time-style=long-iso` layout (`YYYY-MM-DD HH:MM name`). The backend picks `ls -la --time-style=long-iso` only when GNU coreutils are detected — on BusyBox/BSD it runs plain `ls -la`, whose default format is `Mon DD HH:MM name`. The column shift made the time/year tokens collapse into the filename field.

## Fix

Parse `ls -l` output on the **backend** and return structured `Vec<FileEntry>`. The frontend no longer interprets column layout.

**New `src-tauri/src/ls_parser.rs`** locates the date field by pattern (column-count agnostic) and transparently supports:

| Format | Example |
|--------|---------|
| GNU long-iso | `drwxr-xr-x 5 root root 4096 2025-01-15 12:32 dev` |
| BusyBox/BSD recent | `drwxr-xr-x 5 root root 4096 Jan 15 12:32 dev` |
| BusyBox/BSD older | `-rw-r--r-- 1 root root 85234 Nov 09 2000 gamelist.xml` |

Plus real-world variants: ACL (`+`) / SELinux (`.`) perms suffix, extra SELinux context column, missing group column, numeric owner/group, symlink targets, filenames with spaces.

### Files changed
- `src-tauri/src/ls_parser.rs` *(new)* — robust column-agnostic parser
- `src-tauri/src/commands.rs` — `list_files` returns `Vec<FileEntry>`
- `src-tauri/src/lib.rs` — register module
- `src/components/integrated-file-browser.tsx` — consume `FileEntry[]`; remove string parsing (file list + dir tree)
- `src/components/sftp-panel.tsx` — consume `FileEntry[]`; remove string parsing
- `src/__tests__/connection.test.ts` — align test contract with new return type

### Drive-by
`ftp_client::parse_ftp_list_line` had the same fixed-index bug for SELinux-context / no-group listings. Applied the same robust algorithm there with 10 new regression tests. Chosen to bundle per discussion (same class of bug, keeps the codebase consistent).

## Test plan

| Check | Result |
|-------|--------|
| `ls_parser` unit tests (18, incl. end-to-end arcade-box scenario) | ✅ pass |
| `ftp_client` regression tests (+10) | ✅ pass |
| Full Rust suite `cargo test --lib` | ✅ **105 passed**, 0 failed, 5 ignored |
| Frontend Vitest | ✅ **508 passed**, 0 failed |
| `tsc --noEmit` | ✅ clean |
| ESLint on changed files | ✅ 0 errors (only pre-existing react-hooks v7 warnings) |

Verified the parser reproduces the user’s exact symptoms with the buggy logic (`name="12:32 dev"`, `name="2000 gamelist.xml"`) and produces clean output (`name="dev"`, `name="gamelist.xml"`, `modified="2000-11-09 00:00:00"`) after the fix.

Closes #63