### PR TITLE
chore(skills): expose repo skills to Claude Code via .claude/skills symlink

### DIFF
--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.github/skills


### PR DESCRIPTION
Mirrors the `labelize` repo layout: skills live in `.github/skills/<name>/SKILL.md` and `.claude/skills` is a relative symlink to `../.github/skills`, so Claude Code picks up repository skills (e.g. `release-version`).

- Adds `.claude/skills` → `../.github/skills` (committed as symlink, mode 120000; blob identical to labelize's)
- No skill content changes — existing `.github/skills/release-version` is now discoverable