### PR TITLE
feat(connection-dialog): add password visibility toggles

### DIFF
--- a/docs/superpowers/specs/2026-08-06-password-view-toggle-design.md
+++ b/docs/superpowers/specs/2026-08-06-password-view-toggle-design.md
@@ -1,0 +1,72 @@
+# Password View Toggle Design
+
+## Context
+
+The connection dialog has three password-style fields, all plain `<Input type="password">` elements in `src/components/connection-dialog.tsx`:
+
+- Password field (`connection-dialog.tsx:795`)
+- SSH passphrase field (`connection-dialog.tsx:821`)
+- Proxy password field (`connection-dialog.tsx:942`)
+
+None of them offer a way to reveal what was typed, and there is no shared password input component in `src/components/ui/`. The shared `Input` component (`src/components/ui/input.tsx`) only forwards the `type` prop.
+
+## Goal
+
+Give every password field a **view/hide password** toggle so users can verify what they typed before connecting. Introduce one reusable `PasswordInput` component so all three fields share the same behavior and styling.
+
+## Design
+
+### New component: `src/components/ui/password-input.tsx`
+
+A small wrapper around the existing `Input` that adds a show/hide control:
+
+- Maintains internal `show` state (defaults to `false`, i.e. hidden).
+- Renders a `relative` wrapper containing the `Input` and an absolutely-positioned icon button on the right (`Eye` when hidden, `EyeOff` when shown).
+- Toggles the inner input's `type` between `"password"` and `"text"` based on `show`.
+- Adds right padding (`pr-10`) to the input so typed text does not run under the button.
+- The button carries an accessible `aria-label`/`title` reflecting the next action — `"Show password"` when hidden, `"Hide password"` when shown. These labels are hardcoded English in the presentational component (consistent with the other `ui/*` components being i18n-free); the connection dialog's surrounding labels already come from `t()`.
+- Spreads all remaining props (`id`, `value`, `onChange`, `placeholder`, `className`, …) through to the inner `Input`, so labels (`htmlFor`/`id`), controlled state, and tests keep working unchanged.
+
+```tsx
+// Illustrative — not final implementation.
+function PasswordInput({ className, ...props }: React.ComponentProps<"input">) {
+  const [show, setShow] = useState(false);
+  return (
+    <div className="relative">
+      <Input type={show ? "text" : "password"} className={cn("pr-10", className)} {...props} />
+      <button
+        type="button"
+        onClick={() => setShow((v) => !v)}
+        aria-label={show ? "Hide password" : "Show password"}
+        title={show ? "Hide password" : "Show password"}
+      >
+        {show ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
+      </button>
+    </div>
+  );
+}
+```
+
+### Swap the three fields
+
+Replace `<Input type="password" …>` with `<PasswordInput …>` in the three locations listed above, keeping each field's `id`, `placeholder`, `value`, and `onChange`.
+
+## Accessibility
+
+- The toggle is a real `<button type="button">`, so it does not submit forms and is keyboard-reachable.
+- It announces its purpose via `aria-label`/`title`, which flips with the current state ("Show"/"Hide").
+- The inner input remains associated with its `Label` through the unchanged `htmlFor`/`id`.
+
+## Error Handling
+
+No new error path. The toggle is purely presentational and never touches config state; a failed or partial render of the button simply leaves the field showing dots, the current default.
+
+## Testing
+
+- Add a focused unit test for `PasswordInput` in `src/__tests__/password-input.test.tsx` (render, toggle `type` between `password`/`text`, `aria-label` flips).
+- Run the existing `connection-dialog*.test.tsx` suites; they query password fields by `getByLabelText('Password')` via the label association, which the wrapper preserves.
+- Run the project type-check and the full `npm test` suite.
+
+## Scope
+
+Limited to the connection dialog's three password fields. No changes to auth logic, config storage, or any non-password inputs. If other password fields appear later, they adopt `PasswordInput` in place of `<Input type="password">`.

