### PR TITLE
fix(file-browser): support intuitive multi-select and batch delete

### DIFF
--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -296,3 +296,145 @@ describe('IntegratedFileBrowser directory download', () => {
     );
   });
 });
+
+describe('IntegratedFileBrowser multi-select and batch delete', () => {
+  const listFilesResponse = [
+    { name: 'a.txt', size: 10, modified: '2024-01-01 00:00', permissions: '-rw-r--r--', file_type: 'File', owner: 'u', group: 'g' },
+    { name: 'b.txt', size: 20, modified: '2024-01-02 00:00', permissions: '-rw-r--r--', file_type: 'File', owner: 'u', group: 'g' },
+    { name: 'c.txt', size: 30, modified: '2024-01-03 00:00', permissions: '-rw-r--r--', file_type: 'File', owner: 'u', group: 'g' },
+  ];
+
+  beforeEach(() => {
+    mocks.invoke.mockImplementation(async (command: string) => {
+      if (command === 'list_files') return listFilesResponse;
+      if (command === 'delete_file') return true;
+      return undefined;
+    });
+  });
+
+  it('plain click selects a single row and Ctrl+Click toggles multi-selection', async () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-multi"
+        isConnected
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByText('a.txt');
+    fireEvent.click(screen.getByText('a.txt'));
+    expect(await screen.findByText('1 selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('b.txt'), { ctrlKey: true });
+    expect(await screen.findByText('2 selected')).toBeTruthy();
+  });
+
+  it('Shift+Click selects the contiguous range from the anchor', async () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-range"
+        isConnected
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByText('a.txt');
+    fireEvent.click(screen.getByText('a.txt'));
+    expect(await screen.findByText('1 selected')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('c.txt'), { shiftKey: true });
+    expect(await screen.findByText('3 selected')).toBeTruthy();
+  });
+
+  it('Delete key with multiple selections opens batch confirm and deletes all', async () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-del"
+        isConnected
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByText('a.txt');
+    fireEvent.click(screen.getByText('a.txt'));
+    fireEvent.click(screen.getByText('b.txt'), { ctrlKey: true });
+    expect(await screen.findByText('2 selected')).toBeTruthy();
+
+    fireEvent.keyDown(document, { key: 'Delete' });
+
+    expect(await screen.findByText('Delete 2 Items?')).toBeTruthy();
+    const confirmButton = screen.getByRole('button', { name: 'Delete' });
+    fireEvent.click(confirmButton);
+
+    await waitFor(() => {
+      const deleteCalls = mocks.invoke.mock.calls.filter(([cmd]) => cmd === 'delete_file');
+      expect(deleteCalls).toHaveLength(2);
+      expect(deleteCalls[0][1]).toMatchObject({ path: '/home/a.txt' });
+      expect(deleteCalls[1][1]).toMatchObject({ path: '/home/b.txt' });
+    });
+  });
+
+  it('right-click on a selected row offers batch delete for the whole selection', async () => {
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-ctxdel"
+        isConnected
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByText('a.txt');
+    fireEvent.click(screen.getByText('a.txt'));
+    fireEvent.click(screen.getByText('b.txt'), { ctrlKey: true });
+    expect(await screen.findByText('2 selected')).toBeTruthy();
+
+    // Right-click a row that is part of the selection. The context-menu mock
+    // renders every row's menu (unlike real Radix, which renders only the open
+    // one), so multiple Delete buttons are expected — clicking any of them
+    // triggers the batch delete for the whole selection.
+    fireEvent.contextMenu(screen.getByText('a.txt'));
+
+    const deleteItems = await screen.findAllByText('Delete');
+    fireEvent.click(deleteItems[0]);
+
+    expect(await screen.findByText('Delete 2 Items?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      const deleteCalls = mocks.invoke.mock.calls.filter(([cmd]) => cmd === 'delete_file');
+      expect(deleteCalls).toHaveLength(2);
+    });
+  });
+
+  it('never includes the ".." parent row in multi-select operations', async () => {
+    // list_files returns 3 real entries; the component prepends a ".." row,
+    // which sits at the top of the sorted list (index 0).
+    render(
+      <IntegratedFileBrowser
+        connectionId="conn-paren"
+        isConnected
+        onClose={() => {}}
+      />,
+    );
+
+    await screen.findByText('a.txt');
+    // Select a.txt (index 1) then Shift+Click c.txt (index 3): the range
+    // covers a, b, c — the ".." row at index 0 must NOT be selected.
+    fireEvent.click(screen.getByText('a.txt'));
+    fireEvent.click(screen.getByText('c.txt'), { shiftKey: true });
+    expect(await screen.findByText('3 selected')).toBeTruthy();
+
+    // Delete via the range selection: only a/b/c are deleted, never "..".
+    fireEvent.keyDown(document, { key: 'Delete' });
+    expect(await screen.findByText('Delete 3 Items?')).toBeTruthy();
+    fireEvent.click(screen.getByRole('button', { name: 'Delete' }));
+
+    await waitFor(() => {
+      const deleteCalls = mocks.invoke.mock.calls.filter(([cmd]) => cmd === 'delete_file');
+      expect(deleteCalls).toHaveLength(3);
+      const paths = deleteCalls.map(([, args]) => args.path);
+      expect(paths).toEqual(['/home/a.txt', '/home/b.txt', '/home/c.txt']);
+      expect(paths).not.toContain('/home/..');
+    });
+  });
+});

