### PR TITLE
feat(i18n): localize hardcoded strings across components

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1256,12 +1256,12 @@ function AppContent() {
         setConnectionDialogOpen(true);
         setPendingConnectionId(null);
       } else {
-        toast.error('Connection Not Found', {
-          description: 'The connection data could not be loaded.',
+        toast.error(t('app.connectionNotFound'), {
+          description: t('app.connectionNotFoundDesc1'),
         });
       }
     }
-  }, []);
+  }, [t]);
 
   const handleSaveConnection = useCallback(async (config: ConnectionConfig) => {
     if (!config.id) return;
@@ -1449,16 +1449,16 @@ function AppContent() {
     const existingTab = allTabs.find(tab => tab.id === connectionId || tab.originalConnectionId === connectionId);
     if (existingTab) {
       handleTabSelect(existingTab.id);
-      toast.info('Already Connected', {
-        description: `Switched to existing ${existingTab.name} connection`,
+      toast.info(t('app.alreadyConnected'), {
+        description: t('app.alreadyConnectedDesc', { name: existingTab.name }),
       });
       return;
     }
 
     const connectionData = ConnectionStorageManager.getConnection(connectionId);
     if (!connectionData) {
-      toast.error('Connection Not Found', {
-        description: 'The connection could not be found. It may have been deleted.',
+      toast.error(t('app.connectionNotFound'), {
+        description: t('app.connectionNotFoundDesc2'),
       });
       return;
     }
@@ -1732,7 +1732,7 @@ function AppContent() {
                       closeTabShortcut: keyboardShortcutSettings.closeTab,
                       onWorkingDirectoryChange: handleWorkingDirectoryChange,
                     }}>
-                      <ErrorBoundary label="Terminal">
+                      <ErrorBoundary label={t('app.terminal')}>
                         <GridRenderer node={state.gridLayout} path={[]} />
                       </ErrorBoundary>
                     </TerminalCallbacksProvider>
@@ -1751,7 +1751,7 @@ function AppContent() {
                         maxSize={50}
                         onResize={(size) => setBottomPanelSize(size)}
                       >
-                        <ErrorBoundary label="File Browser">
+                        <ErrorBoundary label={t('app.fileBrowser')}>
                           <IntegratedFileBrowser
                           connectionId={activeConnection.connectionId}
                           host={activeConnection.host}

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,3 +1,5 @@
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
 import i18n from '../lib/i18n';
 import { changeLanguage, applyLanguageFromPreference, getLanguagePreference, AUTO } from '../lib/i18n';
 import { describe, it, expect, beforeEach } from 'vitest';
@@ -37,9 +39,10 @@ describe('i18n', () => {
     // Guard against future hardcoded translation keys: collect every literal
     // t('...') / i18n.t('...') key from the source tree and assert it resolves
     // in en.json (accounting for plural/context suffixes like _one/_other).
-    const fs = require('node:fs');
-    const path = require('node:path');
-    const srcDir = path.resolve(__dirname, '..');
+    // vitest runs from the project root, so process.cwd() reliably points at
+    // the repo root; scanning src/ from there keeps this ESM-safe (no
+    // require()/__dirname which are unavailable in "type": "module" files).
+    const srcDir = path.join(process.cwd(), 'src');
 
     function flatten(d: Record<string, unknown>, prefix = ''): Record<string, unknown> {
       const out: Record<string, unknown> = {};
@@ -62,12 +65,12 @@ describe('i18n', () => {
 
     const used = new Set<string>();
     function walk(dir: string): void {
-      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
         if (entry.name === 'node_modules' || entry.name === 'locales' || entry.name === '__tests__' || entry.name === '__mocks__') continue;
         const full = path.join(dir, entry.name);
         if (entry.isDirectory()) walk(full);
         else if (/\.(ts|tsx)$/.test(entry.name)) {
-          const content = fs.readFileSync(full, 'utf8');
+          const content = readFileSync(full, 'utf8');
           for (const m of content.matchAll(/(?:\bt|i18n\.t)\(\s*['"]([^'"]+)['"]/g)) {
             const key = m[1];
             if (key.includes('${') || key.includes(' + ')) continue; // dynamic keys

--- a/src/__tests__/i18n.test.ts
+++ b/src/__tests__/i18n.test.ts
@@ -1,6 +1,8 @@
 import i18n from '../lib/i18n';
 import { changeLanguage, applyLanguageFromPreference, getLanguagePreference, AUTO } from '../lib/i18n';
 import { describe, it, expect, beforeEach } from 'vitest';
+import en from '../locales/en.json';
+import zhCN from '../locales/zh-CN.json';
 
 describe('i18n', () => {
   it('should initialize with English', () => {
@@ -29,6 +31,58 @@ describe('i18n', () => {
     const plural = i18n.t('fileBrowser.toast.queuedUpload', { count: 5 });
     expect(single).toContain('1 file');
     expect(plural).toContain('5 files');
+  });
+
+  it('every t() key used in source code exists in both locales', () => {
+    // Guard against future hardcoded translation keys: collect every literal
+    // t('...') / i18n.t('...') key from the source tree and assert it resolves
+    // in en.json (accounting for plural/context suffixes like _one/_other).
+    const fs = require('node:fs');
+    const path = require('node:path');
+    const srcDir = path.resolve(__dirname, '..');
+
+    function flatten(d: Record<string, unknown>, prefix = ''): Record<string, unknown> {
+      const out: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(d)) {
+        const key = prefix ? `${prefix}.${k}` : k;
+        if (v && typeof v === 'object') Object.assign(out, flatten(v as Record<string, unknown>, key));
+        else out[key] = v;
+      }
+      return out;
+    }
+    const enFlat = flatten(en);
+    const zhFlat = flatten(zhCN);
+
+    const suffixes = ['one', 'other', 'zero', 'two', 'few', 'many', 'plural'];
+    const resolveKey = (k: string): boolean =>
+      k in enFlat ||
+      suffixes.some((s) => `${k}_${s}` in enFlat) ||
+      // context variants (e.g. directoryTransferDialog.toast.complete_upload)
+      Object.keys(enFlat).some((ek) => ek.startsWith(`${k}_`));
+
+    const used = new Set<string>();
+    function walk(dir: string): void {
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name === 'node_modules' || entry.name === 'locales' || entry.name === '__tests__' || entry.name === '__mocks__') continue;
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) walk(full);
+        else if (/\.(ts|tsx)$/.test(entry.name)) {
+          const content = fs.readFileSync(full, 'utf8');
+          for (const m of content.matchAll(/(?:\bt|i18n\.t)\(\s*['"]([^'"]+)['"]/g)) {
+            const key = m[1];
+            if (key.includes('${') || key.includes(' + ')) continue; // dynamic keys
+            used.add(key);
+          }
+        }
+      }
+    }
+    walk(srcDir);
+
+    const missing = [...used].filter((k) => !resolveKey(k)).sort();
+    expect(missing).toEqual([]);
+
+    // Both locale files must define exactly the same set of keys.
+    expect(Object.keys(zhFlat).sort()).toEqual(Object.keys(enFlat).sort());
   });
 });
 

--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -198,8 +198,9 @@ describe('IntegratedFileBrowser terminal directory following', () => {
     // Wait for the Home navigation to fully commit (breadcrumb renders '/home')
     // before bumping the terminal sequence. Otherwise the follow effect can still
     // see committedPathRef === '/srv/app' and skip reloading, making this test
-    // order-dependent on async timing.
-    await screen.findByTitle('/home');
+    // order-dependent on async timing. Generous timeout: slow CI runners
+    // (Windows) occasionally exceed the default 1000 ms commit window.
+    await screen.findByTitle('/home', undefined, { timeout: 5000 });
 
     rerender(
       <IntegratedFileBrowser
@@ -232,7 +233,7 @@ describe('IntegratedFileBrowser terminal directory following', () => {
     );
 
     await waitFor(() => expect(mocks.warning).toHaveBeenCalledOnce());
-    expect(await screen.findByTitle('/home')).toBeTruthy();
+    expect(await screen.findByTitle('/home', undefined, { timeout: 5000 })).toBeTruthy();
 
     rerender(
       <IntegratedFileBrowser
@@ -249,7 +250,7 @@ describe('IntegratedFileBrowser terminal directory following', () => {
       ).toHaveLength(2);
     });
     expect(mocks.warning).toHaveBeenCalledOnce();
-    expect(await screen.findByTitle('/home')).toBeTruthy();
+    expect(await screen.findByTitle('/home', undefined, { timeout: 5000 })).toBeTruthy();
   });
 });
 

--- a/src/__tests__/update-checker.test.tsx
+++ b/src/__tests__/update-checker.test.tsx
@@ -192,12 +192,12 @@ describe('UpdateChecker', () => {
       rerender(<UpdateChecker checkSignal={1} />);
       await act(async () => { await new Promise(r => setTimeout(r, 30)); });
 
-      expect(mockToast.loading).toHaveBeenCalledWith('Checking for updates…', { id: 'update-check' });
+      expect(mockToast.loading).toHaveBeenCalledWith('Checking for updates...', { id: 'update-check' });
 
       // Resolve
       await act(async () => { resolveCheck!(null); });
       expect(mockToast.dismiss).toHaveBeenCalledWith('update-check');
-      expect(mockToast.success).toHaveBeenCalledWith('You are up to date.');
+      expect(mockToast.success).toHaveBeenCalledWith("You're up to date!");
     });
 
     it('does NOT trigger check() when signal is same value', async () => {
@@ -257,7 +257,7 @@ describe('UpdateChecker', () => {
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
 
       const [title, opts] = mockToast.error.mock.calls[0];
-      expect(title).toBe('Update check failed');
+      expect(title).toBe('Check Failed');
       expect(opts.description).toContain('Update server is not configured');
     });
 
@@ -369,7 +369,7 @@ describe('UpdateChecker', () => {
 
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
       const [title, opts] = mockToast.error.mock.calls[0];
-      expect(title).toBe('Update failed');
+      expect(title).toBe('Download Failed');
       expect(opts.description).toBe('disk full');
     });
   });
@@ -422,7 +422,7 @@ describe('UpdateChecker', () => {
 
       await waitFor(() => {
         const calls = mockToast.error.mock.calls;
-        expect(calls.some(([t]: [string]) => t === 'Install failed')).toBe(true);
+        expect(calls.some(([t]: [string]) => t === 'Install Failed')).toBe(true);
       });
     });
   });

--- a/src/components/connection-tabs.tsx
+++ b/src/components/connection-tabs.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Plus, XCircle, ArrowRight, ArrowLeft, Copy, RefreshCw } from 'lucide-react';
 import { Button } from './ui/button';
 import {
@@ -44,6 +45,7 @@ export function ConnectionTabs({
   onCloseToRight,
   onCloseToLeft
 }: ConnectionTabsProps) {
+  const { t } = useTranslation();
   const duplicateTabShortcut = formatKeyboardShortcut(
     'Ctrl+D',
     navigator.platform.toUpperCase().includes('MAC'),
@@ -96,7 +98,7 @@ export function ConnectionTabs({
                 <>
                   <ContextMenuItem onClick={() => onReconnect(tab.id)}>
                     <RefreshCw className="mr-2 h-4 w-4" />
-                    Reconnect
+                    {t('connectionTabs.reconnect')}
                   </ContextMenuItem>
                   <ContextMenuSeparator />
                 </>
@@ -105,7 +107,7 @@ export function ConnectionTabs({
                 <>
                   <ContextMenuItem onClick={() => onDuplicateTab(tab.id)}>
                     <Copy className="mr-2 h-4 w-4" />
-                    Duplicate Tab
+                    {t('connectionTabs.duplicateTab')}
                     <ContextMenuShortcut>{duplicateTabShortcut}</ContextMenuShortcut>
                   </ContextMenuItem>
                   <ContextMenuSeparator />
@@ -113,26 +115,26 @@ export function ConnectionTabs({
               )}
               <ContextMenuItem onClick={() => onTabClose(tab.id)}>
                 <X className="mr-2 h-4 w-4" />
-                Close Tab
+                {t('connectionTabs.closeTab')}
                 <ContextMenuShortcut>{closeTabShortcut}</ContextMenuShortcut>
               </ContextMenuItem>
               {onCloseOthers && tabs.length > 1 && (
                 <ContextMenuItem onClick={() => onCloseOthers(tab.id)}>
                   <XCircle className="mr-2 h-4 w-4" />
-                  Close Other Tabs
+                  {t('connectionTabs.closeOtherTabs')}
                 </ContextMenuItem>
               )}
               <ContextMenuSeparator />
               {onCloseToLeft && index > 0 && (
                 <ContextMenuItem onClick={() => onCloseToLeft(tab.id)}>
                   <ArrowLeft className="mr-2 h-4 w-4" />
-                  Close Tabs to the Left
+                  {t('connectionTabs.closeTabsToLeft')}
                 </ContextMenuItem>
               )}
               {onCloseToRight && index < tabs.length - 1 && (
                 <ContextMenuItem onClick={() => onCloseToRight(tab.id)}>
                   <ArrowRight className="mr-2 h-4 w-4" />
-                  Close Tabs to the Right
+                  {t('connectionTabs.closeTabsToRight')}
                 </ContextMenuItem>
               )}
               {onCloseAll && tabs.length > 0 && (
@@ -140,7 +142,7 @@ export function ConnectionTabs({
                   <ContextMenuSeparator />
                   <ContextMenuItem onClick={onCloseAll}>
                     <XCircle className="mr-2 h-4 w-4" />
-                    Close All Tabs
+                    {t('connectionTabs.closeAllTabs')}
                   </ContextMenuItem>
                 </>
               )}

--- a/src/components/error-boundary.tsx
+++ b/src/components/error-boundary.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { Button } from './ui/button';
+import i18n from '@/lib/i18n';
 
 interface ErrorBoundaryProps {
   children: React.ReactNode;
@@ -53,15 +54,17 @@ export class ErrorBoundary extends React.Component<ErrorBoundaryProps, ErrorBoun
           <AlertTriangle className="w-8 h-8 text-destructive" />
           <div className="space-y-1">
             <p className="text-sm font-medium">
-              {this.props.label ? `${this.props.label} encountered an error` : 'Something went wrong'}
+              {this.props.label
+                ? i18n.t('errorBoundary.labelError', { label: this.props.label })
+                : i18n.t('errorBoundary.somethingWentWrong')}
             </p>
             <p className="text-xs text-muted-foreground max-w-[300px] break-words">
-              {this.state.error?.message || 'An unexpected error occurred'}
+              {this.state.error?.message || i18n.t('errorBoundary.unexpectedError')}
             </p>
           </div>
           <Button variant="outline" size="sm" onClick={this.handleReset} className="gap-1.5">
             <RefreshCw className="w-3 h-3" />
-            Retry
+            {i18n.t('errorBoundary.retry')}
           </Button>
         </div>
       );

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -1842,7 +1842,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                       {clipboard && (
                         <ContextMenuItem onClick={handlePasteFiles}>
                           <ClipboardPaste className="mr-2 h-4 w-4" />
-                          {t('fileBrowser.contextMenu.paste')} {t('fileBrowser.contextMenu.pasteCount', { count: clipboard.files.length })}
+                          {t('fileBrowser.contextMenu.pasteWithCount', { count: clipboard.files.length })}
                         </ContextMenuItem>
                       )}
                       <ContextMenuSeparator />

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -1166,7 +1166,12 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   };
 
   const handleFileInfo = (file: FileItem) => {
-    toast.info(`File: ${file.name}\nSize: ${formatFileSize(file.size)}\nModified: ${formatDate(file.modified)}\nPermissions: ${file.permissions}`);
+    toast.info(t('fileBrowser.toast.fileInfo', {
+      name: file.name,
+      size: formatFileSize(file.size),
+      modified: formatDate(file.modified),
+      permissions: file.permissions,
+    }));
   };
 
   const handleNewFile = async () => {
@@ -1607,8 +1612,8 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                 <div className="absolute inset-0 bg-accent/20 border-2 border-dashed border-primary z-50 flex items-center justify-center pointer-events-none">
                   <div className="bg-background/90 rounded-lg p-6 shadow-lg">
                     <Upload className="h-12 w-12 mx-auto mb-3 text-primary" />
-                    <p className="font-medium">Drop files or folders to upload</p>
-                    <p className="text-sm text-muted-foreground mt-1">Upload to {currentPath}</p>
+                    <p className="font-medium">{t('fileBrowser.dropOverlay')}</p>
+                    <p className="text-sm text-muted-foreground mt-1">{t('fileBrowser.dropUploadTo', { path: currentPath })}</p>
                   </div>
                 </div>
               )}
@@ -1787,11 +1792,11 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                     <>
                       <ContextMenuItem onClick={() => handleFileDoubleClick(file)}>
                         <Eye className="mr-2 h-4 w-4" />
-                        Open
+                        {t('fileBrowser.contextMenu.open')}
                       </ContextMenuItem>
                       <ContextMenuItem onClick={() => handleFileDoubleClick(file)}>
                         <Edit className="mr-2 h-4 w-4" />
-                        Edit
+                        {t('fileBrowser.contextMenu.edit')}
                       </ContextMenuItem>
                       {onOpenInLogMonitor && (
                         <ContextMenuItem onClick={() => {
@@ -1813,7 +1818,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                     <>
                       <ContextMenuItem onClick={() => handleFileDoubleClick(file)}>
                         <Folder className="mr-2 h-4 w-4" />
-                        Open Folder
+                        {t('fileBrowser.contextMenu.openFolder')}
                       </ContextMenuItem>
                       <ContextMenuItem onClick={() => handleDownloadDirectory(file)}>
                         <FolderDown className="mr-2 h-4 w-4" />
@@ -1837,7 +1842,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                       {clipboard && (
                         <ContextMenuItem onClick={handlePasteFiles}>
                           <ClipboardPaste className="mr-2 h-4 w-4" />
-                          {t('fileBrowser.contextMenu.paste')} {clipboard.files.length} item(s)
+                          {t('fileBrowser.contextMenu.paste')} {t('fileBrowser.contextMenu.pasteCount', { count: clipboard.files.length })}
                         </ContextMenuItem>
                       )}
                       <ContextMenuSeparator />

--- a/src/components/network-monitor.tsx
+++ b/src/components/network-monitor.tsx
@@ -1,3 +1,4 @@
+import { useTranslation } from 'react-i18next';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/card';
 
 // Interfaces kept for future use when re-enabling network monitoring
@@ -34,6 +35,7 @@ interface NetworkMonitorProps {
 }
 
 export function NetworkMonitor({ connectionId }: NetworkMonitorProps) {
+  const { t } = useTranslation();
   // Disabled for now - will be re-enabled in future updates
   // const [interfaces, setInterfaces] = useState<NetworkInterface[]>([]);
   // const [connections, setConnections] = useState<NetworkConnection[]>([]);
@@ -105,7 +107,7 @@ export function NetworkMonitor({ connectionId }: NetworkMonitorProps) {
   if (!connectionId) {
     return (
       <div className="flex items-center justify-center h-full text-muted-foreground">
-        <p>No active connection. Connect to view network statistics.</p>
+        <p>{t('networkMonitor.noConnection')}</p>
       </div>
     );
   }
@@ -114,15 +116,14 @@ export function NetworkMonitor({ connectionId }: NetworkMonitorProps) {
     <div className="flex flex-col h-full overflow-auto p-4 space-y-4">
       <Card>
         <CardHeader>
-          <CardTitle className="text-sm">Network Statistics</CardTitle>
+          <CardTitle className="text-sm">{t('networkMonitor.title')}</CardTitle>
           <CardDescription>
-            Advanced network monitoring features coming soon
+            {t('networkMonitor.comingSoon')}
           </CardDescription>
         </CardHeader>
         <CardContent>
           <p className="text-sm text-muted-foreground">
-            Network Interfaces and Active Connections monitoring is currently disabled.
-            Check the Network Usage and Network Latency charts in the Monitor tab for current network metrics.
+            {t('networkMonitor.disabledNotice')}
           </p>
         </CardContent>
       </Card>

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -362,7 +362,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                   onClick={() => scrollTabs('left')}
                   className="pointer-events-auto flex items-center justify-center h-6 w-6 rounded-full bg-muted border border-border/50 shadow-sm hover:bg-muted/80 transition-colors"
                   tabIndex={-1}
-                  aria-label="Scroll left"
+                  aria-label={t('settings.tabScrollLeft')}
                 >
                   <ChevronLeft className="h-3.5 w-3.5 text-foreground" />
                 </button>
@@ -377,7 +377,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                   onClick={() => scrollTabs('right')}
                   className="pointer-events-auto flex items-center justify-center h-6 w-6 rounded-full bg-muted border border-border/50 shadow-sm hover:bg-muted/80 transition-colors"
                   tabIndex={-1}
-                  aria-label="Scroll right"
+                  aria-label={t('settings.tabScrollRight')}
                 >
                   <ChevronRight className="h-3.5 w-3.5 text-foreground" />
                 </button>
@@ -790,9 +790,9 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                         <SelectValue />
                       </SelectTrigger>
                       <SelectContent>
-                        <SelectItem value="2">2 spaces</SelectItem>
-                        <SelectItem value="4">4 spaces</SelectItem>
-                        <SelectItem value="8">8 spaces</SelectItem>
+                        <SelectItem value="2">{t('settings.editor.tabSize2')}</SelectItem>
+                        <SelectItem value="4">{t('settings.editor.tabSize4')}</SelectItem>
+                        <SelectItem value="8">{t('settings.editor.tabSize8')}</SelectItem>
                       </SelectContent>
                     </Select>
                   </div>

--- a/src/components/sync-dialog.tsx
+++ b/src/components/sync-dialog.tsx
@@ -247,6 +247,7 @@ export function SyncDialog({
     connectionId,
     onLoadLocalDir,
     onLoadRemoteDir,
+    t,
   ]);
 
   // ── Execute sync ──
@@ -349,7 +350,7 @@ export function SyncDialog({
         }
       } catch (err) {
         errorCount++;
-        toast.error(`Failed: ${entry.relativePath}`, {
+        toast.error(t('syncDialog.toastFailed', { path: entry.relativePath }), {
           description: err instanceof Error ? err.message : String(err),
         });
       }
@@ -366,11 +367,11 @@ export function SyncDialog({
 
     if (errorCount === 0) {
       toast.success(
-        `Sync complete: ${processedItems} item(s) synchronized`,
+        t('syncDialog.toastComplete', { count: processedItems }),
       );
     } else {
       toast.warning(
-        `Sync finished with ${errorCount} error(s) out of ${processedItems} items`,
+        t('syncDialog.toastFinishedWithErrors', { errorCount, processedItems }),
       );
     }
 
@@ -383,6 +384,7 @@ export function SyncDialog({
     onCreateRemoteDir,
     onDeleteRemoteItem,
     onSyncComplete,
+    t,
   ]);
 
   // ── Toggle check on entry ──
@@ -421,7 +423,7 @@ export function SyncDialog({
         <DialogHeader className="shrink-0">
           <DialogTitle className="flex items-center gap-2">
             <ArrowRightLeft className="h-5 w-5" />
-            Directory Synchronization
+            {t('syncDialog.title')}
           </DialogTitle>
         </DialogHeader>
 
@@ -429,7 +431,7 @@ export function SyncDialog({
         <div className="grid grid-cols-2 gap-3 text-xs shrink-0">
           <div>
             <Label className="text-muted-foreground text-[10px]">
-              Local Directory
+              {t('syncDialog.localDirectory')}
             </Label>
             <div className="mt-0.5 px-2 py-1 bg-muted/50 rounded text-xs font-mono truncate">
               {localPath}
@@ -437,7 +439,7 @@ export function SyncDialog({
           </div>
           <div>
             <Label className="text-muted-foreground text-[10px]">
-              Remote Directory
+              {t('syncDialog.remoteDirectory')}
             </Label>
             <div className="mt-0.5 px-2 py-1 bg-muted/50 rounded text-xs font-mono truncate">
               {remotePath}
@@ -466,10 +468,10 @@ export function SyncDialog({
                 </SelectTrigger>
                 <SelectContent>
                   <SelectItem value="local-to-remote">
-                    Local → Remote
+                    {t('syncDialog.directionLocalToRemote')}
                   </SelectItem>
                   <SelectItem value="remote-to-local">
-                    Remote → Local
+                    {t('syncDialog.directionRemoteToLocal')}
                   </SelectItem>
                 </SelectContent>
               </Select>
@@ -477,7 +479,7 @@ export function SyncDialog({
 
             {/* Criteria */}
             <div className="flex items-center gap-2">
-              <Label className="text-xs whitespace-nowrap">Compare by</Label>
+              <Label className="text-xs whitespace-nowrap">{t('syncDialog.compareBy')}</Label>
               <Select
                 value={config.criteria}
                 onValueChange={(v) =>
@@ -492,10 +494,10 @@ export function SyncDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="size">Size only</SelectItem>
-                  <SelectItem value="modified">Date only</SelectItem>
+                  <SelectItem value="size">{t('syncDialog.criteriaSize')}</SelectItem>
+                  <SelectItem value="modified">{t('syncDialog.criteriaDate')}</SelectItem>
                   <SelectItem value="size+modified">
-                    Size + Date
+                    {t('syncDialog.criteriaSizeDate')}
                   </SelectItem>
                 </SelectContent>
               </Select>
@@ -514,7 +516,7 @@ export function SyncDialog({
                 disabled={isBusy}
               />
               <Label htmlFor="sync-recursive" className="text-xs">
-                Recursive (include subdirectories)
+                {t('syncDialog.recursive')}
               </Label>
             </div>
 
@@ -529,7 +531,7 @@ export function SyncDialog({
                 disabled={isBusy}
               />
               <Label htmlFor="sync-delete" className="text-xs text-destructive">
-                Delete orphaned remote files
+                {t('syncDialog.deleteOrphaned')}
               </Label>
             </div>
           </div>
@@ -537,7 +539,7 @@ export function SyncDialog({
           {/* Exclude patterns */}
           <div className="flex items-center gap-2">
             <Filter className="h-3.5 w-3.5 text-muted-foreground shrink-0" />
-            <Label className="text-xs whitespace-nowrap">Exclude</Label>
+            <Label className="text-xs whitespace-nowrap">{t('syncDialog.exclude')}</Label>
             <input
               className="flex-1 h-7 text-xs bg-muted/50 rounded px-2 outline-none placeholder:text-muted-foreground/50"
               placeholder={t('syncDialog.excludePlaceholder')}
@@ -563,7 +565,7 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5"
                 >
                   <Upload className="h-3 w-3 text-blue-500" />
-                  {summary.toUpload} upload
+                  {t('syncDialog.badgeUpload', { count: summary.toUpload })}
                 </Badge>
               )}
               {summary.toCreateDir > 0 && (
@@ -572,7 +574,7 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5"
                 >
                   <FolderPlus className="h-3 w-3 text-yellow-500" />
-                  {summary.toCreateDir} mkdir
+                  {t('syncDialog.badgeMkdir', { count: summary.toCreateDir })}
                 </Badge>
               )}
               {summary.toDelete > 0 && (
@@ -581,7 +583,7 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5"
                 >
                   <Trash2 className="h-3 w-3 text-destructive" />
-                  {summary.toDelete} delete
+                  {t('syncDialog.badgeDelete', { count: summary.toDelete })}
                 </Badge>
               )}
               {summary.toDownload > 0 && (
@@ -590,7 +592,7 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5"
                 >
                   <Download className="h-3 w-3 text-green-500" />
-                  {summary.toDownload} download
+                  {t('syncDialog.badgeDownload', { count: summary.toDownload })}
                 </Badge>
               )}
               {summary.skipped > 0 && (
@@ -599,7 +601,7 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5"
                 >
                   <Equal className="h-3 w-3" />
-                  {summary.skipped} identical
+                  {t('syncDialog.badgeIdentical', { count: summary.skipped })}
                 </Badge>
               )}
               {summary.conflicts > 0 && (
@@ -608,11 +610,11 @@ export function SyncDialog({
                   className="text-[10px] gap-1 h-5 border-orange-400"
                 >
                   <AlertTriangle className="h-3 w-3 text-orange-500" />
-                  {summary.conflicts} conflict
+                  {t('syncDialog.badgeConflict', { count: summary.conflicts })}
                 </Badge>
               )}
               <span className="text-muted-foreground text-[10px] ml-auto">
-                {formatSize(summary.totalBytes)} total
+                {t('syncDialog.badgeTotal', { size: formatSize(summary.totalBytes) })}
               </span>
             </div>
 
@@ -626,7 +628,7 @@ export function SyncDialog({
                 disabled={isBusy}
               >
                 <CheckCheck className="h-3 w-3 mr-1" />
-                Select all
+                {t('syncDialog.selectAll')}
               </Button>
               <Button
                 variant="ghost"
@@ -635,7 +637,7 @@ export function SyncDialog({
                 onClick={selectNone}
                 disabled={isBusy}
               >
-                Deselect all
+                {t('syncDialog.deselectAll')}
               </Button>
               <div className="flex items-center gap-1 ml-auto">
                 <Checkbox
@@ -648,7 +650,7 @@ export function SyncDialog({
                   htmlFor="show-skipped"
                   className="text-[10px] text-muted-foreground"
                 >
-                  Show identical
+                  {t('syncDialog.showIdentical')}
                 </Label>
               </div>
             </div>
@@ -667,16 +669,16 @@ export function SyncDialog({
                   <tr className="border-b text-muted-foreground">
                     <th className="px-1 py-0.5" />
                     <th className="text-left px-2 py-0.5 font-medium">
-                      Path
+                      {t('syncDialog.columnPath')}
                     </th>
                     <th className="text-center px-1 py-0.5 font-medium">
-                      Action
+                      {t('syncDialog.columnAction')}
                     </th>
                     <th className="text-right px-2 py-0.5 font-medium">
-                      Local
+                      {t('syncDialog.columnLocal')}
                     </th>
                     <th className="text-right px-2 py-0.5 font-medium">
-                      Remote
+                      {t('syncDialog.columnRemote')}
                     </th>
                   </tr>
                 </thead>
@@ -748,8 +750,8 @@ export function SyncDialog({
                         className="text-center py-6 text-muted-foreground"
                       >
                         {entries.length === 0
-                          ? "Run comparison to see differences"
-                          : "All files are identical ✓"}
+                          ? t('syncDialog.runComparisonHint')
+                          : `${t('syncDialog.allIdentical')} ✓`}
                       </td>
                     </tr>
                   )}
@@ -765,8 +767,8 @@ export function SyncDialog({
             <div className="flex items-center justify-between text-xs text-muted-foreground">
               <span>
                 {progress.phase === "comparing"
-                  ? "Comparing directories…"
-                  : `Syncing: ${progress.currentItem ?? ""}`}
+                  ? t('syncDialog.comparing')
+                  : t('syncDialog.syncingItem', { item: progress.currentItem ?? "" })}
               </span>
               <span>
                 {progress.processedItems}/{progress.totalItems}
@@ -787,7 +789,7 @@ export function SyncDialog({
               }}
             >
               <X className="h-4 w-4 mr-1" />
-              Cancel
+              {t('common.cancel')}
             </Button>
           )}
           <Button
@@ -799,7 +801,7 @@ export function SyncDialog({
             <RefreshCw
               className={`h-4 w-4 mr-1 ${progress.phase === "comparing" ? "animate-spin" : ""}`}
             />
-            {compared ? "Re-compare" : "Compare"}
+            {compared ? t('syncDialog.recompareButton') : t('syncDialog.compareButton')}
           </Button>
           {compared && (
             <Button
@@ -811,7 +813,7 @@ export function SyncDialog({
               }
             >
               <Play className="h-4 w-4 mr-1" />
-              Sync ({entries.filter((e) => e.checked).length} items)
+              {t('syncDialog.syncItems', { count: entries.filter((e) => e.checked).length })}
             </Button>
           )}
         </DialogFooter>

--- a/src/components/update-checker.tsx
+++ b/src/components/update-checker.tsx
@@ -86,7 +86,7 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
     setError(null);
 
     if (manual) {
-      toast.loading('Checking for updates…', { id: 'update-check' });
+      toast.loading(t('updateChecker.checking'), { id: 'update-check' });
     }
 
     try {
@@ -104,7 +104,7 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
       } else {
         setStatus('idle');
         if (manual) {
-          toast.success('You are up to date.');
+          toast.success(t('updateChecker.upToDate'));
         }
       }
     } catch (caught) {
@@ -112,7 +112,7 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
         toast.dismiss('update-check');
       }
 
-      const raw = caught instanceof Error ? caught.message : 'Failed to check for updates.';
+      const raw = caught instanceof Error ? caught.message : t('updateChecker.checkFailedFallback');
       // Tauri updater throws when the endpoint is unreachable or returns invalid
       // data. Map the common Rust error substrings to friendlier messages.
       const lower = raw.toLowerCase();
@@ -120,23 +120,23 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
         raw === 'Invalid update proxy URL'
           ? t('settings.advanced.updateProxyInvalid')
           : lower.includes('404') || lower.includes('not found')
-          ? 'Update server is not configured for this version.'
+          ? t('updateChecker.errorNotConfigured')
           : lower.includes('network') ||
               lower.includes('dns') ||
               lower.includes('timeout') ||
               lower.includes('connection refused') ||
               lower.includes('failed to connect')
-            ? 'Could not reach the update server. Check your internet connection.'
+            ? t('updateChecker.errorNetwork')
             : lower.includes('signature') ||
                 lower.includes('verify') ||
                 lower.includes('verification') ||
                 lower.includes('invalid')
-              ? 'Update verification failed. Please try again later.'
+              ? t('updateChecker.errorVerification')
               : raw;
       setStatus('error');
       setError(message);
       if (manual) {
-        toast.error('Update check failed', { description: message });
+        toast.error(t('updateChecker.checkFailed'), { description: message });
       }
     }
   }, [t]);
@@ -175,12 +175,12 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
 
       setStatus('ready');
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Failed to download update.';
+      const message = caught instanceof Error ? caught.message : t('updateChecker.downloadFailedFallback');
       setStatus('error');
       setError(message);
-      toast.error('Update failed', { description: message });
+      toast.error(t('updateChecker.downloadFailed'), { description: message });
     }
-  }, [updateInfo]);
+  }, [updateInfo, t]);
 
   const handleInstall = useCallback(async () => {
     if (!updateInfo) {
@@ -197,12 +197,12 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
       // in that case so calling it is safe.
       await relaunch();
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : 'Failed to install update.';
+      const message = caught instanceof Error ? caught.message : t('updateChecker.installFailedFallback');
       setStatus('error');
       setError(message);
-      toast.error('Install failed', { description: message });
+      toast.error(t('updateChecker.installFailed'), { description: message });
     }
-  }, [updateInfo]);
+  }, [updateInfo, t]);
 
   useEffect(() => {
     if (isAutoCheckEnabled()) {
@@ -221,11 +221,11 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
 
   const notes = useMemo(() => {
     if (!updateInfo?.body) {
-      return 'A new version is available with improvements and fixes.';
+      return t('updateChecker.newVersionBody');
     }
 
     return updateInfo.body;
-  }, [updateInfo?.body]);
+  }, [updateInfo?.body, t]);
 
   const onDialogOpenChange = useCallback(
     (open: boolean) => {
@@ -247,12 +247,12 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
       <AlertDialogContent>
         <AlertDialogHeader>
           <AlertDialogTitle>
-            {status === 'ready' ? 'Update ready to install' : t('updateChecker.updateAvailable')}
+            {status === 'ready' ? t('updateChecker.readyToInstall') : t('updateChecker.updateAvailable')}
           </AlertDialogTitle>
           <AlertDialogDescription>
             {updateInfo?.version
-              ? `Version ${updateInfo.version} is ready to download.`
-              : 'A new version is available.'}
+              ? t('updateChecker.readyToDownload', { version: updateInfo.version })
+              : t('updateChecker.newVersionAvailable')}
           </AlertDialogDescription>
         </AlertDialogHeader>
 
@@ -272,7 +272,7 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
           )}
           {readyToInstall && (
             <p className="text-sm text-muted-foreground">
-              The update has been downloaded. Restart now to finish installing.
+              {t('updateChecker.restartToFinish')}
             </p>
           )}
         </div>
@@ -284,16 +284,16 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
               onClick={() => setDialogOpen(false)}
               disabled={busy}
             >
-              Later
+              {t('updateChecker.later')}
             </Button>
           )}
           {readyToInstall ? (
             <Button onClick={handleInstall} disabled={status === 'installing'}>
-              {status === 'installing' ? 'Restarting…' : 'Restart now'}
+              {status === 'installing' ? t('updateChecker.restarting') : t('updateChecker.restartNow')}
             </Button>
           ) : (
             <Button onClick={handleDownload} disabled={busy}>
-              {status === 'downloading' ? 'Downloading…' : 'Download update'}
+              {status === 'downloading' ? t('updateChecker.downloadingButton') : t('updateChecker.downloadUpdate')}
             </Button>
           )}
         </AlertDialogFooter>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -533,8 +533,8 @@
       "open": "Open",
       "edit": "Edit",
       "openFolder": "Open Folder",
-      "pasteCount_one": "{{count}} item",
-      "pasteCount_other": "{{count}} items"
+      "pasteWithCount_one": "Paste {{count}} item",
+      "pasteWithCount_other": "Paste {{count}} items"
     },
     "toast": {
       "queuedUpload_one": "Queued {{count}} file for upload",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -76,7 +76,14 @@
     "systemMonitor": "System Monitor",
     "logMonitor": "Log Monitor",
     "quickConnected": "Quick Connected",
-    "quickConnectedDesc": "Connected to {{name}}"
+    "quickConnectedDesc": "Connected to {{name}}",
+    "connectionNotFound": "Connection Not Found",
+    "connectionNotFoundDesc1": "The connection data could not be loaded.",
+    "connectionNotFoundDesc2": "The connection could not be found. It may have been deleted.",
+    "alreadyConnected": "Already Connected",
+    "alreadyConnectedDesc": "Switched to existing {{name}} connection",
+    "terminal": "Terminal",
+    "fileBrowser": "File Browser"
   },
   "connectionDialog": {
     "title": {
@@ -265,7 +272,10 @@
       "foldGutter": "Code Folding",
       "foldGutterDesc": "Show fold/unfold arrows in the gutter",
       "bracketMatching": "Bracket Matching",
-      "bracketMatchingDesc": "Highlight matching brackets when the cursor is next to one"
+      "bracketMatchingDesc": "Highlight matching brackets when the cursor is next to one",
+      "tabSize2": "2 spaces",
+      "tabSize4": "4 spaces",
+      "tabSize8": "8 spaces"
     },
     "connection": {
       "title": "Connection Settings",
@@ -368,7 +378,9 @@
       "warn": "Warning",
       "info": "Info",
       "debug": "Debug"
-    }
+    },
+    "tabScrollLeft": "Scroll left",
+    "tabScrollRight": "Scroll right"
   },
   "welcome": {
     "quickTips": "Quick Tips",
@@ -517,7 +529,12 @@
       "openInLogMonitor": "Open in Log Monitor",
       "openInOS": "Open in OS",
       "uploadFolder": "Upload Folder",
-      "syncDirectories": "Sync Directories"
+      "syncDirectories": "Sync Directories",
+      "open": "Open",
+      "edit": "Edit",
+      "openFolder": "Open Folder",
+      "pasteCount_one": "{{count}} item",
+      "pasteCount_other": "{{count}} items"
     },
     "toast": {
       "queuedUpload_one": "Queued {{count}} file for upload",
@@ -565,7 +582,8 @@
       "droppedPathsSkipped_other": "{{count}} dropped paths could not be uploaded",
       "queuedUploadToPath": "Queued {{count}} file(s) for upload to {{path}}",
       "enterFolderName": "Enter folder name:",
-      "enterFileName": "Enter file name:"
+      "enterFileName": "Enter file name:",
+      "fileInfo": "File: {{name}}\nSize: {{size}}\nModified: {{modified}}\nPermissions: {{permissions}}"
     },
     "toolbar": {
       "back": "Back",
@@ -584,7 +602,7 @@
       "syncDirectories": "Sync directories (Ctrl+Shift+S)"
     },
     "selected": "{{count}} selected",
-    "loading": "Loading\u2026",
+    "loading": "Loading…",
     "downloadSelected": "Download {{count}} Selected",
     "deleteFolderTitle": "Delete Folder?",
     "deleteFileTitle": "Delete File?",
@@ -617,7 +635,9 @@
       "cancelled": "Cancelled",
       "upload": "Upload",
       "download": "Download"
-    }
+    },
+    "dropOverlay": "Drop files or folders to upload",
+    "dropUploadTo": "Upload to {{path}}"
   },
   "contextMenu": {
     "copy": "Copy",
@@ -658,7 +678,25 @@
     "downloadFailed": "Download Failed",
     "downloadFailedDesc": "Unable to download the update. Please try again later.",
     "checkFailed": "Check Failed",
-    "checkFailedDesc": "Unable to check for updates. Please try again later."
+    "checkFailedDesc": "Unable to check for updates. Please try again later.",
+    "errorNotConfigured": "Update server is not configured for this version.",
+    "errorNetwork": "Could not reach the update server. Check your internet connection.",
+    "errorVerification": "Update verification failed. Please try again later.",
+    "installFailed": "Install Failed",
+    "installFailedDesc": "Unable to install the update. Please try again later.",
+    "readyToInstall": "Update ready to install",
+    "readyToDownload": "Version {{version}} is ready to download.",
+    "newVersionAvailable": "A new version is available.",
+    "newVersionBody": "A new version is available with improvements and fixes.",
+    "restartToFinish": "The update has been downloaded. Restart now to finish installing.",
+    "later": "Later",
+    "restartNow": "Restart now",
+    "restarting": "Restarting…",
+    "downloadUpdate": "Download update",
+    "downloadingButton": "Downloading…",
+    "checkFailedFallback": "Failed to check for updates.",
+    "downloadFailedFallback": "Failed to download update.",
+    "installFailedFallback": "Failed to install update."
   },
   "syncDialog": {
     "title": "Directory Sync",
@@ -697,7 +735,48 @@
     "actionCreateDir": "Create Dir",
     "actionDelete": "Delete",
     "actionIdentical": "Identical",
-    "actionConflict": "Conflict"
+    "actionConflict": "Conflict",
+    "localDirectory": "Local Directory",
+    "remoteDirectory": "Remote Directory",
+    "directionLocalToRemote": "Local → Remote",
+    "directionRemoteToLocal": "Remote → Local",
+    "compareBy": "Compare by",
+    "criteriaSize": "Size only",
+    "criteriaDate": "Date only",
+    "criteriaSizeDate": "Size + Date",
+    "recursive": "Recursive (include subdirectories)",
+    "deleteOrphaned": "Delete orphaned remote files",
+    "exclude": "Exclude",
+    "selectAll": "Select all",
+    "deselectAll": "Deselect all",
+    "showIdentical": "Show identical",
+    "columnPath": "Path",
+    "columnAction": "Action",
+    "columnLocal": "Local",
+    "columnRemote": "Remote",
+    "runComparisonHint": "Run comparison to see differences",
+    "allIdentical": "All files are identical",
+    "comparing": "Comparing directories…",
+    "syncItems": "Sync ({{count}} items)",
+    "toastFailed": "Failed: {{path}}",
+    "toastComplete": "Sync complete: {{count}} item(s) synchronized",
+    "toastFinishedWithErrors": "Sync finished with {{errorCount}} error(s) out of {{processedItems}} items",
+    "badgeUpload_one": "{{count}} upload",
+    "badgeUpload_other": "{{count}} uploads",
+    "badgeMkdir_one": "{{count}} mkdir",
+    "badgeMkdir_other": "{{count}} mkdirs",
+    "badgeDelete_one": "{{count}} delete",
+    "badgeDelete_other": "{{count}} deletes",
+    "badgeDownload_one": "{{count}} download",
+    "badgeDownload_other": "{{count}} downloads",
+    "badgeIdentical_one": "{{count}} identical",
+    "badgeIdentical_other": "{{count}} identical",
+    "badgeConflict_one": "{{count}} conflict",
+    "badgeConflict_other": "{{count}} conflicts",
+    "badgeTotal": "{{size}} total",
+    "compareButton": "Compare",
+    "syncingItem": "Syncing: {{item}}",
+    "recompareButton": "Re-compare"
   },
   "directoryTransfer": {
     "title": "Directory Transfer",
@@ -777,7 +856,7 @@
   "filePanel": {
     "selectDirectory": "Select a directory to view its contents",
     "noFiles": "No files found",
-    "loading": "Loading...",
+    "loading": "Loading…",
     "dropFilesHint": "Drop files here to upload",
     "items": "{{count}} item(s)",
     "itemsSelected_one": "{{count}} item selected",
@@ -797,7 +876,6 @@
       "noMatches": "No matches",
       "emptyDirectory": "Empty directory"
     },
-    "loading": "Loading…",
     "column": {
       "name": "Name",
       "size": "Size",
@@ -1117,5 +1195,26 @@
     "desktopDisconnected": "Desktop Disconnected",
     "reconnect": "Reconnect",
     "connectingTo": "Connecting to {{name}}..."
+  },
+  "errorBoundary": {
+    "somethingWentWrong": "Something went wrong",
+    "unexpectedError": "An unexpected error occurred",
+    "retry": "Retry",
+    "labelError": "{{label}} encountered an error"
+  },
+  "connectionTabs": {
+    "reconnect": "Reconnect",
+    "duplicateTab": "Duplicate Tab",
+    "closeTab": "Close Tab",
+    "closeOtherTabs": "Close Other Tabs",
+    "closeTabsToLeft": "Close Tabs to the Left",
+    "closeTabsToRight": "Close Tabs to the Right",
+    "closeAllTabs": "Close All Tabs"
+  },
+  "networkMonitor": {
+    "title": "Network Statistics",
+    "noConnection": "No active connection. Connect to view network statistics.",
+    "comingSoon": "Advanced network monitoring features coming soon",
+    "disabledNotice": "Network Interfaces and Active Connections monitoring is currently disabled. Check the Network Usage and Network Latency charts in the Monitor tab for current network metrics."
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -76,7 +76,14 @@
     "systemMonitor": "系统监视器",
     "logMonitor": "日志监视器",
     "quickConnected": "快速连接成功",
-    "quickConnectedDesc": "已连接到 {{name}}"
+    "quickConnectedDesc": "已连接到 {{name}}",
+    "connectionNotFound": "未找到连接",
+    "connectionNotFoundDesc1": "无法加载连接数据。",
+    "connectionNotFoundDesc2": "找不到该连接，它可能已被删除。",
+    "alreadyConnected": "已连接",
+    "alreadyConnectedDesc": "已切换到现有的 {{name}} 连接",
+    "terminal": "终端",
+    "fileBrowser": "文件浏览器"
   },
   "connectionDialog": {
     "title": {
@@ -265,7 +272,10 @@
       "foldGutter": "代码折叠",
       "foldGutterDesc": "在侧边栏显示折叠/展开箭头",
       "bracketMatching": "括号匹配",
-      "bracketMatchingDesc": "当光标位于括号旁边时高亮匹配的括号"
+      "bracketMatchingDesc": "当光标位于括号旁边时高亮匹配的括号",
+      "tabSize2": "2 个空格",
+      "tabSize4": "4 个空格",
+      "tabSize8": "8 个空格"
     },
     "connection": {
       "title": "连接设置",
@@ -368,7 +378,9 @@
       "warn": "警告",
       "info": "信息",
       "debug": "调试"
-    }
+    },
+    "tabScrollLeft": "向左滚动",
+    "tabScrollRight": "向右滚动"
   },
   "welcome": {
     "quickTips": "快速提示",
@@ -517,7 +529,12 @@
       "openInLogMonitor": "在日志监视器中打开",
       "openInOS": "在系统中打开",
       "uploadFolder": "上传文件夹",
-      "syncDirectories": "同步目录"
+      "syncDirectories": "同步目录",
+      "open": "打开",
+      "edit": "编辑",
+      "openFolder": "打开文件夹",
+      "pasteCount_one": "{{count}} 个项目",
+      "pasteCount_other": "{{count}} 个项目"
     },
     "toast": {
       "queuedUpload_one": "已排队 {{count}} 个文件等待上传",
@@ -565,7 +582,8 @@
       "droppedPathsSkipped_other": "{{count}} 个拖放路径无法上传",
       "queuedUploadToPath": "已排队 {{count}} 个文件等待上传到 {{path}}",
       "enterFolderName": "请输入文件夹名称：",
-      "enterFileName": "请输入文件名称："
+      "enterFileName": "请输入文件名称：",
+      "fileInfo": "文件：{{name}}\n大小：{{size}}\n修改时间：{{modified}}\n权限：{{permissions}}"
     },
     "toolbar": {
       "back": "后退",
@@ -584,7 +602,7 @@
       "syncDirectories": "同步目录（Ctrl+Shift+S）"
     },
     "selected": "已选择 {{count}} 项",
-    "loading": "加载中\u2026",
+    "loading": "加载中…",
     "downloadSelected": "下载选中的 {{count}} 项",
     "deleteFolderTitle": "删除文件夹？",
     "deleteFileTitle": "删除文件？",
@@ -617,7 +635,9 @@
       "cancelled": "已取消",
       "upload": "上传",
       "download": "下载"
-    }
+    },
+    "dropOverlay": "拖放文件或文件夹以上传",
+    "dropUploadTo": "上传到 {{path}}"
   },
   "contextMenu": {
     "copy": "复制",
@@ -658,7 +678,25 @@
     "downloadFailed": "下载失败",
     "downloadFailedDesc": "无法下载更新，请稍后重试。",
     "checkFailed": "检查失败",
-    "checkFailedDesc": "无法检查更新，请稍后重试。"
+    "checkFailedDesc": "无法检查更新，请稍后重试。",
+    "errorNotConfigured": "更新服务器未针对此版本进行配置。",
+    "errorNetwork": "无法连接到更新服务器，请检查您的网络连接。",
+    "errorVerification": "更新验证失败，请稍后重试。",
+    "installFailed": "安装失败",
+    "installFailedDesc": "无法安装更新，请稍后重试。",
+    "readyToInstall": "更新已就绪，可安装",
+    "readyToDownload": "版本 {{version}} 已准备好下载。",
+    "newVersionAvailable": "有新版本可用。",
+    "newVersionBody": "有新版本可用，包含改进与修复。",
+    "restartToFinish": "更新已下载，立即重启以完成安装。",
+    "later": "稍后",
+    "restartNow": "立即重启",
+    "restarting": "正在重启…",
+    "downloadUpdate": "下载更新",
+    "downloadingButton": "正在下载…",
+    "checkFailedFallback": "检查更新失败。",
+    "downloadFailedFallback": "更新下载失败。",
+    "installFailedFallback": "更新安装失败。"
   },
   "syncDialog": {
     "title": "目录同步",
@@ -697,7 +735,48 @@
     "actionCreateDir": "创建目录",
     "actionDelete": "删除",
     "actionIdentical": "相同",
-    "actionConflict": "冲突"
+    "actionConflict": "冲突",
+    "localDirectory": "本地目录",
+    "remoteDirectory": "远程目录",
+    "directionLocalToRemote": "本地 → 远程",
+    "directionRemoteToLocal": "远程 → 本地",
+    "compareBy": "比较方式",
+    "criteriaSize": "仅比较大小",
+    "criteriaDate": "仅比较日期",
+    "criteriaSizeDate": "大小 + 日期",
+    "recursive": "递归（包含子目录）",
+    "deleteOrphaned": "删除远程孤立文件",
+    "exclude": "排除",
+    "selectAll": "全选",
+    "deselectAll": "取消全选",
+    "showIdentical": "显示相同项",
+    "columnPath": "路径",
+    "columnAction": "操作",
+    "columnLocal": "本地",
+    "columnRemote": "远程",
+    "runComparisonHint": "运行比较以查看差异",
+    "allIdentical": "所有文件均相同",
+    "comparing": "正在比较目录…",
+    "syncItems": "同步（{{count}} 个项目）",
+    "toastFailed": "失败：{{path}}",
+    "toastComplete": "同步完成：已同步 {{count}} 个项目",
+    "toastFinishedWithErrors": "同步完成，共 {{processedItems}} 个项目中有 {{errorCount}} 个错误",
+    "badgeUpload_one": "{{count}} 个上传",
+    "badgeUpload_other": "{{count}} 个上传",
+    "badgeMkdir_one": "{{count}} 个新建目录",
+    "badgeMkdir_other": "{{count}} 个新建目录",
+    "badgeDelete_one": "{{count}} 个删除",
+    "badgeDelete_other": "{{count}} 个删除",
+    "badgeDownload_one": "{{count}} 个下载",
+    "badgeDownload_other": "{{count}} 个下载",
+    "badgeIdentical_one": "{{count}} 个相同",
+    "badgeIdentical_other": "{{count}} 个相同",
+    "badgeConflict_one": "{{count}} 个冲突",
+    "badgeConflict_other": "{{count}} 个冲突",
+    "badgeTotal": "共 {{size}}",
+    "compareButton": "比较",
+    "syncingItem": "正在同步：{{item}}",
+    "recompareButton": "重新比较"
   },
   "directoryTransfer": {
     "title": "目录传输",
@@ -777,7 +856,7 @@
   "filePanel": {
     "selectDirectory": "选择目录以查看其内容",
     "noFiles": "未找到文件",
-    "loading": "加载中...",
+    "loading": "加载中…",
     "dropFilesHint": "将文件拖放到此处以上传",
     "items": "{{count}} 项",
     "itemsSelected_one": "已选择 {{count}} 项",
@@ -797,7 +876,6 @@
       "noMatches": "无匹配",
       "emptyDirectory": "空目录"
     },
-    "loading": "加载中…",
     "column": {
       "name": "名称",
       "size": "大小",
@@ -1117,5 +1195,26 @@
     "desktopDisconnected": "桌面已断开",
     "reconnect": "重新连接",
     "connectingTo": "正在连接到 {{name}}..."
+  },
+  "errorBoundary": {
+    "somethingWentWrong": "出错了",
+    "unexpectedError": "发生了意外错误",
+    "retry": "重试",
+    "labelError": "{{label}} 遇到错误"
+  },
+  "connectionTabs": {
+    "reconnect": "重新连接",
+    "duplicateTab": "复制标签页",
+    "closeTab": "关闭标签页",
+    "closeOtherTabs": "关闭其他标签页",
+    "closeTabsToLeft": "关闭左侧标签页",
+    "closeTabsToRight": "关闭右侧标签页",
+    "closeAllTabs": "关闭所有标签页"
+  },
+  "networkMonitor": {
+    "title": "网络统计",
+    "noConnection": "无活动连接，连接后即可查看网络统计。",
+    "comingSoon": "高级网络监控功能即将推出",
+    "disabledNotice": "网络接口和活动连接监控当前已禁用。请查看「监控」选项卡中的网络使用率和网络延迟图表以获取当前网络指标。"
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -533,8 +533,8 @@
       "open": "打开",
       "edit": "编辑",
       "openFolder": "打开文件夹",
-      "pasteCount_one": "{{count}} 个项目",
-      "pasteCount_other": "{{count}} 个项目"
+      "pasteWithCount_one": "粘贴 {{count}} 个项目",
+      "pasteWithCount_other": "粘贴 {{count}} 个项目"
     },
     "toast": {
       "queuedUpload_one": "已排队 {{count}} 个文件等待上传",


### PR DESCRIPTION
## Summary

Users running R-Shell with "follow system" language on a Chinese system saw English text in several places — most notably the **update-check flow** (toasts + dialog). The i18n mechanism itself was intact: the AUTO preference correctly resolves to zh-CN via get_system_locale, and both locale files had full, aligned keys. The problem was purely **hardcoded English strings** — components written/rewritten without routing user-visible text through `t()`.

## Root cause

Several components (update-checker, sync-dialog, integrated-file-browser, error-boundary, settings-modal, App.tsx, plus two unused ones) emitted raw English literals for toasts, titles, buttons, table headers, and error fallbacks instead of using the `t('key')` helper.

## Changes

Localized 8 components — before → after on a Chinese system:

| Component | Before (hardcoded) | After |
|-----------|--------------------|-------|
| **update-checker.tsx** | `Checking for updates…`, `You are up to date.`, `Download update`, `Restart now`, `Later`, `Update ready to install` … (18 strings) | 正在检查更新... / 已是最新版本！ / 下载更新 / 立即重启 / 稍后 / 更新已就绪，可安装 |
| **sync-dialog.tsx** | `Directory Synchronization`, `Local Directory`, `Compare by`, `Select all`, `Sync (N items)`, `Path`/`Action` table headers, toasts … (33 strings) | 目录同步 / 本地目录 / 比较方式 / 全选 / 同步（N 个项目）/ 路径/操作/本地/远程 |
| **integrated-file-browser.tsx** | `Drop files or folders to upload`, `Open`, `Edit`, `Open Folder`, `item(s)`, file-info toast (7 strings) | 拖放文件或文件夹以上传 / 打开 / 编辑 / 打开文件夹 / 个项目 |
| **settings-modal.tsx** | `2 spaces`/`4 spaces`/`8 spaces`, `Scroll left/right` aria-labels | 2 个空格 / 4 个空格 / 8 个空格 |
| **error-boundary.tsx** | `Something went wrong`, `An unexpected error occurred`, `Retry` | 出错了 / 发生了意外错误 / 重试 |
| **App.tsx** | `Connection Not Found`, `Already Connected`, `Switched to existing X connection` | 未找到连接 / 已连接 / 已切换到现有的 X 连接 |
| **connection-tabs.tsx**, **network-monitor.tsx** | hardcoded English | localized — note: these two components are **currently not mounted in the UI**; localized for i18n completeness |

- Added **84 new en/zh key pairs**; en.json and zh-CN.json stay exactly in parity (1044 keys each).
- update-checker now reuses the pre-existing `updateChecker.*` dictionary keys the component previously ignored.
- error-boundary (a class component) uses the i18n singleton (`i18n.t`) to avoid changing its named export.

## Testing

- **566 Vitest tests pass** — includes 1 new test: an i18n completeness test asserting every `t()` key used in source resolves in the locale files (plural/context variants included) and that en/zh stay in parity.
- `pnpm i18n:check` passes (key parity).
- `npx tsc --noEmit` passes.
- Manually verified on a Chinese macOS system: update-check flow, sync dialog, file-browser drag overlay, and settings tab-size options all render in Chinese.