--- a/src/__tests__/password-input.test.tsx
+++ b/src/__tests__/password-input.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { PasswordInput } from '../components/ui/password-input';
+
+describe('PasswordInput', () => {
+  it('renders masked by default with a show toggle', () => {
+    render(<PasswordInput id="pw" />);
+    const input = document.getElementById('pw') as HTMLInputElement;
+    expect(input.type).toBe('password');
+    expect(screen.getByRole('button', { name: 'Show password' })).toBeTruthy();
+  });
+
+  it('reveals the value when toggled and hides it again', () => {
+    render(<PasswordInput id="pw" />);
+    const input = document.getElementById('pw') as HTMLInputElement;
+
+    fireEvent.click(screen.getByRole('button', { name: 'Show password' }));
+    expect(input.type).toBe('text');
+    expect(screen.getByRole('button', { name: 'Hide password' })).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: 'Hide password' }));
+    expect(input.type).toBe('password');
+  });
+
+  it('passes through value and change events', () => {
+    const onChange = vi.fn();
+    render(<PasswordInput id="pw" value="s3cret" onChange={onChange} />);
+    const input = document.getElementById('pw') as HTMLInputElement;
+    expect(input.value).toBe('s3cret');
+    fireEvent.change(input, { target: { value: 'new' } });
+    expect(onChange).toHaveBeenCalled();
+  });
+});

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
+import { PasswordInput } from './ui/password-input';
 import { Label } from './ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './ui/tabs';
@@ -790,9 +791,8 @@ const handleCancelConnectionAttempt = async () => {
                 {config.authMethod === 'password' && (
                   <div className="space-y-2">
                     <Label htmlFor="password">{t('connectionDialog.label.password')}</Label>
-                    <Input
+                    <PasswordInput
                       id="password"
-                      type="password"
                       placeholder={t('connectionDialog.placeholder.password')}
                       value={config.password}
                       onChange={(e) => updateConfig({ password: e.target.value })}
@@ -816,9 +816,8 @@ const handleCancelConnectionAttempt = async () => {
                     </div>
                     <div className="space-y-2">
                       <Label htmlFor="passphrase">{t('connectionDialog.label.passphrase')}</Label>
-                      <Input
+                      <PasswordInput
                         id="passphrase"
-                        type="password"
                         placeholder={t('connectionDialog.placeholder.passphrase')}
                         value={config.passphrase}
                         onChange={(e) => updateConfig({ passphrase: e.target.value })}
@@ -937,9 +936,8 @@ const handleCancelConnectionAttempt = async () => {
                       </div>
                       <div className="space-y-2">
                         <Label htmlFor="proxy-password">{t('connectionDialog.label.proxyPassword')}</Label>
-                        <Input
+                        <PasswordInput
                           id="proxy-password"
-                          type="password"
                           placeholder={t('connectionDialog.placeholder.proxyPassword')}
                           value={config.proxyPassword}
                           onChange={(e) => updateConfig({ proxyPassword: e.target.value })}

--- a/src/components/ui/password-input.tsx
+++ b/src/components/ui/password-input.tsx
@@ -1,0 +1,31 @@
+import * as React from "react";
+import { Eye, EyeOff } from "lucide-react";
+import { Button } from "./button";
+import { Input } from "./input";
+import { cn } from "./utils";
+
+function PasswordInput({ className, type: _type, ...props }: React.ComponentProps<"input">) {
+  const [show, setShow] = React.useState(false);
+  return (
+    <div className="relative">
+      <Input
+        type={show ? "text" : "password"}
+        className={cn("pr-10", className)}
+        {...props}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="absolute right-1 top-1/2 h-7 w-7 -translate-y-1/2 text-muted-foreground hover:text-foreground"
+        aria-label={show ? "Hide password" : "Show password"}
+        title={show ? "Hide password" : "Show password"}
+        onClick={() => setShow((v) => !v)}
+      >
+        {show ? <EyeOff /> : <Eye />}
+      </Button>
+    </div>
+  );
+}
+
+export { PasswordInput };


### PR DESCRIPTION
## Summary

- add a reusable `PasswordInput` component with Eye/EyeOff show-hide controls
- use it for connection password, private-key passphrase, and proxy password fields
- preserve existing label associations, controlled values, and shared input behavior
- add focused tests for masking, reveal/hide toggling, and change-event passthrough

## Testing

- `npm test` — 44 files, 544 tests passed
- `npx tsc --noEmit` — passed

## Notes

- password fields remain masked by default and reset to masked when remounted
- toggle buttons use `type=\"button\"` and action-based accessibility labels

🤖 Generated with [Claude Code](https://claude.com/claude-code)