--- a/src/__tests__/integrated-file-browser-keyboard.test.tsx
+++ b/src/__tests__/integrated-file-browser-keyboard.test.tsx
@@ -406,9 +406,10 @@ describe('IntegratedFileBrowser multi-select and batch delete', () => {
     });
   });
 
-  it('never includes the ".." parent row in multi-select operations', async () => {
+  it('Ctrl+A selects all real entries but never the ".." parent row', async () => {
     // list_files returns 3 real entries; the component prepends a ".." row,
-    // which sits at the top of the sorted list (index 0).
+    // which sits at the top of the sorted list (index 0). Ctrl+A must exclude
+    // it (the only path where the exclusion is actually exercised).
     render(
       <IntegratedFileBrowser
         connectionId="conn-paren"
@@ -418,13 +419,10 @@ describe('IntegratedFileBrowser multi-select and batch delete', () => {
     );
 
     await screen.findByText('a.txt');
-    // Select a.txt (index 1) then Shift+Click c.txt (index 3): the range
-    // covers a, b, c — the ".." row at index 0 must NOT be selected.
-    fireEvent.click(screen.getByText('a.txt'));
-    fireEvent.click(screen.getByText('c.txt'), { shiftKey: true });
+    fireEvent.keyDown(document, { key: 'a', ctrlKey: true });
     expect(await screen.findByText('3 selected')).toBeTruthy();
 
-    // Delete via the range selection: only a/b/c are deleted, never "..".
+    // Delete via the selection: only a/b/c are deleted, never "..".
     fireEvent.keyDown(document, { key: 'Delete' });
     expect(await screen.findByText('Delete 3 Items?')).toBeTruthy();
     fireEvent.click(screen.getByRole('button', { name: 'Delete' }));

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -867,7 +867,8 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
     }
 
     if (event.ctrlKey || event.metaKey) {
-      // Ctrl/Cmd + Click: toggle this row in/out of the selection.
+      // Ctrl/Cmd + Click: toggle this row in/out of the selection and move
+      // the range anchor so a following Shift+Click ranges from this row.
       const newSelected = new Set(selectedFiles);
       if (newSelected.has(fileName)) {
         newSelected.delete(fileName);
@@ -875,6 +876,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
         newSelected.add(fileName);
       }
       setSelectedFiles(newSelected);
+      lastSelectedIndexRef.current = index;
     } else {
       // Plain click: single-select this row (keeps double-click navigation).
       setSelectedFiles(new Set([fileName]));
@@ -1018,8 +1020,16 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   };
 
   const handleDownloadMultiple = async (selectedFileItems: FileItem[]) => {
+    // Batch download is scoped to files. If the selection contains folders,
+    // tell the user they are skipped instead of silently dropping them.
     const filesToDownload = selectedFileItems.filter(f => f.type === 'file');
-    if (filesToDownload.length === 0) return;
+    const skippedDirs = selectedFileItems.filter(f => f.type === 'directory').length;
+    if (filesToDownload.length === 0) {
+      if (skippedDirs > 0) {
+        toast.info(t('fileBrowser.toast.downloadFoldersNotSupported'));
+      }
+      return;
+    }
     try {
       const destDir = await tauriOpen({ directory: true });
       if (!destDir) return;
@@ -1034,7 +1044,16 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
           totalBytes: f.size,
         })),
       });
-      toast.info(t('fileBrowser.toast.queuedDownload', { count: filesToDownload.length }));
+      if (skippedDirs > 0) {
+        toast.info(
+          t('fileBrowser.toast.downloadedFilesSkippedFolders', {
+            count: filesToDownload.length,
+            folders: skippedDirs,
+          }),
+        );
+      } else {
+        toast.info(t('fileBrowser.toast.queuedDownload', { count: filesToDownload.length }));
+      }
     } catch (error) {
       console.error('Download dialog error:', error);
     }
@@ -1120,7 +1139,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
         description: t('fileBrowser.toast.deleteFailedDesc'),
       });
     } else {
-      toast.error(t('fileBrowser.toast.deleteSomeFailed', { count: failed.length, total: deletingFiles.length }));
+      toast.error(t('fileBrowser.toast.deleteSomeFailed', { failed: failed.length, total: deletingFiles.length }));
     }
 
     setDeletingFiles(null);

