### PR TITLE
fix(file-browser): show owner and group in SSH file listings

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2695,12 +2695,24 @@ pub async fn list_local_files(path: String) -> Result<Vec<FileEntry>, String> {
         #[cfg(not(unix))]
         let permissions: Option<String> = None;
 
+        // Numeric uid/gid — the filesystem exposes ids, not names, without a
+        // passwd/group lookup. Symbolic names come from remote `ls -l` listings.
+        #[cfg(unix)]
+        let (owner, group): (Option<String>, Option<String>) = {
+            use std::os::unix::fs::MetadataExt;
+            (Some(metadata.uid().to_string()), Some(metadata.gid().to_string()))
+        };
+        #[cfg(not(unix))]
+        let (owner, group): (Option<String>, Option<String>) = (None, None);
+
         entries.push(FileEntry {
             name,
             size,
             modified,
             permissions,
             file_type,
+            owner,
+            group,
         });
     }
 

--- a/src-tauri/src/ftp_client.rs
+++ b/src-tauri/src/ftp_client.rs
@@ -342,11 +342,22 @@ fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
 
     // Size is the rightmost numeric token strictly left of the date triple.
     // (Falls back to 0 for listings without a size column — e.g. some minimal daemons.)
-    let size = tokens[..month_idx]
+    // Its index lets us read owner/group relative to it (see below).
+    let size_idx = tokens[..month_idx]
         .iter()
-        .rev()
-        .find_map(|t| t.parse::<u64>().ok())
+        .rposition(|t| t.parse::<u64>().is_ok());
+    let size = size_idx
+        .and_then(|i| tokens[i].parse::<u64>().ok())
         .unwrap_or(0);
+
+    // Owner/group: `perms links owner group [context] size`. Owner is always the
+    // 3rd column; group is the 4th when the size token sits at index 3 or later
+    // (the no-group BusyBox variant drops it, a SELinux context pushes it right).
+    let owner = tokens.get(2).map(|s| s.to_string());
+    let group = match size_idx {
+        Some(i) if i > 3 => tokens.get(3).map(|s| s.to_string()),
+        _ => None,
+    };
 
     Some(FileEntry {
         name,
@@ -354,6 +365,8 @@ fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
         modified,
         permissions: Some(perms_str.to_string()),
         file_type,
+        owner,
+        group,
     })
 }
 
@@ -683,6 +696,8 @@ mod tests {
         assert!(matches!(entry.file_type, FileEntryType::Directory));
         assert_eq!(entry.size, 4096);
         assert_eq!(entry.permissions.as_deref(), Some("drwxr-xr-x"));
+        assert_eq!(entry.owner.as_deref(), Some("user"));
+        assert_eq!(entry.group.as_deref(), Some("group"));
     }
 
     #[test]
@@ -692,6 +707,8 @@ mod tests {
         assert_eq!(entry.name, "report.pdf");
         assert!(matches!(entry.file_type, FileEntryType::File));
         assert_eq!(entry.size, 12345);
+        assert_eq!(entry.owner.as_deref(), Some("user"));
+        assert_eq!(entry.group.as_deref(), Some("group"));
     }
 
     #[test]
