### PR TITLE
fix(terminal): recover SSH-dead sessions via typed errors and auto re-auth

### DIFF
--- a/src-tauri/src/connection_manager.rs
+++ b/src-tauri/src/connection_manager.rs
@@ -12,6 +12,51 @@ use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
 
+/// Error from starting a PTY session, distinguishing a dead/unusable SSH
+/// session (the frontend must re-authenticate — a WebSocket retry cannot
+/// recover) from other failures that leave the session intact.
+#[derive(Debug)]
+pub enum PtyStartError {
+    /// The SSH session is gone or unusable. Any stale client has already
+    /// been evicted from the connection map.
+    SshSessionDead(String),
+    /// Any other failure; the session is left as-is.
+    Other(anyhow::Error),
+}
+
+impl std::fmt::Display for PtyStartError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            PtyStartError::SshSessionDead(msg) => write!(f, "{}", msg),
+            PtyStartError::Other(e) => write!(f, "{}", e),
+        }
+    }
+}
+
+impl std::error::Error for PtyStartError {}
+
+impl From<anyhow::Error> for PtyStartError {
+    fn from(e: anyhow::Error) -> Self {
+        PtyStartError::Other(e)
+    }
+}
+
+/// Whether an error raised while opening a channel indicates the underlying
+/// SSH session itself is dead (transport gone), as opposed to recoverable
+/// conditions like the server temporarily refusing more channels
+/// (`ChannelOpenFailure`, e.g. MaxSessions exhaustion).
+fn is_session_dead_error(e: &anyhow::Error) -> bool {
+    matches!(
+        e.downcast_ref::<russh::Error>(),
+        Some(russh::Error::SendError)
+            | Some(russh::Error::Disconnect)
+            | Some(russh::Error::HUP)
+            | Some(russh::Error::ConnectionTimeout)
+            | Some(russh::Error::KeepaliveTimeout)
+            | Some(russh::Error::InactivityTimeout)
+    )
+}
+
 pub struct ConnectionManager {
     connections: Arc<RwLock<HashMap<String, Arc<RwLock<SshClient>>>>>,
     pty_sessions: Arc<RwLock<HashMap<String, Arc<PtySession>>>>,
@@ -117,19 +162,44 @@ impl ConnectionManager {
 
     /// Start a PTY shell connection (like ttyd does)
     /// Enables interactive commands: vim, less, more, top, htop, etc.
+    ///
+    /// If the stored SSH session turns out to be dead (e.g. the transport
+    /// dropped while a terminal was idle), the stale client is evicted and
+    /// `PtyStartError::SshSessionDead` is returned so the frontend can
+    /// escalate to a full reconnect instead of retrying the WebSocket.
     pub async fn start_pty_connection(
         &self,
         connection_id: &str,
         cols: u32,
         rows: u32,
-    ) -> Result<u64> {
-        // Get the SSH client
-        let connections = self.connections.read().await;
-        let client = connections
-            .get(connection_id)
-            .ok_or_else(|| anyhow::anyhow!("Connection not found"))?;
+    ) -> Result<u64, PtyStartError> {
+        // Get the SSH client. A missing entry means the SSH session is gone
+        // entirely — same escalation as a dead transport.
+        let client = {
+            let connections = self.connections.read().await;
+            connections.get(connection_id).cloned().ok_or_else(|| {
+                PtyStartError::SshSessionDead(format!(
+                    "SSH session not found for {} (connection closed); reconnect required",
+                    connection_id
+                ))
+            })?
+        };
 
-        let client = client.read().await;
+        // Create PTY session. The map lock is released first so a slow or
+        // failing handshake can't block unrelated connections.
+        let pty = match client.read().await.create_pty_session(cols, rows).await {
+            Ok(pty) => pty,
+            Err(e) => {
+                if is_session_dead_error(&e) {
+                    self.evict_dead_connection(connection_id, &client).await;
+                    return Err(PtyStartError::SshSessionDead(format!(
+                        "SSH session for {} is no longer responsive: {}",
+                        connection_id, e
+                    )));
+                }
+                return Err(PtyStartError::Other(e));
+            }
+        };
 
         // Cancel and remove any existing PTY session for this connection first.
         // This ensures the old SSH channel and reader task are torn down before
@@ -141,9 +211,6 @@ impl ConnectionManager {
                 tracing::info!("Cancelled old PTY session for {}", connection_id);
             }
         }
-
-        // Create PTY session
-        let pty = client.create_pty_session(cols, rows).await?;
 
         // Bump generation so any in-flight Close for the old session is ignored
         let mut generations = self.pty_generations.write().await;
@@ -157,6 +224,36 @@ impl ConnectionManager {
         pty_sessions.insert(connection_id.to_string(), Arc::new(pty));
 
         Ok(current_gen)
+    }
+
+    /// Evict a dead SSH connection, guarded by `Arc` identity so a
+    /// concurrently recreated connection (fresh `ssh_connect` under the same
+    /// id) is never removed. Also tears down the dead PTY session and cached
+    /// OS info so dependent subsystems stop probing the stale handle.
+    async fn evict_dead_connection(&self, connection_id: &str, expected: &Arc<RwLock<SshClient>>) {
+        {
+            let mut connections = self.connections.write().await;
+            let is_same = connections
+                .get(connection_id)
+                .map(|current| Arc::ptr_eq(current, expected))
+                .unwrap_or(false);
+            if !is_same {
+                return;
+            }
+            connections.remove(connection_id);
+        }
+        tracing::info!("Evicted dead SSH session for {}", connection_id);
+
+        // Best-effort DISCONNECT so the server can clean up promptly.
+        let mut client = expected.write().await;
+        let _ = client.disconnect().await;
+
+        // The PTY channel on a dead session is dead too — stop its reader.
+        let mut pty_sessions = self.pty_sessions.write().await;
+        if let Some(session) = pty_sessions.remove(connection_id) {
+            session.cancel.cancel();
+        }
+        self.os_info_cache.remove(connection_id).await;
     }
 
     /// Send data to PTY (user input)
@@ -508,12 +605,66 @@ mod tests {
 
         // Simulate dispatch logic from list_remote_files command
         let sftp_type = mgr.get_connection_type("conn-sftp").await.unwrap();
-        assert_eq!(sftp_type, "SFTP");
+        assert_eq!(sftp_type, "SFTP".to_string());
 
         let ftp_type = mgr.get_connection_type("conn-ftp").await.unwrap();
-        assert_eq!(ftp_type, "FTP");
+        assert_eq!(ftp_type, "FTP".to_string());
 
         // Unknown connection returns None
         assert!(mgr.get_connection_type("conn-unknown").await.is_none());
+    }
+
+    // ===== PTY start error classification / stale-session eviction =====
+
+    #[test]
+    fn test_session_dead_error_classification() {
+        // Transport-gone errors indicate the SSH session itself is dead.
+        assert!(is_session_dead_error(&anyhow::anyhow!(
+            russh::Error::SendError
+        )));
+        assert!(is_session_dead_error(&anyhow::anyhow!(
+            russh::Error::Disconnect
+        )));
+        assert!(is_session_dead_error(&anyhow::anyhow!(russh::Error::HUP)));
+        assert!(is_session_dead_error(&anyhow::anyhow!(
+            russh::Error::KeepaliveTimeout
+        )));
+        // Server refusing another channel (e.g. MaxSessions) is transient —
+        // the session must NOT be evicted for it.
+        assert!(!is_session_dead_error(&anyhow::anyhow!(
+            russh::Error::ChannelOpenFailure(russh::ChannelOpenFailure::AdministrativelyProhibited)
+        )));
+        // Unrelated failures stay unclassified.
+        assert!(!is_session_dead_error(&anyhow::anyhow!(
+            "some other failure"
+        )));
+    }
+
+    #[tokio::test]
+    async fn test_start_pty_missing_connection_reports_session_dead() {
+        let mgr = ConnectionManager::new();
+        let err = mgr.start_pty_connection("ghost", 80, 24).await.unwrap_err();
+        assert!(matches!(err, PtyStartError::SshSessionDead(_)));
+    }
+
+    #[tokio::test]
+    async fn test_evict_dead_connection_guarded_by_arc_identity() {
+        let mgr = ConnectionManager::new();
+        let stale_client = Arc::new(RwLock::new(SshClient::new()));
+        let live_client = Arc::new(RwLock::new(SshClient::new()));
+
+        // A newer connection was recreated under the same id.
+        {
+            let mut connections = mgr.connections.write().await;
+            connections.insert("conn-1".to_string(), live_client.clone());
+        }
+
+        // Evicting via the stale Arc must leave the newer connection alive.
+        mgr.evict_dead_connection("conn-1", &stale_client).await;
+        assert!(mgr.get_connection("conn-1").await.is_some());
+
+        // Evicting with the matching Arc removes it.
+        mgr.evict_dead_connection("conn-1", &live_client).await;
+        assert!(mgr.get_connection("conn-1").await.is_none());
     }
 }

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -52,7 +52,14 @@ pub enum WsMessage {
         generation: Option<u64>,
     },
     /// Error message
-    Error { message: String },
+    Error {
+        message: String,
+        /// Machine-readable classification (see [`error_code`]) so the
+        /// frontend can react without string-matching human messages.
+        /// Absent for legacy/unclassified errors.
+        #[serde(default)]
+        code: Option<String>,
+    },
     /// Success confirmation
     Success { message: String },
     /// PTY session started — includes the generation counter so the frontend
@@ -158,6 +165,65 @@ enum PtyLifecycleEvent {
         connection_id: String,
         generation: Option<u64>,
     },
+}
+
+/// Machine-readable error codes carried on `WsMessage::Error` so the frontend
+/// can classify failures deterministically instead of matching message text.
+pub mod error_code {
+    /// The SSH session itself is dead (transport dropped / stale client
+    /// evicted). A WebSocket-only retry cannot recover; the frontend should
+    /// escalate to a full reconnect (re-authentication).
+    pub const SSH_SESSION_DEAD: &str = "ssh_session_dead";
+}
+
+/// Error returned to the frontend over the WebSocket, optionally carrying a
+/// machine-readable [`error_code`].
+#[derive(Debug)]
+struct WsError {
+    code: Option<&'static str>,
+    message: String,
+}
+
+impl WsError {
+    fn new(message: impl Into<String>) -> Self {
+        Self {
+            code: None,
+            message: message.into(),
+        }
+    }
+
+    fn coded(code: &'static str, message: impl Into<String>) -> Self {
+        Self {
+            code: Some(code),
+            message: message.into(),
+        }
+    }
+}
+
+impl std::fmt::Display for WsError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self.code {
+            Some(code) => write!(f, "[{}] {}", code, self.message),
+            None => write!(f, "{}", self.message),
+        }
+    }
+}
+
+impl From<anyhow::Error> for WsError {
+    fn from(e: anyhow::Error) -> Self {
+        WsError::new(e.to_string())
+    }
+}
+
+impl From<crate::connection_manager::PtyStartError> for WsError {
+    fn from(e: crate::connection_manager::PtyStartError) -> Self {
+        match e {
+            crate::connection_manager::PtyStartError::SshSessionDead(msg) => {
+                WsError::coded(error_code::SSH_SESSION_DEAD, msg)
+            }
+            crate::connection_manager::PtyStartError::Other(e) => WsError::new(e.to_string()),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -331,6 +397,7 @@ impl WebSocketServer {
                         Err(e) => {
                             let error = WsMessage::Error {
                                 message: format!("Invalid message format: {}", e),
+                                code: None,
                             };
                             let _ = send_control(&tx, &error).await?;
                             continue;
@@ -355,7 +422,8 @@ impl WebSocketServer {
                         Ok(PtyLifecycleEvent::None) => {}
                         Err(e) => {
                             let error = WsMessage::Error {
-                                message: format!("Error handling message: {}", e),
+                                message: format!("Error handling message: {}", e.message),
+                                code: e.code.map(|code| code.to_string()),
                             };
                             let _ = send_control(&tx, &error).await?;
                         }
@@ -400,7 +468,7 @@ impl WebSocketServer {
         msg: WsMessage,
         tx: WsTx,
         output_controls: OutputControls,
-    ) -> Result<PtyLifecycleEvent> {
+    ) -> Result<PtyLifecycleEvent, WsError> {
         match msg {
             WsMessage::StartPty {
                 connection_id,
@@ -543,6 +611,7 @@ impl WebSocketServer {
                                 );
                                 let error_msg = WsMessage::Error {
                                     message: format!("Connection lost: {}", e),
+                                    code: None,
                                 };
                                 let _ = send_control(&tx_clone, &error_msg).await;
                                 break;
@@ -651,6 +720,7 @@ impl WebSocketServer {
                 } else {
                     let error = WsMessage::Error {
                         message: format!("Desktop connection not found: {}", connection_id),
+                        code: None,
                     };
                     send_control(&tx, &error).await?;
                 }
@@ -746,5 +816,47 @@ impl WebSocketServer {
                 Ok(PtyLifecycleEvent::None)
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::error_code;
+    use super::{WsError, WsMessage};
+    use crate::connection_manager::PtyStartError;
+
+    #[test]
+    fn test_error_message_serde_round_trips_code() {
+        let msg: WsMessage = serde_json::from_str(
+            r#"{"type":"Error","message":"SSH session dead","code":"ssh_session_dead"}"#,
+        )
+        .unwrap();
+        match msg {
+            WsMessage::Error { message, code } => {
+                assert_eq!(message, "SSH session dead");
+                assert_eq!(code.as_deref(), Some(error_code::SSH_SESSION_DEAD));
+            }
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_error_message_serde_without_code_is_backward_compatible() {
+        let msg: WsMessage = serde_json::from_str(r#"{"type":"Error","message":"boom"}"#).unwrap();
+        match msg {
+            WsMessage::Error { code, .. } => assert_eq!(code, None),
+            other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_ws_error_from_pty_start_error_maps_codes() {
+        let coded = WsError::from(PtyStartError::SshSessionDead("dead".to_string()));
+        assert_eq!(coded.code, Some(error_code::SSH_SESSION_DEAD));
+        assert_eq!(coded.message, "dead");
+
+        let uncoded = WsError::from(PtyStartError::Other(anyhow::anyhow!("misc")));
+        assert_eq!(uncoded.code, None);
+        assert_eq!(uncoded.message, "misc");
     }
 }

--- a/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
+++ b/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
@@ -199,6 +199,14 @@ async function mountTerminalWithPty(connectionId: string, onStatusChange: (id: s
 
   const webSocket = mocks.webSockets[mocks.webSockets.length - 1];
   expect(webSocket?.onmessage).toBeTypeOf('function');
+  // Real backend flow: Success arrives first (marks the session established
+  // and sets hasEverConnected), then PtyStarted.
+  webSocket.onmessage({
+    data: JSON.stringify({
+      type: 'Success',
+      message: `PTY connection started: ${connectionId}`,
+    }),
+  } as MessageEvent);
   webSocket.onmessage({
     data: JSON.stringify({
       type: 'PtyStarted',
@@ -276,6 +284,18 @@ describe('PtyTerminal ssh_session_dead escalation', () => {
     // The user sees an actionable message rather than a raw error.
     expect(lastTerminal().write).toHaveBeenCalledWith(
       expect.stringContaining(i18n.t('ptyTerminal.sshSessionLost')),
+    );
+
+    // The close() above fires onclose in a real browser — it must NOT print
+    // auto-reconnect banners next to the escalation message or schedule
+    // further WS retries (App.tsx owns recovery now).
+    webSocket.onclose?.();
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledTimes(1);
+    expect(lastTerminal().write).not.toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.autoReconnectFailed', { attempts: 5 })),
+    );
+    expect(lastTerminal().write).not.toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.reconnectFailedPermanently')),
     );
   });
 

--- a/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
+++ b/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { PtyTerminal } from '../components/pty-terminal';
+import i18n from '../lib/i18n';
+
+const mocks = vi.hoisted(() => {
+  const terminals: Array<any> = [];
+  const webSockets: Array<any> = [];
+  const terminalCallbacks = {
+    onReconnectTab: vi.fn(),
+    onWorkingDirectoryChange: vi.fn(),
+  };
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    buffer = {
+      active: {
+        length: 0,
+        getLine: vi.fn(),
+      },
+    };
+    parser = {
+      registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    refresh = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
+    onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
+    attachCustomKeyEventHandler = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => '');
+    selectAll = vi.fn();
+    clear = vi.fn();
+    reset = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = 3;
+    });
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: (() => void) | null = null;
+
+    constructor(public url: string) {
+      webSockets.push(this);
+    }
+  }
+
+  const Terminal = vi.fn(function Terminal() {
+    const terminal = new MockTerminal();
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  const FitAddon = vi.fn(function FitAddon() {
+    return new MockFitAddon();
+  });
+
+  return { terminals, webSockets, terminalCallbacks, Terminal, FitAddon, MockWebSocket };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.Terminal,
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: mocks.FitAddon,
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddon() {
+    return { dispose: vi.fn(), onContextLoss: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: vi.fn(function SearchAddon() {
+    return {
+      findNext: vi.fn(),
+      findPrevious: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('@xterm/addon-clipboard', () => ({
+  ClipboardAddon: vi.fn(function ClipboardAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  readText: vi.fn().mockResolvedValue(''),
+  writeText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: {
+    background: '#000000',
+  },
+  terminalThemes: {
+    'vs-code-dark': {
+      background: '#000000',
+    },
+  },
+  loadAppearanceSettings: vi.fn(() => ({
+    allowTransparency: false,
+    backgroundImage: '',
+    opacity: 100,
+    theme: 'vs-code-dark',
+  })),
+  getThemeAwareTerminalOptions: vi.fn(() => ({
+    cursorBlink: true,
+    cursorStyle: 'block',
+    fontFamily: 'monospace',
+    fontSize: 14,
+    scrollback: 10000,
+    theme: {},
+  })),
+  getThemeAwareTerminalTheme: vi.fn(() => ({
+    background: '#000000',
+  })),
+}));
+
+vi.mock('../components/terminal/terminal-context-menu', () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/terminal/terminal-search-bar', () => ({
+  TerminalSearchBar: () => null,
+}));
+
+vi.mock('../lib/restoration-manager', () => ({
+  signalReady: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => mocks.terminalCallbacks,
+}));
+
+vi.mock('../lib/terminal-working-directory', () => ({
+  registerTerminalWorkingDirectoryHandler: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+function renderTerminal(connectionId: string, onStatusChange: (id: string, status: string) => void) {
+  return render(
+    <PtyTerminal
+      connectionId={connectionId}
+      connectionName="SSH Server"
+      host="127.0.0.1"
+      username="root"
+      isActive
+      onConnectionStatusChange={onStatusChange as PtyTerminalProps['onConnectionStatusChange']}
+    />,
+  );
+}
+
+interface PtyTerminalProps {
+  onConnectionStatusChange?: (connectionId: string, status: 'connected' | 'connecting' | 'disconnected' | 'pending') => void;
+}
+
+/** Mount, establish the WebSocket + PTY session, return the live mock socket. */
+async function mountTerminalWithPty(connectionId: string, onStatusChange: (id: string, status: string) => void) {
+  renderTerminal(connectionId, onStatusChange);
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60);
+  });
+
+  const webSocket = mocks.webSockets[mocks.webSockets.length - 1];
+  expect(webSocket?.onmessage).toBeTypeOf('function');
+  webSocket.onmessage({
+    data: JSON.stringify({
+      type: 'PtyStarted',
+      connection_id: connectionId,
+      generation: 1,
+    }),
+  } as MessageEvent);
+  return webSocket;
+}
+
+function sendError(webSocket: { onmessage: ((event: MessageEvent) => void) | null }, message: string, code?: string) {
+  webSocket.onmessage({
+    data: JSON.stringify({ type: 'Error', message, ...(code ? { code } : {}) }),
+  } as MessageEvent);
+}
+
+function lastTerminal() {
+  return mocks.terminals[mocks.terminals.length - 1];
+}
+
+describe('PtyTerminal ssh_session_dead escalation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.terminals.length = 0;
+    mocks.webSockets.length = 0;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 600,
+    });
+
+    vi.stubGlobal('WebSocket', mocks.MockWebSocket);
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        return window.setTimeout(() => callback(performance.now()), 0);
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => window.clearTimeout(id)));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('escalates a coded ssh_session_dead error to the App-level full reconnect', async () => {
+    const onStatusChange = vi.fn();
+    const webSocket = await mountTerminalWithPty('ssh-dead-1', onStatusChange);
+
+    sendError(
+      webSocket,
+      'SSH session for ssh-dead-1 is no longer responsive: Channel send error',
+      'ssh_session_dead',
+    );
+
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledTimes(1);
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledWith('ssh-dead-1');
+    // Status flips to disconnected and the socket is closed.
+    expect(onStatusChange).toHaveBeenCalledWith('ssh-dead-1', 'disconnected');
+    expect(webSocket.close).toHaveBeenCalled();
+    // The user sees an actionable message rather than a raw error.
+    expect(lastTerminal().write).toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.sshSessionLost')),
+    );
+  });
+
+  it('escalates only once per mount even if more coded errors arrive', async () => {
+    const onStatusChange = vi.fn();
+    const webSocket = await mountTerminalWithPty('ssh-dead-2', onStatusChange);
+
+    sendError(webSocket, 'SSH session dead again', 'ssh_session_dead');
+    sendError(webSocket, 'SSH session dead again', 'ssh_session_dead');
+
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps the legacy keyword behavior for uncoded errors', async () => {
+    const onStatusChange = vi.fn();
+    const webSocket = await mountTerminalWithPty('legacy-1', onStatusChange);
+
+    sendError(webSocket, 'Connection lost: PTY connection closed');
+
+    // No App-level escalation for uncoded errors — the existing WS retry
+    // loop owns recovery.
+    expect(mocks.terminalCallbacks.onReconnectTab).not.toHaveBeenCalled();
+    expect(onStatusChange).toHaveBeenCalledWith('legacy-1', 'disconnected');
+    expect(webSocket.close).toHaveBeenCalled();
+  });
+
+  it('stops auto-escalating after the module-level budget is exhausted across remounts', async () => {
+    const onStatusChange = vi.fn();
+    const connectionId = 'ssh-dead-budget';
+
+    // Remount 1 and 2: escalation claimed within budget.
+    for (let cycle = 0; cycle < 2; cycle++) {
+      const webSocket = await mountTerminalWithPty(connectionId, onStatusChange);
+      sendError(webSocket, 'SSH session dead', 'ssh_session_dead');
+      cleanup();
+    }
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledTimes(2);
+
+    // Remount 3: budget exhausted — no escalation, manual-reconnect hint shown.
+    const webSocket = await mountTerminalWithPty(connectionId, onStatusChange);
+    sendError(webSocket, 'SSH session dead', 'ssh_session_dead');
+    expect(mocks.terminalCallbacks.onReconnectTab).toHaveBeenCalledTimes(2);
+    expect(lastTerminal().write).toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.sshSessionDeadPermanent')),
+    );
+  });
+});

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -29,6 +29,39 @@ interface PtyTerminalProps {
   onConnectionStatusChange?: (connectionId: string, status: 'connected' | 'connecting' | 'disconnected' | 'pending') => void;
 }
 
+// ---------------------------------------------------------------------------
+// ssh_session_dead escalation budget
+//
+// When the backend reports the SSH session itself died (backend error code
+// `ssh_session_dead`), a WebSocket-only retry cannot recover — the correct
+// response is a full reconnect (disconnect + re-authenticate), which runs in
+// App.tsx via onReconnectTab and remounts this component. Because each
+// escalation remounts PtyTerminal (resetting its refs), the attempt budget
+// must live at module level: auto-escalate at most ESCALATION_LIMIT times per
+// connection per window, then fall back to asking the user to reconnect
+// manually. Each failed re-auth leaves the tab disconnected (no remount), so
+// this guard mainly protects against pathological remount loops.
+// ---------------------------------------------------------------------------
+const SSH_DEAD_ESCALATION_LIMIT = 2;
+const SSH_DEAD_ESCALATION_WINDOW_MS = 10 * 60 * 1000;
+const sshDeadEscalations = new Map<string, { count: number; windowStart: number }>();
+
+/** Claim one auto-escalation attempt for this connection. Returns false when
+ *  the budget is exhausted (caller should surface a manual-reconnect hint). */
+function claimSshDeadEscalation(connectionId: string): boolean {
+  const now = Date.now();
+  const entry = sshDeadEscalations.get(connectionId);
+  if (!entry || now - entry.windowStart > SSH_DEAD_ESCALATION_WINDOW_MS) {
+    sshDeadEscalations.set(connectionId, { count: 1, windowStart: now });
+    return true;
+  }
+  if (entry.count >= SSH_DEAD_ESCALATION_LIMIT) {
+    return false;
+  }
+  entry.count += 1;
+  return true;
+}
+
 /**
  * PTY-based Interactive Terminal Component
  * 
@@ -81,6 +114,11 @@ export function PtyTerminal({
   
   // PTY session generation — used in Close to avoid stale-close races
   const ptyGenerationRef = React.useRef<number | null>(null);
+
+  // Set once this mount has already escalated a `ssh_session_dead` error to a
+  // full reconnect — prevents duplicate App-level reconnects if more coded
+  // errors arrive before the component remounts.
+  const sshDeadEscalatedRef = React.useRef(false);
   
   // Reconnect key — incrementing this forces the main effect to tear down and rebuild
   const [reconnectKey, setReconnectKey] = React.useState(0);
@@ -582,6 +620,36 @@ export function PtyTerminal({
               
             case 'Error': {
               console.error('[PTY Terminal] Error:', msg.message);
+              const errorCode: string | undefined = msg.code;
+
+              // The backend detected the SSH session itself is dead (stale
+              // client already evicted server-side). Retrying the WebSocket
+              // can never recover this — escalate once to a full reconnect
+              // (disconnect + re-authenticate) via the App-level handler,
+              // within the module-level budget.
+              if (errorCode === 'ssh_session_dead') {
+                // Stop both frontend retry loops; recovery is App-driven now.
+                reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS;
+                autoReconnectAfterDropRef.current = MAX_AUTO_RECONNECT_AFTER_DROP;
+                if (connectionStatusRef.current !== 'disconnected') {
+                  connectionStatusRef.current = 'disconnected';
+                  onConnectionStatusChange?.(connectionId, 'disconnected');
+                }
+                if (!sshDeadEscalatedRef.current) {
+                  sshDeadEscalatedRef.current = true;
+                  if (onReconnectTab && claimSshDeadEscalation(connectionId)) {
+                    term.write(`\r\n\x1b[33m${i18n.t('ptyTerminal.sshSessionLost')}\x1b[0m\r\n`);
+                    void onReconnectTab(connectionId);
+                  } else {
+                    term.write(`\r\n\x1b[31m${i18n.t('ptyTerminal.sshSessionDeadPermanent')}\x1b[0m\r\n`);
+                  }
+                }
+                if (ws.readyState === WebSocket.OPEN) {
+                  ws.close();
+                }
+                break;
+              }
+
               term.write(`\r\n\x1b[31m${i18n.t('ptyTerminal.error', { message: msg.message })}\x1b[0m\r\n`);
               const errorMsgLower = msg.message.toLowerCase();
               // Permanent failures (SSH session gone on the backend) — stop the

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -50,6 +50,16 @@ const sshDeadEscalations = new Map<string, { count: number; windowStart: number 
  *  the budget is exhausted (caller should surface a manual-reconnect hint). */
 function claimSshDeadEscalation(connectionId: string): boolean {
   const now = Date.now();
+  // Opportunistic pruning: tab ids include unique suffixes (e.g.
+  // `${id}-dup-${Date.now()}`), so stale entries would otherwise accumulate
+  // for the app's lifetime. Only paid once the map grows past a small bound.
+  if (sshDeadEscalations.size > 64) {
+    for (const [key, entry] of sshDeadEscalations) {
+      if (now - entry.windowStart > SSH_DEAD_ESCALATION_WINDOW_MS) {
+        sshDeadEscalations.delete(key);
+      }
+    }
+  }
   const entry = sshDeadEscalations.get(connectionId);
   if (!entry || now - entry.windowStart > SSH_DEAD_ESCALATION_WINDOW_MS) {
     sshDeadEscalations.set(connectionId, { count: 1, windowStart: now });
@@ -695,6 +705,12 @@ export function PtyTerminal({
 
       ws.onclose = () => {
         console.log('[PTY Terminal] WebSocket closed');
+        // Closed as part of a ssh_session_dead escalation — App.tsx owns
+        // recovery now. Don't print auto-reconnect banners on top of the
+        // escalation message or schedule WS retries next to it.
+        if (sshDeadEscalatedRef.current) {
+          return;
+        }
         if (isRunning) {
           // If a session was successfully established, a WS drop means the
           // remote shell is gone (e.g. sleep/wake cycle, server timeout).

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1094,7 +1094,9 @@
     "autoReconnectFailed": "[Connection lost. Auto-reconnect failed after {{attempts}} attempts. Use right-click → Reconnect.]",
     "reconnectingAfterDrop": "[Connection lost. Reconnecting in {{seconds}}s (attempt {{attempt}}/{{max}})...]",
     "reconnectFailedPermanently": "[Connection failed permanently. Use right-click → Reconnect to retry.]",
-    "reconnectingAfterClose": "[Connection closed. Reconnecting in {{seconds}}s (attempt {{attempt}}/{{max}})...]"
+    "reconnectingAfterClose": "[Connection closed. Reconnecting in {{seconds}}s (attempt {{attempt}}/{{max}})...]",
+    "sshSessionLost": "[SSH session lost. Reconnecting with full authentication...]",
+    "sshSessionDeadPermanent": "[SSH session lost and automatic recovery limit reached. Use right-click → Reconnect to retry.]"
   },
   "systemMonitor": {
     "systemOverview": "System Overview",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1094,7 +1094,9 @@
     "autoReconnectFailed": "[连接丢失。自动重连 {{attempts}} 次后失败，请使用右键 → 重新连接。]",
     "reconnectingAfterDrop": "[连接丢失。{{seconds}} 秒后重新连接（第 {{attempt}}/{{max}} 次尝试）...]",
     "reconnectFailedPermanently": "[连接永久失败，请使用右键 → 重新连接以重试。]",
-    "reconnectingAfterClose": "[连接已关闭。{{seconds}} 秒后重新连接（第 {{attempt}}/{{max}} 次尝试）...]"
+    "reconnectingAfterClose": "[连接已关闭。{{seconds}} 秒后重新连接（第 {{attempt}}/{{max}} 次尝试）...]",
+    "sshSessionLost": "[SSH 会话已丢失。正在重新进行完整认证并重连...]",
+    "sshSessionDeadPermanent": "[SSH 会话已丢失且已达自动恢复上限，请使用右键 → 重新连接重试。]"
   },
   "systemMonitor": {
     "systemOverview": "系统概览",


### PR DESCRIPTION
## Problem (from #95)

The reported failure sequence was:

```
[Error: Connection lost: PTY connection closed]   ← SSH channel/transport died first
[Connection lost. Reconnecting in 2s (attempt 1/5)...]
✓ WebSocket connected                              ← transport rebuilt
[Error: Error handling message: Channel send error] ← StartPty on the STALE SshClient (russh SendError) — ignored by the keyword filter
[Error: Error handling message: PTY connection not found] ← symptom misclassified as the verdict
[Connection failed permanently.]
```

Root cause: the auto-reconnect assumes the SSH session outlives the WebSocket. When the failure order is reversed (SSH dies first), the stale `SshClient` is never evicted (`is_connected` has no callers), `StartPty` fails on the corpse, the fatal `Channel send error` matches none of the frontend's keyword filters, and the follow-on `PTY connection not found` hard-caps retries — even though a full re-auth (right-click → Reconnect) works fine.

## Changes

**Backend**
- `start_pty_connection` returns `PtyStartError::SshSessionDead` when the SSH session is missing or the transport is dead (`SendError` / `Disconnect` / `HUP` / timeout class — verified against russh 0.44.1). Transient `ChannelOpenFailure` (e.g. MaxSessions) does **not** evict.
- Dead sessions are evicted with an `Arc`-identity guard (a concurrently recreated connection survives), including PTY teardown and OS-info cache cleanup.
- `WsMessage::Error` carries an optional machine-readable `code` (`ssh_session_dead`); absent on legacy errors — fully backward compatible on the wire.

**Frontend**
- `PtyTerminal` reacts to the coded error by stopping both WS retry loops and escalating once to the App-level full reconnect (`onReconnectTab`: disconnect + re-authenticate + remount). A module-level budget (2 per connection per 10 min, survives remounts) prevents pathological loops; beyond it, the manual-reconnect hint is shown.
- Legacy uncoded errors keep the existing keyword behaviour unchanged.
- New i18n keys in en + zh-CN (`sshSessionLost`, `sshSessionDeadPermanent`).

## Tests
- Rust (6 new): error classification (dead vs MaxSessions-transient vs unrelated), missing-connection → `SshSessionDead`, eviction identity guard, serde round-trip with/without `code`, `WsError` code mapping. `cargo test`: 141 passed.
- Frontend (4 new): escalation fires once with status/close/message assertions, no double-escalation per mount, legacy path unchanged, budget exhaustion across remounts. Full suite: 593 passed. `tsc --noEmit` clean, i18n parity 1082/1082, eslint 0 errors on touched files.

## Scope

Partially addresses #95 — the failure order observed in the report (SSH dies first) is now recoverable end-to-end. The complementary scenario (pure WebSocket drop with SSH alive → PTY grace period + reattach) is intentionally left as a follow-up on top of the detached-session registry from #76.

🤖 Generated with [ZCode](https://github.com/ZhipuAI/ZCode)