--- a/src/components/integrated-file-browser.tsx
+++ b/src/components/integrated-file-browser.tsx
@@ -157,7 +157,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
   const [clipboard, setClipboard] = useState<{ files: FileItem[], operation: 'copy' | 'cut' } | null>(null);
   const [renamingFile, setRenamingFile] = useState<FileItem | null>(null);
   const [newFileName, setNewFileName] = useState('');
-  const [deletingFile, setDeletingFile] = useState<FileItem | null>(null);
+  const [deletingFiles, setDeletingFiles] = useState<FileItem[] | null>(null);
   const [directoryTransfer, setDirectoryTransfer] = useState<{
     sourcePath: string;
     destinationRoot: string;
@@ -328,7 +328,8 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
             break;
           case 'a':
             event.preventDefault();
-            setSelectedFiles(new Set(files.map(f => f.name)));
+            // Select all real entries, never the ".." parent row.
+            setSelectedFiles(new Set(files.filter(f => f.name !== '..').map(f => f.name)));
             break;
           case 'r':
             event.preventDefault();
@@ -337,8 +338,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
         }
       } else if (event.key === 'Delete' && selectedFiles.size > 0) {
         event.preventDefault();
-        const selectedFileItems = files.filter(f => selectedFiles.has(f.name));
-        selectedFileItems.forEach(handleDeleteFile);
+        handleDeleteSelected();
       } else if (event.key === 'F2' && selectedFiles.size === 1) {
         event.preventDefault();
         const selectedFile = files.find(f => selectedFiles.has(f.name));
@@ -836,10 +836,38 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
     }
   };
 
