### PR TITLE
fix(test): stabilize flaky file-browser follow test

### DIFF
--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -190,12 +190,20 @@ describe('IntegratedFileBrowser terminal directory following', () => {
         mocks.invoke.mock.calls.filter(([, args]) => args.path === '/srv/app'),
       ).toHaveLength(1);
     });
+    // Wait for the follow navigation to FULLY commit (breadcrumb renders
+    // '/srv/app') before clicking Home. Otherwise navigateTo('/home') can no-op
+    // while currentPath is still the initial '/home', and the pending follow
+    // load then lands on /srv/app — making the findByTitle('/home') below time
+    // out under CI timing jitter (pre-existing flake, seen on Windows + macOS).
+    await screen.findByTitle('/srv/app');
     fireEvent.click(screen.getByTitle('Home'));
+    // Require the Home click to trigger its own load (1 mount safety-net call
+    // + 1 navigation call) — a bare "called with" can be satisfied by the
+    // mount's safety-net loadFiles('/home') and masks a no-op navigation.
     await waitFor(() => {
-      expect(mocks.invoke).toHaveBeenCalledWith('list_files', {
-        connectionId: 'conn-manual',
-        path: '/home',
-      });
+      expect(
+        mocks.invoke.mock.calls.filter(([, args]) => args.path === '/home'),
+      ).toHaveLength(2);
     });
     // Wait for the Home navigation to fully commit (breadcrumb renders '/home')
     // before bumping the terminal sequence. Otherwise the follow effect can still


### PR DESCRIPTION
## Problem

The `returns to the same terminal directory after manual navigation on the next prompt` test in `integrated-file-browser-keyboard.test.tsx` flakes intermittently on **Windows and macOS CI** (3 observed failures) at `findByTitle('/home')` — the same file has a documented history of timing flakes (prior fix in `fc2ff27`).

## Root cause

On mount, two loads race:
- the **safety-net** load of `/home` (initial `committedPathRef`), and
- the **follow** load of `/srv/app` (from `terminalWorkingDirectory`).

If the follow's `setCurrentPath('/srv/app')` hasn't committed when the test clicks Home:
1. `navigateTo('/home')` **no-ops** — `currentPath` is still the initial `/home`, and `navigateTo` early-returns on `path === currentPath`.
2. The `waitFor('/home' called)` passes **spuriously** via the mount's safety-net call (it only checks "called with", not count).
3. The pending follow load then commits `/srv/app`, so `findByTitle('/home')` times out.

This window is microtask-tight, which is why it only manifests under CI CPU contention.

## Fix

- **Wait for the follow to fully commit** (`findByTitle('/srv/app')`) before clicking Home — so the navigation can't no-op.
- **Require the Home click to trigger its own load** (assert 2 `/home` calls: mount safety-net + navigation) instead of a bare "called with", which the mount call alone satisfies.

## Verification

- **Reproduced** locally with a 0–30ms jitter on the follow invoke: original test **14/30 failures**, fixed test **0/30 failures**.
- Full suite green locally: **565 tests pass**, `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)