@@ -743,6 +760,9 @@ mod tests {
         assert_eq!(entry.name, "dev");
         assert!(matches!(entry.file_type, FileEntryType::Directory));
         assert_eq!(entry.size, 4096);
+        // SELinux context column sits between group and size — group still found.
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group.as_deref(), Some("root"));
         // Time-format date must keep its time-of-day, not bleed into the name.
         assert!(
             entry.modified.as_deref().unwrap_or("").ends_with(" 12:32:00"),
@@ -782,6 +802,9 @@ mod tests {
         assert_eq!(entry.name, "gamelist.xml");
         assert_eq!(entry.size, 85234);
         assert_eq!(entry.permissions.as_deref(), Some("-rw-r--r--"));
+        // No group column → owner parsed, group left as None.
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group, None);
         assert!(
             entry.modified.is_some(),
             "modified should be parsed, got None"
@@ -796,6 +819,8 @@ mod tests {
         assert!(matches!(entry.file_type, FileEntryType::Directory));
         assert_eq!(entry.size, 4096);
         assert!(entry.modified.is_some());
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group, None);
     }
 
     #[test]
@@ -804,6 +829,8 @@ mod tests {
         let entry = parse_ftp_list_line(line).expect("should parse");
         assert_eq!(entry.name, "shared");
         assert_eq!(entry.size, 4096);
+        assert_eq!(entry.owner.as_deref(), Some("1000"));
+        assert_eq!(entry.group.as_deref(), Some("1000"));
     }
 
     #[test]

--- a/src-tauri/src/ftp_client.rs
+++ b/src-tauri/src/ftp_client.rs
@@ -351,8 +351,9 @@ fn parse_ftp_list_line(line: &str) -> Option<FileEntry> {
         .unwrap_or(0);
 
     // Owner/group: `perms links owner group [context] size`. Owner is always the
-    // 3rd column; group is the 4th when the size token sits at index 3 or later
-    // (the no-group BusyBox variant drops it, a SELinux context pushes it right).
+    // 3rd column; group is the 4th when the size token sits at index 4 or later
+    // (a size at index 3 is the no-group BusyBox variant, an optional SELinux
+    // context column pushes size further right).
     let owner = tokens.get(2).map(|s| s.to_string());
     let group = match size_idx {
         Some(i) if i > 3 => tokens.get(3).map(|s| s.to_string()),

--- a/src-tauri/src/ls_parser.rs
+++ b/src-tauri/src/ls_parser.rs
@@ -19,6 +19,11 @@
 //! The parser is column-count agnostic: it locates the date field by pattern
 //! and treats everything to its right as the filename, so adding or removing
 //! an owner/group/context column does not corrupt the result.
+//!
+//! `owner`/`group` are extracted from the fixed left-hand columns
+//! (`perms links owner group [context] size`): owner is always token 2, and
+//! group is token 3 whenever the size token sits at index 3 or later (absent
+//! in the no-group BusyBox variant).
 
 use crate::sftp_client::{FileEntry, FileEntryType};
 
@@ -83,11 +88,23 @@ pub fn parse_ls_long_line(line: &str) -> Option<FileEntry> {
     }
 
     // Size is the rightmost numeric token strictly left of the date columns.
-    let size = tokens[..date_start]
+    // Record its index too so owner/group can be read relative to it.
+    let size_idx = tokens[..date_start]
         .iter()
-        .rev()
-        .find_map(|t| t.parse::<u64>().ok())
+        .rposition(|t| t.parse::<u64>().is_ok());
+    let size = size_idx
+        .and_then(|i| tokens[i].parse::<u64>().ok())
         .unwrap_or(0);
+
+    // Owner/group: `ls -l` lays out `perms links owner group [context] size`.
+    // Owner is always the 3rd column; group is the 4th — when the size lands at
+    // index 3 the group column is absent (busybox-embedded variants), and when
+    // it lands at index 4+ a SELinux context column sits between group and size.
+    let owner = tokens.get(2).map(|s| s.to_string());
+    let group = match size_idx {
+        Some(i) if i > 3 => tokens.get(3).map(|s| s.to_string()),
+        _ => None,
+    };
 
     Some(FileEntry {
         name,
@@ -95,6 +112,8 @@ pub fn parse_ls_long_line(line: &str) -> Option<FileEntry> {
         modified,
         permissions: Some(perms_str.to_string()),
         file_type,
+        owner,
+        group,
     })
 }
 
@@ -300,6 +319,8 @@ mod tests {
         assert_eq!(entry.size, 4096);
         assert_eq!(entry.modified.as_deref(), Some("2025-01-15 12:32"));
         assert_eq!(entry.permissions.as_deref(), Some("drwxr-xr-x"));
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group.as_deref(), Some("root"));
     }
 
     #[test]
@@ -384,6 +405,9 @@ mod tests {
         assert_eq!(entry.name, "gamelist.xml");
         assert_eq!(entry.size, 85234);
         assert!(entry.modified.is_some());
+        // No group column → owner parsed, group left as None.
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group, None);
     }
 
     #[test]
@@ -401,6 +425,9 @@ mod tests {
         let entry = parse_ls_long_line(line).expect("should parse");
         assert_eq!(entry.name, "dev");
         assert_eq!(entry.size, 4096);
+        // SELinux context column sits between group and size — group still found.
+        assert_eq!(entry.owner.as_deref(), Some("root"));
+        assert_eq!(entry.group.as_deref(), Some("root"));
     }
 
     #[test]
@@ -409,6 +436,9 @@ mod tests {
         let entry = parse_ls_long_line(line).expect("should parse");
         assert_eq!(entry.name, "shared");
         assert_eq!(entry.size, 4096);
+        // Numeric uid/gid are the two tokens left of the numeric size.
+        assert_eq!(entry.owner.as_deref(), Some("1000"));
+        assert_eq!(entry.group.as_deref(), Some("1000"));
     }
 
     #[test]
@@ -506,6 +536,8 @@ mod tests {
         assert_eq!(dev.name, "dev");
         assert_eq!(dev.size, 104);
         assert!(matches!(dev.file_type, FileEntryType::Directory));
+        assert_eq!(dev.owner.as_deref(), Some("root"));
+        assert_eq!(dev.group.as_deref(), Some("root"));
 
         let proc_entry = parse_ls_long_line(lines[1]).expect("proc must parse");
         assert_eq!(proc_entry.name, "proc");

--- a/src-tauri/src/ls_parser.rs
+++ b/src-tauri/src/ls_parser.rs
@@ -98,9 +98,9 @@ pub fn parse_ls_long_line(line: &str) -> Option<FileEntry> {
         .unwrap_or(0);
 
     // Owner/group: `ls -l` lays out `perms links owner group [context] size`.
-    // Owner is always the 3rd column; group is the 4th — when the size lands at
-    // index 3 the group column is absent (busybox-embedded variants), and when
-    // it lands at index 4+ a SELinux context column sits between group and size.
+    // Owner is always the 3rd column; group is the 4th whenever the size token
+    // sits at index 4 or later — a size at index 3 marks the no-group BusyBox
+    // variant, and an optional SELinux context column pushes size further right.
     let owner = tokens.get(2).map(|s| s.to_string());
     let group = match size_idx {
         Some(i) if i > 3 => tokens.get(3).map(|s| s.to_string()),

--- a/src-tauri/src/ls_parser.rs
+++ b/src-tauri/src/ls_parser.rs
@@ -22,8 +22,9 @@
 //!
 //! `owner`/`group` are extracted from the fixed left-hand columns
 //! (`perms links owner group [context] size`): owner is always token 2, and
-//! group is token 3 whenever the size token sits at index 3 or later (absent
-//! in the no-group BusyBox variant).
+//! group is token 3 whenever the size token sits at index 4 or later — a size
+//! at index 3 marks the no-group BusyBox variant, and an optional SELinux
+//! context column pushes size further right.
 
 use crate::sftp_client::{FileEntry, FileEntryType};
 

--- a/src-tauri/src/sftp_client.rs
+++ b/src-tauri/src/sftp_client.rs
@@ -39,6 +39,11 @@ pub struct FileEntry {
     pub modified: Option<String>,
     pub permissions: Option<String>,
     pub file_type: FileEntryType,
+    /// Owning user (symbolic name where the backend can resolve it, numeric
+    /// uid otherwise). `None` when the listing doesn't carry the column.
+    pub owner: Option<String>,
+    /// Owning group (symbolic name or numeric gid). `None` when absent.
+    pub group: Option<String>,
 }
 
 /// Backward-compatible alias for code that still references RemoteFileEntry.
@@ -79,6 +84,10 @@ pub(crate) async fn list_sftp_dir(sftp: &SftpSession, path: &str) -> Result<Vec<
             modified: attrs.mtime.map(|t| chrono_from_unix_timestamp(t as u64)),
             permissions: attrs.permissions.map(format_permissions),
             file_type,
+            // SFTP exposes numeric ids only — map them to strings so the UI can
+            // render something real instead of a placeholder.
+            owner: attrs.uid.map(|uid| uid.to_string()),
+            group: attrs.gid.map(|gid| gid.to_string()),
         });
     }
 
@@ -505,6 +514,8 @@ mod tests {
             modified: Some("2024-01-01 00:00:00".to_string()),
             permissions: Some("rw-r--r--".to_string()),
             file_type: FileEntryType::File,
+            owner: None,
+            group: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("\"name\":\"test.txt\""));
@@ -520,6 +531,8 @@ mod tests {
             modified: None,
             permissions: Some("rwxr-xr-x".to_string()),
             file_type: FileEntryType::Directory,
+            owner: None,
+            group: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("Directory"));
@@ -534,6 +547,8 @@ mod tests {
             modified: None,
             permissions: None,
             file_type: FileEntryType::Symlink,
+            owner: None,
+            group: None,
         };
         let json = serde_json::to_string(&entry).unwrap();
         assert!(json.contains("Symlink"));

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -570,7 +570,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
       // discarded without showing an error toast.  maxRetries=2 means up
       // to 3 total attempts with 1 s → 2 s backoff.
       const entries = await withRetry(
-        () => invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink' }>>(
+        () => invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink'; owner: string | null; group: string | null }>>(
           'list_files',
           { connectionId, path: targetPath },
         ),
@@ -600,8 +600,10 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
             size: entry.size,
             modified: modifiedDate,
             permissions: entry.permissions ?? '',
-            owner: '-',
-            group: '-',
+            // owner/group come from the backend's `ls -l` parse; fall back to
+            // '-' for listings that omit the columns (e.g. no-group BusyBox).
+            owner: entry.owner ?? '-',
+            group: entry.group ?? '-',
             path: targetPath === '/' ? `/${entry.name}` : `${targetPath}/${entry.name}`,
           };
         });