+  // Index (within the current sorted list) of the last plain click, used as
+  // the anchor for Shift+Click range selection. Reset when the list changes.
+  const lastSelectedIndexRef = useRef<number | null>(null);
+
   const handleFileSelect = (fileName: string, event: React.MouseEvent) => {
-    // Only select/deselect if Ctrl (Windows/Linux) or Cmd (Mac) is pressed
+    event.preventDefault();
+    event.stopPropagation();
+    const index = sortedFiles.findIndex((f) => f.name === fileName);
+    const lastIndex = lastSelectedIndexRef.current;
+
+    if (event.shiftKey && lastIndex !== null && index !== -1) {
+      // Shift+Click: select the contiguous range from the anchor to this row,
+      // excluding the ".." parent row which is never part of a selection.
+      const [start, end] = lastIndex <= index ? [lastIndex, index] : [index, lastIndex];
+      const rangeNames = sortedFiles
+        .slice(start, end + 1)
+        .map((f) => f.name)
+        .filter((name) => name !== '..');
+      const newSelected = new Set(selectedFiles);
+      rangeNames.forEach((name) => newSelected.add(name));
+      // Keep non-range selections only when Ctrl/Cmd is also held; a plain
+      // Shift+Click behaves like the platform default and replaces the range.
+      if (!event.ctrlKey && !event.metaKey) {
+        setSelectedFiles(new Set(rangeNames));
+      } else {
+        setSelectedFiles(newSelected);
+      }
+      return;
+    }
+
     if (event.ctrlKey || event.metaKey) {
-      event.stopPropagation();
+      // Ctrl/Cmd + Click: toggle this row in/out of the selection.
       const newSelected = new Set(selectedFiles);
       if (newSelected.has(fileName)) {
         newSelected.delete(fileName);
@@ -847,23 +875,29 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
         newSelected.add(fileName);
       }
       setSelectedFiles(newSelected);
+    } else {
+      // Plain click: single-select this row (keeps double-click navigation).
+      setSelectedFiles(new Set([fileName]));
+      lastSelectedIndexRef.current = index;
     }
-    // If not holding Ctrl/Cmd, do nothing (allow double-click to handle navigation)
   };
 
   const handleFileClick = (file: FileItem, event: React.MouseEvent) => {
-    console.log('handleFileClick called', { file, ctrlKey: event.ctrlKey, metaKey: event.metaKey });
-    
-    if (event.ctrlKey || event.metaKey) {
-      // Ctrl/Cmd + Click: toggle selection
+    // The ".." row is navigation-only: it is never selectable, and any click
+    // (plain or modifier) navigates back to the parent directory.
+    if (file.name === '..') {
+      navigateTo(file.path);
+      setSelectedFiles(new Set());
+      lastSelectedIndexRef.current = null;
+      return;
+    }
+    if (event.ctrlKey || event.metaKey || event.shiftKey) {
+      // Ctrl/Cmd/Shift + Click: toggle / range selection.
       handleFileSelect(file.name, event);
     } else {
-      // Regular click on directory: navigate into it
-      if (file.type === 'directory') {
-        console.log('Click - navigating to directory:', file.path);
-        navigateTo(file.path);
-      }
-      // Regular click on file: do nothing (or optionally preview)
+      // Plain click on a folder or file: single-select it. Opening a folder
+      // (drilling in) happens on double-click via handleFileDoubleClick.
+      handleFileSelect(file.name, event);
     }
   };
 
@@ -1043,41 +1077,60 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
 
   function handleDeleteFile(file: FileItem) {
     console.log('[FileBrowser] Opening delete confirmation for:', file.name);
-    setDeletingFile(file);
+    setDeletingFiles([file]);
   };
 
-  const confirmDeleteFile = async () => {
-    if (!deletingFile) return;
-    
-    console.log('[FileBrowser] Confirming delete for:', deletingFile.name);
-    try {
-      const filePath = deletingFile.path;
-      console.log('[FileBrowser] Deleting file', { 
-        filePath,
-        isDirectory: deletingFile.type === 'directory',
-        connectionId
-      });
+  function handleDeleteSelected() {
+    const selectedItems = files.filter(f => selectedFiles.has(f.name) && f.name !== '..');
+    if (selectedItems.length === 0) return;
+    console.log('[FileBrowser] Opening delete confirmation for', selectedItems.length, 'items');
+    setDeletingFiles(selectedItems);
+  }
 
-      await invoke<boolean>('delete_file', {
-        connectionId,
-        path: filePath,
-        isDirectory: deletingFile.type === 'directory'
-      });
-      
-      toast.success(t('fileBrowser.toast.deleted', { name: deletingFile.name }));
-      setDeletingFile(null);
-      void loadFiles();
-    } catch (error) {
-      console.error('[FileBrowser] Failed to delete file:', error);
-      toast.error(t('fileBrowser.toast.deleteFailed'), {
-        description: error instanceof Error ? error.message : t('fileBrowser.toast.deleteFailedDesc'),
-      });
+  const confirmDeleteFile = async () => {
+    if (!deletingFiles || deletingFiles.length === 0) return;
+
+    console.log('[FileBrowser] Confirming delete for', deletingFiles.length, 'items:', deletingFiles.map(f => f.name));
+    const failed: string[] = [];
+
+    for (const file of deletingFiles) {
+      try {
+        console.log('[FileBrowser] Deleting file', {
+          filePath: file.path,
+          isDirectory: file.type === 'directory',
+          connectionId,
+        });
+        await invoke<boolean>('delete_file', {
+          connectionId,
+          path: file.path,
+          isDirectory: file.type === 'directory',
+        });
+      } catch (error) {
+        console.error('[FileBrowser] Failed to delete file:', error);
+        failed.push(file.name);
+      }
     }
+
+    if (deletingFiles.length === 1 && failed.length === 0) {
+      toast.success(t('fileBrowser.toast.deleted', { name: deletingFiles[0].name }));
+    } else if (failed.length === 0) {
+      toast.success(t('fileBrowser.toast.deletedMultiple', { count: deletingFiles.length }));
+    } else if (failed.length === deletingFiles.length) {
+      toast.error(t('fileBrowser.toast.deleteFailed'), {
+        description: t('fileBrowser.toast.deleteFailedDesc'),
+      });
+    } else {
+      toast.error(t('fileBrowser.toast.deleteSomeFailed', { count: failed.length, total: deletingFiles.length }));
+    }
+
+    setDeletingFiles(null);
+    setSelectedFiles(new Set());
+    void loadFiles();
   };
 
   const cancelDeleteFile = () => {
     console.log('[FileBrowser] User cancelled deletion');
-    setDeletingFile(null);
+    setDeletingFiles(null);
   };
 
   function handleCopyFiles(files: FileItem[]) {
@@ -1379,6 +1432,12 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
     return sortDirection === 'asc' ? comparison : -comparison;
   });
 
+  // Reset the Shift+Click range anchor whenever the visible list changes
+  // (files, search, or sort), so stale indexes never mis-select rows.
+  useEffect(() => {
+    lastSelectedIndexRef.current = null;
+  }, [files, searchTerm, sortField, sortDirection]);
+
   // Count actual files/folders (excluding ".." navigation entry)
   const actualItemCount = filteredFiles.filter(file => file.name !== '..').length;
   
@@ -1548,8 +1607,16 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
           <span className="shrink-0 whitespace-nowrap text-[11px] text-muted-foreground">{t('fileBrowser.items', { count: actualItemCount })}</span>
 
           {selectedFiles.size > 0 && (
-            <span className="shrink-0 whitespace-nowrap rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary">
+            <span
+              className="shrink-0 whitespace-nowrap rounded-full bg-primary/10 px-2 py-0.5 text-[11px] text-primary"
+              title={t('fileBrowser.multiSelectHint')}
+            >
               {t('fileBrowser.selected', { count: selectedFiles.size })}
+            </span>
+          )}
+          {selectedFiles.size === 1 && (
+            <span className="shrink-0 whitespace-nowrap text-[10px] text-muted-foreground/70">
+              {t('fileBrowser.multiSelectHint')}
             </span>
           )}
         </div>
@@ -1736,7 +1803,7 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                         }}>
                           <ContextMenuTrigger asChild>
                             <div
