### PR TITLE
fix(restore): cancel session restore when the 60s overall timeout fires

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,6 +35,7 @@ import type { TerminalTab } from './lib/terminal-group-types';
 import { Toaster } from './components/ui/sonner';
 import { toast } from 'sonner';
 import { dispatchTerminalCommand, type TerminalCommand } from './lib/terminal-commands';
+import { getRestoreTiming } from './lib/restore-timing';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -61,6 +62,14 @@ function AppContent() {
   // Terminal group state from context
   const { state, dispatch, activeGroup, activeTab, activeConnection } = useTerminalGroups();
   const workingDirectorySequenceRef = useRef(0);
+  // Fresh mirror of `state` for the mount-only restore effect (empty deps):
+  // the closure's `state` is a mount-time snapshot, but the restore loop may
+  // take minutes, during which the user can switch/split groups. Reading via
+  // this ref keeps the ADD_TAB target group current.
+  const stateRef = useRef(state);
+  useEffect(() => {
+    stateRef.current = state;
+  }, [state]);
   const [terminalWorkingDirectories, setTerminalWorkingDirectories] = useState<
     Record<string, { path: string; sequence: number }>
   >({});
@@ -242,16 +251,30 @@ function AppContent() {
   useEffect(() => {
     /** Race a promise against a timeout; rejects with a clear message on expiry. */
     function withTimeout<T>(promise: Promise<T>, ms: number, label: string): Promise<T> {
-      return Promise.race([
-        promise,
-        new Promise<never>((_resolve, reject) =>
-          setTimeout(() => reject(new Error(`Timeout: ${label} did not complete within ${ms / 1000}s`)), ms),
-        ),
-      ]);
+      return new Promise<T>((resolve, reject) => {
+        const timer = setTimeout(
+          () => reject(new Error(`Timeout: ${label} did not complete within ${ms / 1000}s`)),
+          ms,
+        );
+        promise.then(
+          (value) => {
+            clearTimeout(timer);
+            resolve(value);
+          },
+          (err: unknown) => {
+            clearTimeout(timer);
+            reject(err instanceof Error ? err : new Error(String(err)));
+          },
+        );
+      });
     }
 
-    const CONNECT_TIMEOUT_MS = 15_000; // 15 s per backend connect call
-    const OVERALL_RESTORE_TIMEOUT_MS = 60_000; // 60 s for the entire restore
+    const { connectTimeoutMs: CONNECT_TIMEOUT_MS, overallTimeoutMs: OVERALL_RESTORE_TIMEOUT_MS } = getRestoreTiming();
+
+    // Soft-cancel flag: once the overall timeout fires, the restore loop stops
+    // initiating NEW connections. The connection currently in flight is allowed
+    // to finish naturally so a just-succeeding host is not killed mid-handshake.
+    let restoreCancelled = false;
 
     const restoreConnections = async () => {
       const activeConnections = ActiveConnectionsManager.getActiveConnections();
@@ -263,8 +286,9 @@ function AppContent() {
       // Collect tab IDs already present in the restored layout state to avoid duplicates.
       // The TerminalGroupProvider may have loaded tabs from localStorage, so we only need
       // to re-establish SSH connections for those tabs, not add them again.
+      // stateRef keeps the ADD_TAB target group fresh for long-running restores.
       const existingTabIds = new Set(
-        Object.values(state.groups).flatMap(g => g.tabs.map(t => t.id))
+        Object.values(stateRef.current.groups).flatMap(g => g.tabs.map(t => t.id))
       );
 
       console.log('Previous connections found:', activeConnections);
@@ -276,8 +300,17 @@ function AppContent() {
 
       let restoredCount = 0;
       let failedCount = 0;
+      let skippedByTimeout = 0;
 
       for (let i = 0; i < sortedConnections.length; i++) {
+        if (restoreCancelled) {
+          // Overall timeout fired: stop initiating new connections. Count the
+          // remaining entries as skipped so the summary reflects reality.
+          skippedByTimeout += sortedConnections.length - i;
+          console.warn(`Session restore cancelled at connection ${i + 1}/${sortedConnections.length}; ${skippedByTimeout} connection(s) skipped`);
+          break;
+        }
+
         const activeConn = sortedConnections[i];
         const connectionIdToLoad = activeConn.originalConnectionId || activeConn.connectionId;
         const connectionData = ConnectionStorageManager.getConnection(connectionIdToLoad);
@@ -356,7 +389,7 @@ function AppContent() {
                 connectionStatus: 'connected',
                 reconnectCount: 0,
               };
-              dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+              dispatch({ type: 'ADD_TAB', groupId: stateRef.current.activeGroupId, tab: newTab });
             }
 
             restoredCount++;
@@ -416,7 +449,7 @@ function AppContent() {
                 connectionStatus: 'connected',
                 reconnectCount: 0,
               };
-              dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+              dispatch({ type: 'ADD_TAB', groupId: stateRef.current.activeGroupId, tab: newTab });
             }
 
             restoredCount++;
@@ -452,7 +485,7 @@ function AppContent() {
                   connectionStatus: 'connecting',
                   reconnectCount: 0,
                 };
-                dispatch({ type: 'ADD_TAB', groupId: state.activeGroupId, tab: newTab });
+                dispatch({ type: 'ADD_TAB', groupId: stateRef.current.activeGroupId, tab: newTab });
               }
 
               restoredCount++;
@@ -478,13 +511,22 @@ function AppContent() {
         }
       }
 
-      if (restoredCount > 0) {
+      const totalFailed = failedCount + skippedByTimeout;
+      if (restoreCancelled) {
+        // The overall timeout fired (possibly while the LAST connection was
+        // still in flight, so the loop never saw the flag at a loop head).
+        // The timeout toast below already told the user; keep the
+        // active-connections list intact so a manual reconnect of the skipped
+        // hosts is still possible, and do not emit a contradicting success or
+        // "all failed" toast here.
+      } else if (restoredCount > 0 && skippedByTimeout === 0) {
         toast.success(t('app.connectionsRestored'), {
-          description: failedCount > 0
-            ? t('app.connectionsRestoredDesc', { restoredCount, failedCount })
+          description: totalFailed > 0
+            ? t('app.connectionsRestoredDesc', { restoredCount, failedCount: totalFailed })
             : t('app.connectionsRestoredAllDesc', { restoredCount }),
         });
-      } else if (failedCount > 0) {
+      } else if (restoredCount === 0 && totalFailed > 0 && skippedByTimeout === 0) {
+        // All connections failed without a timeout: nothing left to restore.
         ActiveConnectionsManager.clearActiveConnections();
         toast.error(t('app.restoreFailed'), {
           description: t('app.restoreFailedDesc'),
@@ -498,10 +540,21 @@ function AppContent() {
     };
 
     withTimeout(restoreConnections(), OVERALL_RESTORE_TIMEOUT_MS, 'Session restore').catch((err) => {
-      console.error('Session restore timed out:', err);
-      toast.error(t('app.restoreTimedOut'), {
-        description: t('app.restoreTimedOutDesc'),
-      });
+      // Distinguish the overall-timeout rejection from an unexpected error
+      // thrown by restoreConnections itself (e.g. storage parse). Only the
+      // former should cancel the loop and show the timeout toast.
+      const isOverallTimeout = err instanceof Error && err.message.startsWith('Timeout:');
+      if (isOverallTimeout) {
+        console.error('Session restore timed out:', err);
+        // Soft-cancel: the in-flight connection may still complete, but the loop
+        // must not start any new connections after this point.
+        restoreCancelled = true;
+        toast.error(t('app.restoreTimedOut'), {
+          description: t('app.restoreTimedOutDesc'),
+        });
+      } else {
+        console.error('Session restore failed:', err);
+      }
       setCurrentRestoreTarget(null);
       setIsRestoring(false);
       setRestoringProgress({ current: 0, total: 0 });

--- a/src/__tests__/restore-timeout-cancellation.test.tsx
+++ b/src/__tests__/restore-timeout-cancellation.test.tsx
@@ -15,9 +15,10 @@
  * active-connections list is kept intact so a manual reconnect stays possible.
  *
  * This test renders the real App shell (mocked providers like the reconnect
- * test) with a mocked ActiveConnectionsManager returning 5 connections, a
- * hung `ssh_connect` for the first one, and fake timers to fast-forward past
- * the 60 s threshold.
+ * test) with a mocked ActiveConnectionsManager returning 5 connections and a
+ * hung `ssh_connect`. It runs on shortened REAL timers via
+ * `setRestoreTimingForTests` (per-connect 100 ms, overall 350 ms) instead of
+ * fake timers, which avoids fighting fake-timer/React-scheduler interplay.
  */
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -30,6 +31,7 @@ const lifecycle = vi.hoisted(() => ({
   invoke: vi.fn(),
   activeConnections: [] as Array<{ tabId: string; connectionId: string; order: number; tabType: string; protocol: string }>,
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  clearActiveConnectionsCalls: 0,
 }));
 
 let mockState: TerminalGroupState;
@@ -81,7 +83,11 @@ vi.mock('@/lib/connection-storage', async (importOriginal) => {
     ActiveConnectionsManager: {
       getActiveConnections: () => lifecycle.activeConnections,
       saveActiveConnections: () => {},
-      clearActiveConnections: () => {},
+      // Observable no-op: the test asserts the timeout path must NOT wipe the
+      // reconnect list, so count invocations instead of silently clearing.
+      clearActiveConnections: () => {
+        lifecycle.clearActiveConnectionsCalls++;
+      },
     },
   };
 });
@@ -92,6 +98,17 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 vi.mock('@tauri-apps/api/event', () => ({
   listen: vi.fn(async () => vi.fn()),
+}));
+
+// The real restore loop waits up to 3 s per connection on
+// registerRestoration (for the PTY to signal ready). Collapse that gate so
+// serial connections proceed instantly; otherwise the overall-timeout window
+// would elapse while the loop is still parked on the FIRST gate and never
+// reach the "timeout lands on the final in-flight connection" case.
+vi.mock('@/lib/restoration-manager', () => ({
+  registerRestoration: vi.fn(async () => {}),
+  signalReady: vi.fn(),
+  clearAllRestorations: vi.fn(),
 }));
 
 vi.mock('sonner', () => ({ toast: lifecycle.toast }));
@@ -194,6 +211,7 @@ describe('session restore overall-timeout cancellation', () => {
     lifecycle.toast.error.mockReset();
     lifecycle.toast.success.mockReset();
     lifecycle.toast.info.mockReset();
+    lifecycle.clearActiveConnectionsCalls = 0;
   });
 
   afterEach(() => {
@@ -239,5 +257,63 @@ describe('session restore overall-timeout cancellation', () => {
     await new Promise((resolve) => setTimeout(resolve, 300));
     const sshCallsAfter = lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect').length;
     expect(sshCallsAfter).toBe(sshCallsAtTimeout);
+  });
+
+  it('suppresses the summary toast and keeps the active list when the overall timeout lands during the final in-flight connection', async () => {
+    // The per-connect budget must outlive the overall budget so the 5th
+    // connection can still be in flight when the overall timeout fires at
+    // 350 ms (a per-connect 100 ms budget would reject it first, which is not
+    // the reported worst case).
+    setRestoreTimingForTests({ connectTimeoutMs: 10_000, overallTimeoutMs: 350 });
+
+    // First 4 connections succeed immediately; the 5th hangs until we settle
+    // it AFTER the overall timeout has already fired.
+    let settleFinal: (() => void) | undefined;
+    const finalInvoke = new Promise<{ success: boolean }>((resolve) => {
+      settleFinal = () => resolve({ success: true });
+    });
+    let sshCalls = 0;
+    lifecycle.invoke.mockImplementation((command: string) => {
+      if (command === 'ssh_connect') {
+        sshCalls++;
+        if (sshCalls < 5) return Promise.resolve({ success: true });
+        return finalInvoke;
+      }
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+
+    render(<App />);
+
+    // Wait for the overall-timeout toast (fires at ~350 ms of real time).
+    await vi.waitFor(
+      () => {
+        expect(lifecycle.toast.error).toHaveBeenCalled();
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // Note: App.tsx's allTabs effect calls clearActiveConnections() once on
+    // mount (no tabs restored yet) — that happens BEFORE the restore loop, so
+    // snapshot the count and assert the timeout path adds no further wipes.
+    const clearCallsAtTimeout = lifecycle.clearActiveConnectionsCalls;
+    const errorCallsAtSettle = lifecycle.toast.error.mock.calls.length;
+    const successCallsBefore = lifecycle.toast.success.mock.calls.length;
+
+    // The final connection was already in flight when the timeout fired; let
+    // it succeed now (soft-cancel allows in-flight work to finish naturally).
+    settleFinal!();
+
+    // Give the loop a moment to complete the final iteration.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    // The timeout toast already told the user: settling the in-flight
+    // connection afterwards must not emit a contradicting success summary, an
+    // extra error toast, or another list wipe (skipped hosts stay manually
+    // reconnectable).
+    expect(lifecycle.toast.success.mock.calls.length).toBe(successCallsBefore);
+    expect(lifecycle.toast.error.mock.calls.length).toBe(errorCallsAtSettle);
+    expect(lifecycle.clearActiveConnectionsCalls).toBe(clearCallsAtTimeout);
+    expect(lifecycle.activeConnections).toHaveLength(5);
   });
 });

--- a/src/__tests__/restore-timeout-cancellation.test.tsx
+++ b/src/__tests__/restore-timeout-cancellation.test.tsx
@@ -1,0 +1,243 @@
+/**
+ * Regression test for: session restore keeps connecting after the 60 s
+ * overall timeout has fired.
+ *
+ * Root cause (App.tsx restore effect): the outer
+ * `withTimeout(restoreConnections(), 60_000)` only raced the promise — when
+ * the timeout rejected, the restore loop kept running in the background and
+ * kept issuing `invoke('ssh_connect')` / dispatching ADD_TAB. The user saw the
+ * "restore timed out" toast and a closed overlay, but tabs still appeared
+ * late and new connections kept being initiated.
+ *
+ * Fix: a soft-cancel flag. Once the overall timeout fires, the loop stops
+ * initiating NEW connections; the connection currently in flight is allowed to
+ * finish naturally. The remaining entries are counted as skipped and the
+ * active-connections list is kept intact so a manual reconnect stays possible.
+ *
+ * This test renders the real App shell (mocked providers like the reconnect
+ * test) with a mocked ActiveConnectionsManager returning 5 connections, a
+ * hung `ssh_connect` for the first one, and fake timers to fast-forward past
+ * the 60 s threshold.
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { TerminalGroupState } from '../lib/terminal-group-types';
+import App from '../App';
+import { getRestoreTiming, setRestoreTimingForTests } from '../lib/restore-timing';
+
+const lifecycle = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  activeConnections: [] as Array<{ tabId: string; connectionId: string; order: number; tabType: string; protocol: string }>,
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+}));
+
+let mockState: TerminalGroupState;
+
+function makeMockState(): TerminalGroupState {
+  return {
+    groups: { 'group-1': { id: 'group-1', tabs: [], activeTabId: null } },
+    activeGroupId: 'group-1',
+    gridLayout: { type: 'leaf', groupId: 'group-1' },
+    nextGroupId: 2,
+    tabToGroupMap: {},
+  };
+}
+
+vi.mock('@/lib/terminal-group-context', async () => {
+  const ReactModule = await import('react');
+  const { terminalGroupReducer } = await import('@/lib/terminal-group-reducer');
+  const Ctx = ReactModule.createContext<unknown>(null);
+  return {
+    TerminalGroupProvider: ({ children }: { children: React.ReactNode }) => {
+      const [state, dispatch] = ReactModule.useReducer(terminalGroupReducer, mockState);
+      const activeGroup = state.groups[state.activeGroupId] ?? null;
+      const activeTab =
+        activeGroup?.tabs.find((t) => t.id === activeGroup.activeTabId) ?? null;
+      const activeConnection = activeTab
+        ? { connectionId: activeTab.id, name: activeTab.name, protocol: '', host: '', username: '', status: activeTab.connectionStatus }
+        : null;
+      const value = ReactModule.useMemo(
+        () => ({ state, dispatch, activeGroup, activeTab, activeConnection }),
+        [state],
+      );
+      return ReactModule.createElement(Ctx.Provider, { value }, children);
+    },
+    useTerminalGroups: () => ReactModule.useContext(Ctx),
+  };
+});
+
+vi.mock('@/components/pty-terminal', async () => {
+  const ReactModule = await import('react');
+  return {
+    PtyTerminal: () => ReactModule.createElement('div', { 'data-testid': 'pty' }),
+  };
+});
+
+vi.mock('@/lib/connection-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/connection-storage')>();
+  return {
+    ...actual,
+    ActiveConnectionsManager: {
+      getActiveConnections: () => lifecycle.activeConnections,
+      saveActiveConnections: () => {},
+      clearActiveConnections: () => {},
+    },
+  };
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => lifecycle.invoke(...args),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('sonner', () => ({ toast: lifecycle.toast }));
+
+vi.mock('@/components/connection-dialog', async () => {
+  const ReactModule = await import('react');
+  return { ConnectionDialog: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/system-monitor', async () => {
+  const ReactModule = await import('react');
+  return { SystemMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/log-monitor', async () => {
+  const ReactModule = await import('react');
+  return { LogMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/menu-bar', async () => {
+  const ReactModule = await import('react');
+  return { MenuBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/status-bar', async () => {
+  const ReactModule = await import('react');
+  return { StatusBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/integrated-file-browser', async () => {
+  const ReactModule = await import('react');
+  return { IntegratedFileBrowser: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/update-checker', async () => {
+  const ReactModule = await import('react');
+  return { UpdateChecker: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/welcome-screen', async () => {
+  const ReactModule = await import('react');
+  return { WelcomeScreen: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/ui/sonner', async () => {
+  const ReactModule = await import('react');
+  return { Toaster: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/desktop-viewer', async () => {
+  const ReactModule = await import('react');
+  return { DesktopViewer: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-browser-view', async () => {
+  const ReactModule = await import('react');
+  return { FileBrowserView: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-editor-view', async () => {
+  const ReactModule = await import('react');
+  return { FileEditorView: () => ReactModule.createElement('div') };
+});
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+describe('session restore overall-timeout cancellation', () => {
+  beforeEach(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverMock;
+    mockState = makeMockState();
+    localStorage.clear();
+
+    // 5 saved SSH connections, all with credentials, all marked active.
+    const connections = Array.from({ length: 5 }, (_, i) => ({
+      id: `conn-${i + 1}`,
+      name: `Server ${i + 1}`,
+      host: 'example.com',
+      port: 22,
+      username: 'root',
+      protocol: 'SSH',
+      authMethod: 'password',
+      password: 'secret',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+    localStorage.setItem('r-shell-connections', JSON.stringify(connections));
+    localStorage.setItem(
+      'r-shell-active-connections',
+      JSON.stringify(
+        connections.map((c, i) => ({
+          tabId: c.id,
+          connectionId: c.id,
+          order: i,
+          tabType: 'terminal',
+          protocol: 'SSH',
+        })),
+      ),
+    );
+    lifecycle.activeConnections = connections.map((c, i) => ({
+      tabId: c.id,
+      connectionId: c.id,
+      order: i,
+      tabType: 'terminal' as const,
+      protocol: 'SSH' as const,
+    }));
+
+    lifecycle.invoke.mockReset();
+    lifecycle.toast.error.mockReset();
+    lifecycle.toast.success.mockReset();
+    lifecycle.toast.info.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    // Restore production timing defaults for other tests.
+    setRestoreTimingForTests({ connectTimeoutMs: 15_000, overallTimeoutMs: 60_000 });
+  });
+
+  it('stops initiating new connections after the overall timeout fires', async () => {
+    // Shrink the timeouts so the test runs on real timers in milliseconds:
+    // per-connect 100 ms, overall 350 ms — far below the 500 ms that 5 serial
+    // connections would need, so the overall budget fires mid-restore.
+    setRestoreTimingForTests({ connectTimeoutMs: 100, overallTimeoutMs: 350 });
+
+    // Every ssh_connect hangs forever (never resolves).
+    lifecycle.invoke.mockImplementation((command: string) => {
+      if (command === 'ssh_connect') {
+        return new Promise(() => {});
+      }
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+
+    render(<App />);
+
+    // Wait for the overall-timeout toast (fires at ~350 ms of real time).
+    // Generous timeout: slow CI runners occasionally exceed the default 1000 ms.
+    await vi.waitFor(
+      () => {
+        expect(lifecycle.toast.error).toHaveBeenCalled();
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // Snapshot how many connections were initiated by the time the budget
+    // fired; then wait well past the point where any remaining connection
+    // would have started (500 ms serial). The count must NOT grow — the cancel
+    // flag stopped the loop from initiating the rest.
+    const sshCallsAtTimeout = lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect').length;
+    expect(sshCallsAtTimeout).toBeGreaterThan(0);
+    expect(sshCallsAtTimeout).toBeLessThan(5);
+
+    await new Promise((resolve) => setTimeout(resolve, 300));
+    const sshCallsAfter = lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect').length;
+    expect(sshCallsAfter).toBe(sshCallsAtTimeout);
+  });
+});

--- a/src/lib/restoration-manager.ts
+++ b/src/lib/restoration-manager.ts
@@ -43,6 +43,10 @@ export function signalReady(connectionId: string): void {
 export function clearAllRestorations(): void {
   for (const entry of pendingRestorations.values()) {
     clearTimeout(entry.timeout);
+    // Resolve any in-flight registerRestoration promises so an await on them
+    // (e.g. the session-restore loop) does not hang forever after a timeout
+    // or abort clears the registry.
+    entry.resolve();
   }
   pendingRestorations.clear();
   earlySignals.clear();

--- a/src/lib/restore-timing.ts
+++ b/src/lib/restore-timing.ts
@@ -1,0 +1,29 @@
+/**
+ * Session-restore timing for App.tsx's mount-time restore effect.
+ *
+ * The values are mutable behind a setter so tests can shrink the timeouts and
+ * run on real timers (fast, deterministic) instead of fighting
+ * fake-timer/React-scheduler interplay. Production always uses the defaults
+ * and nothing else in the app mutates them.
+ */
+
+let connectTimeoutMs = 15_000; // per backend connect call
+let overallTimeoutMs = 60_000; // entire restore budget
+
+export interface RestoreTiming {
+  connectTimeoutMs: number;
+  overallTimeoutMs: number;
+}
+
+export function getRestoreTiming(): RestoreTiming {
+  return { connectTimeoutMs, overallTimeoutMs };
+}
+
+/**
+ * Test-only override. Callers (tests) must restore the defaults afterwards,
+ * e.g. in afterEach.
+ */
+export function setRestoreTimingForTests(partial: Partial<RestoreTiming>): void {
+  connectTimeoutMs = partial.connectTimeoutMs ?? connectTimeoutMs;
+  overallTimeoutMs = partial.overallTimeoutMs ?? overallTimeoutMs;
+}


### PR DESCRIPTION
## Summary

Fixes #98

The session-restore loop kept running after the 60 s overall timeout: it continued issuing `ssh_connect` and `ADD_TAB` in the background while the UI already showed `Restore Timed Out` with the overlay closed.

## Changes

- **Soft-cancel flag**: once the overall timeout fires, the loop stops initiating NEW connections; the in-flight one finishes naturally (a just-succeeding host is not killed mid-handshake).
- **Skipped connections counted**: remaining entries are counted as skipped; the active-connections list is kept intact so skipped hosts can be manually reconnected.
- **Summary gating**: the overall-timeout branch also suppresses the success/failure summary when the timeout lands during the last connection's in-flight await (no contradicting toast, no list wipe).
- **`clearAllRestorations()` resolves in-flight `registerRestoration` promises** so the loop cannot hang in that window.
- **`withTimeout` clears its timer on settle** (no dangling 15s/60s timers).
- **Stale-state fix**: the restore loop reads group state via a ref instead of the mount-time snapshot, so `ADD_TAB` lands in the currently active group during long restores.

## Repro

1. Create 5 SSH connections that cannot connect (e.g. host `10.255.255.1`, port 22) and save them.
2. Close and reopen the app; the restore flow reconnects them serially, each hanging ~15s.
3. At ~60s the `Restore Timed Out` toast appears. **Before**: tabs keep appearing and new `ssh_connect` calls continue. **After**: no new connections are initiated; the list stays intact for manual reconnect.

## Test

- New `restore-timeout-cancellation` test (verified: fails on the buggy version, passes on the fix) with an independent self-review pass.
- 579 tests pass; tsc clean; no new lint warnings.
- Manually verified in the packaged app.