--- a/src/components/sftp-panel.tsx
+++ b/src/components/sftp-panel.tsx
@@ -87,7 +87,7 @@ export function SFTPPanel({
 
     try {
       setLoading(true);
-      const entries = await invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink' }>>(
+      const entries = await invoke<Array<{ name: string; size: number; modified: string | null; permissions: string | null; file_type: 'File' | 'Directory' | 'Symlink'; owner: string | null; group: string | null }>>(
         'list_files',
         { connection_id: connectionId, path }
       );
@@ -108,8 +108,8 @@ export function SFTPPanel({
             size: entry.size,
             modified,
             permissions: entry.permissions ?? '',
-            owner: '-',
-            group: '-',
+            owner: entry.owner ?? '-',
+            group: entry.group ?? '-',
           };
         });
 


### PR DESCRIPTION
## What

The SSH file browser always rendered `-:-` in the user/group column. The data was never carried end-to-end:

- `FileEntry` (Rust) had no `owner`/`group` fields
- `ls_parser` discarded the owner/group columns from `ls -l` output
- both frontend consumers (`integrated-file-browser.tsx`, `sftp-panel.tsx`) hardcoded `'-'`

## Changes

- **`FileEntry`**: added `owner`/`group` `Option<String>` fields
- **`ls_parser` / `ftp_client`**: extract owner (token 2) and group (token 3 when present), handling no-group BusyBox and SELinux-context column variants
- **`list_sftp_dir` / `list_local_files`**: populate numeric uid/gid where a symbolic name isn't available
- **Frontend**: render the backend values with a `'-'` fallback for listings that genuinely omit the columns

The SSH browser now shows real `user:group` (e.g. `root:root`).

## Verification

- `cargo test`: 141 passed (on the feature branch tree)
- `tsc --noEmit`: clean
- `pnpm test`: 576 passed
- `pnpm lint`: 0 new errors/warnings (the single pre-existing error is in `settings-modal.tsx`)
- New/existing parser tests cover standard, no-group, SELinux-context, and numeric uid/gid layouts

🤖 Generated with [Claude Code](https://claude.com/claude-code)