-                              className={`flex items-center px-2 py-1 cursor-pointer transition-colors duration-100 rounded-md mx-1 my-px ${
+                              className={`select-none flex items-center px-2 py-1 cursor-pointer transition-colors duration-100 rounded-md mx-1 my-px ${
                                 isSel
                                   ? 'bg-accent/80 ring-1 ring-inset ring-accent-foreground/10'
                                   : isParent
@@ -1748,7 +1815,9 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                               onClick={(e) => handleFileClick(file, e)}
                               onDoubleClick={() => handleFileDoubleClick(file)}
                               onContextMenu={() => {
-                                if (!selectedFiles.has(file.name)) {
+                                // Right-clicking a non-selected row singles it out,
+                                // except the ".." parent row, which is never selectable.
+                                if (file.name !== '..' && !selectedFiles.has(file.name)) {
                                   setSelectedFiles(new Set([file.name]));
                                 }
                               }}
@@ -1831,11 +1900,11 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                   {/* Common actions */}
                   {file.name !== '..' && (
                     <>
-                      <ContextMenuItem onClick={() => handleCopyFiles([file])}>
+                      <ContextMenuItem onClick={() => handleCopyFiles(selectedFiles.has(file.name) && selectedFiles.size > 1 ? files.filter(f => selectedFiles.has(f.name) && f.name !== '..') : [file])}>
                         <Copy className="mr-2 h-4 w-4" />
                         {t('fileBrowser.contextMenu.copy')}
                       </ContextMenuItem>
-                      <ContextMenuItem onClick={() => handleCutFiles([file])}>
+                      <ContextMenuItem onClick={() => handleCutFiles(selectedFiles.has(file.name) && selectedFiles.size > 1 ? files.filter(f => selectedFiles.has(f.name) && f.name !== '..') : [file])}>
                         <Scissors className="mr-2 h-4 w-4" />
                         {t('fileBrowser.contextMenu.cut')}
                       </ContextMenuItem>
@@ -1859,19 +1928,17 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                     </>
                   )}
 
-                  {/* Download for files */}
+                  {/* Download */}
                   {file.type === 'file' && (
                     <>
-                      <ContextMenuItem onClick={() => handleDownload(file)}>
+                      <ContextMenuItem
+                        onClick={() => selectedFiles.size > 1 && selectedFiles.has(file.name)
+                          ? handleDownloadMultiple(files.filter(f => selectedFiles.has(f.name) && f.name !== '..'))
+                          : handleDownload(file)}
+                      >
                         <Download className="mr-2 h-4 w-4" />
                         {t('fileBrowser.contextMenu.download')}
                       </ContextMenuItem>
-                      {selectedFiles.size > 1 && (
-                        <ContextMenuItem onClick={() => handleDownloadMultiple(files.filter(f => selectedFiles.has(f.name)))}>
-                          <Download className="mr-2 h-4 w-4" />
-                          {t('fileBrowser.downloadSelected', { count: selectedFiles.size })}
-                        </ContextMenuItem>
-                      )}
                       <ContextMenuSeparator />
                     </>
                   )}
@@ -1890,9 +1957,11 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
                   {file.name !== '..' && (
                     <>
                       <ContextMenuSeparator />
-                      <ContextMenuItem 
+                      <ContextMenuItem
                         className="text-destructive focus:text-destructive"
-                        onClick={() => handleDeleteFile(file)}
+                        onClick={() => selectedFiles.size > 1 && selectedFiles.has(file.name)
+                          ? handleDeleteSelected()
+                          : handleDeleteFile(file)}
                       >
                         <Trash2 className="mr-2 h-4 w-4" />
                         {t('fileBrowser.contextMenu.delete')}
@@ -1990,16 +2059,38 @@ export function IntegratedFileBrowser({ connectionId, host: _host, isConnected, 
       )}
 
       {/* Delete Confirmation Dialog */}
-      <AlertDialog open={!!deletingFile} onOpenChange={(open) => !open && setDeletingFile(null)}>
+      <AlertDialog open={!!deletingFiles} onOpenChange={(open) => !open && setDeletingFiles(null)}>
         <AlertDialogContent>
           <AlertDialogHeader>
-            <AlertDialogTitle>{deletingFile?.type === 'directory' ? t('fileBrowser.deleteFolderTitle') : t('fileBrowser.deleteFileTitle')}</AlertDialogTitle>
+            <AlertDialogTitle>
+              {deletingFiles && deletingFiles.length > 1
+                ? t('fileBrowser.deleteMultipleTitle', { count: deletingFiles.length })
+                : deletingFiles?.[0]?.type === 'directory'
+                  ? t('fileBrowser.deleteFolderTitle')
+                  : t('fileBrowser.deleteFileTitle')}
+            </AlertDialogTitle>
             <AlertDialogDescription>
-              {t('fileBrowser.deleteConfirm', { name: deletingFile?.name })}
-              {deletingFile?.type === 'directory' && (
-                <span className="block mt-2 text-destructive font-medium">
-                  {t('fileBrowser.deleteFolderWarning')}
+              {deletingFiles && deletingFiles.length > 1 ? (
+                <span>
+                  {t('fileBrowser.deleteMultipleConfirm', { count: deletingFiles.length })}
+                  {deletingFiles.some(f => f.type === 'directory') && (
+                    <span className="block mt-2 text-destructive font-medium">
+                      {t('fileBrowser.deleteFolderWarning')}
+                    </span>
+                  )}
+                  <span className="mt-2 block max-h-40 overflow-y-auto rounded border border-border bg-muted/40 p-2 text-xs">
+                    {deletingFiles.map(f => f.name).join(', ')}
+                  </span>
                 </span>
+              ) : (
+                <>
+                  {t('fileBrowser.deleteConfirm', { name: deletingFiles?.[0]?.name })}
+                  {deletingFiles?.[0]?.type === 'directory' && (
+                    <span className="block mt-2 text-destructive font-medium">
+                      {t('fileBrowser.deleteFolderWarning')}
+                    </span>
+                  )}
+                </>
               )}
               {t('fileBrowser.cannotBeUndone')}
             </AlertDialogDescription>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -585,7 +585,9 @@
       "enterFileName": "Enter file name:",
       "fileInfo": "File: {{name}}\nSize: {{size}}\nModified: {{modified}}\nPermissions: {{permissions}}",
       "deletedMultiple": "{{count}} items deleted successfully",
-      "deleteSomeFailed": "{{failed}} of {{total}} items failed to delete"
+      "deleteSomeFailed": "{{failed}} of {{total}} items failed to delete",
+      "downloadFoldersNotSupported": "Folders cannot be batch-downloaded; use Download directory instead",
+      "downloadedFilesSkippedFolders": "Downloaded {{count}} files, skipped {{folders}} folder(s)"
     },
     "toolbar": {
       "back": "Back",

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -583,7 +583,9 @@
       "queuedUploadToPath": "Queued {{count}} file(s) for upload to {{path}}",
       "enterFolderName": "Enter folder name:",
       "enterFileName": "Enter file name:",
-      "fileInfo": "File: {{name}}\nSize: {{size}}\nModified: {{modified}}\nPermissions: {{permissions}}"
+      "fileInfo": "File: {{name}}\nSize: {{size}}\nModified: {{modified}}\nPermissions: {{permissions}}",
+      "deletedMultiple": "{{count}} items deleted successfully",
+      "deleteSomeFailed": "{{failed}} of {{total}} items failed to delete"
     },
     "toolbar": {
       "back": "Back",
@@ -603,7 +605,6 @@
     },
     "selected": "{{count}} selected",
     "loading": "Loading…",
-    "downloadSelected": "Download {{count}} Selected",
     "deleteFolderTitle": "Delete Folder?",
     "deleteFileTitle": "Delete File?",
     "contextMenuRefresh": "Refresh",
@@ -637,7 +638,10 @@
       "download": "Download"
     },
     "dropOverlay": "Drop files or folders to upload",
-    "dropUploadTo": "Upload to {{path}}"
+    "dropUploadTo": "Upload to {{path}}",
+    "multiSelectHint": "Tip: Cmd/Ctrl+Click to select multiple, Shift+Click for range",
+    "deleteMultipleTitle": "Delete {{count}} Items?",
+    "deleteMultipleConfirm": "Are you sure you want to delete these {{count}} items?"
   },
   "contextMenu": {
     "copy": "Copy",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -583,7 +583,9 @@
       "queuedUploadToPath": "已排队 {{count}} 个文件等待上传到 {{path}}",
       "enterFolderName": "请输入文件夹名称：",
       "enterFileName": "请输入文件名称：",
-      "fileInfo": "文件：{{name}}\n大小：{{size}}\n修改时间：{{modified}}\n权限：{{permissions}}"
+      "fileInfo": "文件：{{name}}\n大小：{{size}}\n修改时间：{{modified}}\n权限：{{permissions}}",
+      "deletedMultiple": "已成功删除 {{count}} 个项目",
+      "deleteSomeFailed": "{{total}} 个项目中有 {{failed}} 个删除失败"
     },
     "toolbar": {
       "back": "后退",
@@ -603,7 +605,6 @@
     },
     "selected": "已选择 {{count}} 项",
     "loading": "加载中…",
-    "downloadSelected": "下载选中的 {{count}} 项",
     "deleteFolderTitle": "删除文件夹？",
     "deleteFileTitle": "删除文件？",
     "contextMenuRefresh": "刷新",
@@ -637,7 +638,10 @@
       "download": "下载"
     },
     "dropOverlay": "拖放文件或文件夹以上传",
-    "dropUploadTo": "上传到 {{path}}"
+    "dropUploadTo": "上传到 {{path}}",
+    "multiSelectHint": "提示：Cmd/Ctrl+点击 多选，Shift+点击 范围选择",
+    "deleteMultipleTitle": "删除 {{count}} 个项目？",
+    "deleteMultipleConfirm": "确定要删除这 {{count}} 个项目吗？"
   },
   "contextMenu": {
     "copy": "复制",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -585,7 +585,9 @@
       "enterFileName": "请输入文件名称：",
       "fileInfo": "文件：{{name}}\n大小：{{size}}\n修改时间：{{modified}}\n权限：{{permissions}}",
       "deletedMultiple": "已成功删除 {{count}} 个项目",
-      "deleteSomeFailed": "{{total}} 个项目中有 {{failed}} 个删除失败"
+      "deleteSomeFailed": "{{total}} 个项目中有 {{failed}} 个删除失败",
+      "downloadFoldersNotSupported": "文件夹不支持批量下载，请使用「下载文件夹」",
+      "downloadedFilesSkippedFolders": "已下载 {{count}} 个文件，跳过 {{folders}} 个文件夹"
     },
     "toolbar": {
       "back": "后退",


### PR DESCRIPTION
## Summary

Improves the file browser's multi-select and batch operations to match platform conventions.

Fixes #97

### Changes
- **Single click selects a row**; folders open only on double-click (previously single-click drilled into folders)
- **Shift+Click** selects a contiguous range; **Cmd/Ctrl+Click** toggles rows; **Ctrl+A** selects all real entries (never the `..` parent row)
- **Delete key and context-menu Delete** operate on the whole selection via a batch confirmation dialog that lists every affected item (previously only the last item was deleted)
- Context-menu **Download/Copy/Cut** act on the selection when multiple rows are selected; dropped the "N Selected" labels
- Rows are `select-none` so range selection no longer highlights text
- The `..` parent row is never selectable and is excluded from all batch operations

### Test
- 583 frontend tests pass
- i18n parity: 1049 keys in both locales
- Manually verified in the packaged app