### PR TITLE
fix(terminal): lazy WebGL per visible pane + deterministic activation repair

### DIFF
--- a/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
+++ b/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
@@ -1,0 +1,379 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { PtyTerminal } from '../components/pty-terminal';
+
+const mocks = vi.hoisted(() => {
+  const terminals: Array<any> = [];
+  const webSockets: Array<any> = [];
+  const webglInstances: Array<any> = [];
+  const terminalCallbacks = {
+    onReconnectTab: vi.fn(),
+    onWorkingDirectoryChange: vi.fn(),
+  };
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    buffer = {
+      active: {
+        length: 0,
+        getLine: vi.fn(),
+      },
+    };
+    parser = {
+      registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    refresh = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
+    onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
+    attachCustomKeyEventHandler = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => '');
+    selectAll = vi.fn();
+    clear = vi.fn();
+    reset = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = 3;
+    });
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: (() => void) | null = null;
+
+    constructor(public url: string) {
+      webSockets.push(this);
+    }
+  }
+
+  const Terminal = vi.fn(function Terminal() {
+    const terminal = new MockTerminal();
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  const FitAddon = vi.fn(function FitAddon() {
+    return new MockFitAddon();
+  });
+
+  const WebglAddon = vi.fn(function WebglAddon() {
+    const instance = {
+      dispose: vi.fn(),
+      onContextLoss: vi.fn(),
+    };
+    webglInstances.push(instance);
+    return instance;
+  });
+
+  return { terminals, webSockets, webglInstances, terminalCallbacks, Terminal, FitAddon, WebglAddon, MockWebSocket };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.Terminal,
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: mocks.FitAddon,
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: mocks.WebglAddon,
+}));
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: vi.fn(function SearchAddon() {
+    return {
+      findNext: vi.fn(),
+      findPrevious: vi.fn(),
+      dispose: vi.fn(),
+    };
+  }),
+}));
+
+vi.mock('@xterm/addon-clipboard', () => ({
+  ClipboardAddon: vi.fn(function ClipboardAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  readText: vi.fn().mockResolvedValue(''),
+  writeText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: {
+    background: '#000000',
+  },
+  terminalThemes: {
+    'vs-code-dark': {
+      background: '#000000',
+    },
+  },
+  loadAppearanceSettings: vi.fn(() => ({
+    allowTransparency: false,
+    backgroundImage: '',
+    opacity: 100,
+    theme: 'vs-code-dark',
+  })),
+  getThemeAwareTerminalOptions: vi.fn(() => ({
+    cursorBlink: true,
+    cursorStyle: 'block',
+    fontFamily: 'monospace',
+    fontSize: 14,
+    scrollback: 10000,
+    theme: {},
+  })),
+  getThemeAwareTerminalTheme: vi.fn(() => ({
+    background: '#000000',
+  })),
+}));
+
+vi.mock('../components/terminal/terminal-context-menu', () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/terminal/terminal-search-bar', () => ({
+  TerminalSearchBar: () => null,
+}));
+
+vi.mock('../lib/restoration-manager', () => ({
+  signalReady: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => mocks.terminalCallbacks,
+}));
+
+vi.mock('../lib/terminal-working-directory', () => ({
+  registerTerminalWorkingDirectoryHandler: vi.fn(() => ({ dispose: vi.fn() })),
+}));
+
+/** Controls what offsetWidth/offsetHeight report for every element. */
+let containerSize = 800;
+
+function stubContainerSize() {
+  Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+    configurable: true,
+    get: () => containerSize,
+  });
+  Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+    configurable: true,
+    get: () => containerSize,
+  });
+}
+
+async function flushFrames(frames: number) {
+  for (let i = 0; i < frames; i++) {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(16);
+    });
+  }
+}
+
+describe('PtyTerminal renderer lifecycle (issue #87)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.terminals.length = 0;
+    mocks.webSockets.length = 0;
+    mocks.webglInstances.length = 0;
+    containerSize = 800;
+    stubContainerSize();
+
+    vi.stubGlobal('WebSocket', mocks.MockWebSocket);
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    // rAF paced like real frames (~16ms) so the activation retry budget
+    // spans multiple flushFrames calls instead of collapsing into one tick.
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        return window.setTimeout(() => callback(performance.now()), 16);
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => window.clearTimeout(id)));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('does not create a WebGL context for a terminal that mounts inactive', async () => {
+    render(
+      <PtyTerminal
+        connectionId="hidden-1"
+        connectionName="Hidden"
+        host="127.0.0.1"
+        username="root"
+        isActive={false}
+      />,
+    );
+    await flushFrames(3);
+
+    // Hidden panes must stay on the DOM renderer so many mounted tabs cannot
+    // exhaust Chromium's WebGL context budget.
+    expect(mocks.WebglAddon).not.toHaveBeenCalled();
+  });
+
+  it('loads WebGL when the terminal becomes active and releases it when hidden again', async () => {
+    const view = render(
+      <PtyTerminal
+        connectionId="lazy-1"
+        connectionName="Lazy"
+        host="127.0.0.1"
+        username="root"
+        isActive={false}
+      />,
+    );
+    await flushFrames(2);
+    expect(mocks.webglInstances).toHaveLength(0);
+
+    // Becoming visible: activation loads the renderer and repaints.
+    view.rerender(
+      <PtyTerminal
+        connectionId="lazy-1"
+        connectionName="Lazy"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+    await flushFrames(3);
+
+    expect(mocks.webglInstances).toHaveLength(1);
+    expect(mocks.terminals[0].loadAddon).toHaveBeenCalledWith(mocks.webglInstances[0]);
+    expect(mocks.terminals[0].refresh).toHaveBeenCalledWith(0, mocks.terminals[0].rows - 1);
+    expect(mocks.terminals[0].focus).toHaveBeenCalled();
+
+    // Hidden again: the GPU context is released.
+    view.rerender(
+      <PtyTerminal
+        connectionId="lazy-1"
+        connectionName="Lazy"
+        host="127.0.0.1"
+        username="root"
+        isActive={false}
+      />,
+    );
+    await flushFrames(1);
+    expect(mocks.webglInstances[0].dispose).toHaveBeenCalled();
+  });
+
+  it('loads WebGL at mount for a terminal that mounts active', async () => {
+    render(
+      <PtyTerminal
+        connectionId="visible-1"
+        connectionName="Visible"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+    await flushFrames(2);
+    expect(mocks.webglInstances).toHaveLength(1);
+  });
+
+  it('repaints through a fallback renderer after WebGL context loss', async () => {
+    const view = render(
+      <PtyTerminal
+        connectionId="ctxloss-1"
+        connectionName="CtxLoss"
+        host="127.0.0.1"
+        username="root"
+        isActive={false}
+      />,
+    );
+    view.rerender(
+      <PtyTerminal
+        connectionId="ctxloss-1"
+        connectionName="CtxLoss"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+    await flushFrames(3);
+    expect(mocks.webglInstances).toHaveLength(1);
+
+    const terminal = mocks.terminals[0];
+    const fitAddonInstance = mocks.terminals[0].loadAddon.mock.calls[0][0];
+    terminal.refresh.mockClear();
+
+    // Fire the context-loss handler captured by onContextLoss.
+    const onContextLoss = mocks.webglInstances[0].onContextLoss.mock.calls[0][0] as () => void;
+    onContextLoss();
+
+    expect(mocks.webglInstances[0].dispose).toHaveBeenCalled();
+    expect(fitAddonInstance.fit).toHaveBeenCalled();
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+  });
+
+  it('keeps retrying activation until the container becomes visible (0×0 → sized)', async () => {
+    containerSize = 0;
+    render(
+      <PtyTerminal
+        connectionId="slowwake-1"
+        connectionName="SlowWake"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+
+    // Still zero-sized after several frames — activation must not be
+    // consumed and no repaint may happen yet. (focus was called exactly once
+    // by the mount path for initially-active terminals; WebGL loads at mount
+    // for active panes — the context budget is bounded by visible panes.)
+    await flushFrames(5);
+    const terminal = mocks.terminals[0];
+    expect(terminal.focus).toHaveBeenCalledTimes(1);
+    expect(terminal.refresh).not.toHaveBeenCalled();
+
+    // The container finally becomes visible (e.g. wake from display sleep).
+    containerSize = 800;
+    await flushFrames(3);
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+    expect(terminal.focus).toHaveBeenCalledTimes(2);
+    expect(mocks.webglInstances).toHaveLength(1);
+  });
+});

--- a/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
+++ b/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
@@ -86,7 +86,11 @@ const mocks = vi.hoisted(() => {
     return instance;
   });
 
-  return { terminals, webSockets, webglInstances, terminalCallbacks, Terminal, FitAddon, WebglAddon, MockWebSocket };
+  const resizeObservers: Array<{
+    callback: (entries: Array<{ contentRect: { width: number; height: number } }>) => void;
+  }> = [];
+
+  return { terminals, webSockets, webglInstances, resizeObservers, terminalCallbacks, Terminal, FitAddon, WebglAddon, MockWebSocket };
 });
 
 vi.mock('@xterm/xterm', () => ({
@@ -209,6 +213,7 @@ describe('PtyTerminal renderer lifecycle (issue #87)', () => {
     mocks.terminals.length = 0;
     mocks.webSockets.length = 0;
     mocks.webglInstances.length = 0;
+    mocks.resizeObservers.length = 0;
     containerSize = 800;
     stubContainerSize();
 
@@ -216,6 +221,9 @@ describe('PtyTerminal renderer lifecycle (issue #87)', () => {
     vi.stubGlobal(
       'ResizeObserver',
       class {
+        constructor(callback: (entries: Array<{ contentRect: { width: number; height: number } }>) => void) {
+          mocks.resizeObservers.push({ callback });
+        }
         observe = vi.fn();
         disconnect = vi.fn();
       },
@@ -375,5 +383,38 @@ describe('PtyTerminal renderer lifecycle (issue #87)', () => {
     expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
     expect(terminal.focus).toHaveBeenCalledTimes(2);
     expect(mocks.webglInstances).toHaveLength(1);
+  });
+
+  it('completes a pending activation via ResizeObserver even below the fit threshold', async () => {
+    // Regression: activation completion was gated behind debouncedFit's
+    // ">100px" check. A pane that stayed 0×0 past the rAF retry budget and
+    // then became visible at a small (sub-100px) size would never activate.
+    containerSize = 0;
+    render(
+      <PtyTerminal
+        connectionId="smallsplit-1"
+        connectionName="SmallSplit"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+
+    // Exhaust the rAF retry budget (~120 frames) while still 0×0.
+    await flushFrames(130);
+    const terminal = mocks.terminals[0];
+    expect(terminal.refresh).not.toHaveBeenCalled();
+
+    // The pane appears at 30px — too small for debouncedFit, but a valid
+    // non-zero size that must complete the activation.
+    containerSize = 30;
+    const observer = mocks.resizeObservers[0];
+    expect(observer).toBeDefined();
+    act(() => {
+      observer.callback([{ contentRect: { width: 30, height: 30 } }]);
+    });
+
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+    expect(terminal.focus).toHaveBeenCalledTimes(2);
   });
 });

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -238,7 +238,9 @@ export function PtyTerminal({
     // ones were evicted overnight, leaving permanently black "input-dead"
     // panes: under WebGL, text exists only as pixels on the GL canvas. The
     // addon is now loaded only while the pane is visible; hidden panes use
-    // the DOM renderer, whose text survives in the DOM.
+    // the DOM renderer (xterm v6 core's `_createRenderer()` builds
+    // `DomRenderer` — the same renderer the WebglAddon restores on dispose),
+    // whose text lives as DOM rows and survives the pane being hidden.
     const ensureWebglRenderer = () => {
       if (webglAddonRef.current) return;
       // WebGL can't render transparency, so background images stay on canvas.
@@ -889,13 +891,20 @@ export function PtyTerminal({
         // Only refit if the container has a reasonable size
         if (entry.contentRect.width > 100 && entry.contentRect.height > 100) {
           debouncedFit();
-          // A 0×0 → non-zero transition can be the first reliable visibility
-          // signal (e.g. after display sleep/wake). If an activation is still
-          // pending — its rAF retry budget may have expired while the pane
-          // was hidden — finish it now.
-          if (isActiveStateRef.current && !wasActiveRef.current) {
-            activateTerminalRef.current?.();
-          }
+        }
+        // A 0×0 → non-zero transition can be the first reliable visibility
+        // signal (e.g. after display sleep/wake). If an activation is still
+        // pending — its rAF retry budget may have expired while the pane was
+        // hidden — finish it now. Any non-zero size counts: deeply split
+        // panes can legitimately be narrower than debouncedFit's 100px
+        // threshold, and activation must not inherit it.
+        if (
+          isActiveStateRef.current &&
+          !wasActiveRef.current &&
+          entry.contentRect.width > 0 &&
+          entry.contentRect.height > 0
+        ) {
+          activateTerminalRef.current?.();
         }
       }
     });
@@ -1007,7 +1016,8 @@ export function PtyTerminal({
       wasActiveRef.current = false;
       isActiveStateRef.current = false;
       // Release this pane's WebGL context while hidden — visible panes get
-      // the GPU; hidden panes keep their text via the DOM renderer.
+      // the GPU; hidden panes keep their text via the DOM renderer (xterm
+      // v6 core's `_createRenderer()` → `DomRenderer`, restored on dispose).
       webglControlsRef.current?.release();
       return;
     }

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -99,10 +99,24 @@ export function PtyTerminal({
   const wsRef = React.useRef<WebSocket | null>(null);
   const rendererRef = React.useRef<string>('canvas');
   const webglAddonRef = React.useRef<WebglAddon | null>(null);
+  // Lazy WebGL controls, populated by the terminal-creation effect so the
+  // activation effect can load/release the renderer without re-running the
+  // whole session setup.
+  const webglControlsRef = React.useRef<{ ensure: () => void; release: () => void } | null>(null);
+  // Mirrors the latest `isActive` prop for non-effect code paths (the
+  // ResizeObserver completing a pending activation).
+  const isActiveStateRef = React.useRef(isActive);
+  // Set by the activation effect while an activation is pending; lets the
+  // ResizeObserver finish an activation on a 0×0 → non-zero transition.
+  const activateTerminalRef = React.useRef<(() => void) | null>(null);
   const clipboardAddonRef = React.useRef<ClipboardAddon | null>(null);
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const initialIsActiveRef = React.useRef(isActive);
-  const wasActiveRef = React.useRef(isActive);
+  // Starts false even for active mounts: every pane — including one that
+  // mounts active behind a still-0×0 container — must pass through the
+  // activation effect's measured fit + refresh + focus before the latch is
+  // consumed (issue #87).
+  const wasActiveRef = React.useRef(false);
   
   // Search bar state
   const [searchVisible, setSearchVisible] = React.useState(false);
@@ -216,18 +230,33 @@ export function PtyTerminal({
     clipboardAddonRef.current = clipboardAddon;
     
     term.open(terminalRef.current);
-    
-    // Load WebGL renderer for better performance
-    // NOTE: WebGL doesn't support transparency, so skip it when background image is set
-    if (!appearance.backgroundImage) {
+
+    // --- Lazy WebGL renderer lifecycle ---
+    // Every mounted terminal used to create a WebGL context at mount and
+    // hold it for its whole life — including hidden panes. With many tabs
+    // the live contexts exceeded Chromium's budget and the oldest (hidden)
+    // ones were evicted overnight, leaving permanently black "input-dead"
+    // panes: under WebGL, text exists only as pixels on the GL canvas. The
+    // addon is now loaded only while the pane is visible; hidden panes use
+    // the DOM renderer, whose text survives in the DOM.
+    const ensureWebglRenderer = () => {
+      if (webglAddonRef.current) return;
+      // WebGL can't render transparency, so background images stay on canvas.
+      if (hadBackgroundImageRef.current) return;
       try {
         const webglAddon = new WebglAddon();
-        // Dispose listener — xterm calls this when the addon is disposed
         webglAddon.onContextLoss(() => {
-          webglAddon.dispose();
+          // Disposing restores xterm's DOM renderer, but that path is
+          // best-effort — force a full repaint so the pane can never stay
+          // black after losing its context.
+          try { webglAddon.dispose(); } catch { /* already disposed */ }
           webglAddonRef.current = null;
           rendererRef.current = 'canvas';
-          console.warn('[PTY Terminal] WebGL context lost, falling back to canvas');
+          console.warn('[PTY Terminal] WebGL context lost, fell back to canvas');
+          fitRef.current?.fit();
+          if (term.rows > 0) {
+            term.refresh(0, term.rows - 1);
+          }
         });
         term.loadAddon(webglAddon);
         webglAddonRef.current = webglAddon;
@@ -237,11 +266,22 @@ export function PtyTerminal({
         rendererRef.current = 'canvas';
         console.warn('[PTY Terminal] WebGL not supported, falling back to canvas:', e);
       }
-    } else {
+    };
+    const releaseWebglRenderer = () => {
+      const addon = webglAddonRef.current;
+      if (!addon) return;
+      webglAddonRef.current = null;
       rendererRef.current = 'canvas';
-      console.log('[PTY Terminal] Using canvas renderer (background image requires transparency)');
+      try { addon.dispose(); } catch { /* already disposed */ }
+      console.log('[PTY Terminal] WebGL renderer released (tab hidden)');
+    };
+    webglControlsRef.current = { ensure: ensureWebglRenderer, release: releaseWebglRenderer };
+    if (initialIsActiveRef.current) {
+      ensureWebglRenderer();
+    } else {
+      console.log('[PTY Terminal] Using canvas renderer (hidden tab; WebGL loads on activation)');
     }
-    
+
     fitAddon.fit();
 
     // Store refs
@@ -849,6 +889,13 @@ export function PtyTerminal({
         // Only refit if the container has a reasonable size
         if (entry.contentRect.width > 100 && entry.contentRect.height > 100) {
           debouncedFit();
+          // A 0×0 → non-zero transition can be the first reliable visibility
+          // signal (e.g. after display sleep/wake). If an activation is still
+          // pending — its rAF retry budget may have expired while the pane
+          // was hidden — finish it now.
+          if (isActiveStateRef.current && !wasActiveRef.current) {
+            activateTerminalRef.current?.();
+          }
         }
       }
     });
@@ -922,6 +969,7 @@ export function PtyTerminal({
         try { webglAddonRef.current.dispose(); } catch (_e) { /* already disposed */ }
         webglAddonRef.current = null;
       }
+      webglControlsRef.current = null;
       if (clipboardAddonRef.current) {
         try { clipboardAddonRef.current.dispose(); } catch (_e) { /* already disposed */ }
         clipboardAddonRef.current = null;
@@ -957,30 +1005,58 @@ export function PtyTerminal({
   React.useEffect(() => {
     if (!isActive) {
       wasActiveRef.current = false;
+      isActiveStateRef.current = false;
+      // Release this pane's WebGL context while hidden — visible panes get
+      // the GPU; hidden panes keep their text via the DOM renderer.
+      webglControlsRef.current?.release();
       return;
     }
 
     if (wasActiveRef.current) {
+      isActiveStateRef.current = true;
       return;
     }
+    isActiveStateRef.current = true;
 
-    wasActiveRef.current = true;
-
-    const frameId = window.requestAnimationFrame(() => {
+    // Retry until the container has a real size, then fit + full refresh +
+    // focus — and only then consume the activation latch. A single rAF was
+    // not enough: after display sleep/wake or slow layout the portal host
+    // can still be 0×0 in the first frame(s), and the old code consumed the
+    // latch before checking, leaving the pane blank and unfocused forever.
+    let attempts = 0;
+    const MAX_ACTIVATE_ATTEMPTS = 120; // ~2s at 60fps
+    let rafId = 0;
+    const tryActivate = () => {
       const term = xtermRef.current;
       const fitAddon = fitRef.current;
       const container = containerRef.current;
       if (!term || !fitAddon || !container) return;
-      if (container.offsetWidth <= 0 || container.offsetHeight <= 0) return;
 
+      if (container.offsetWidth <= 0 || container.offsetHeight <= 0) {
+        attempts += 1;
+        if (attempts < MAX_ACTIVATE_ATTEMPTS) {
+          rafId = window.requestAnimationFrame(tryActivate);
+        }
+        return;
+      }
+
+      wasActiveRef.current = true;
+      // Make sure a working renderer is in place before repainting — this
+      // loads WebGL for a pane that just became visible.
+      webglControlsRef.current?.ensure();
       fitAddon.fit();
       if (term.rows > 0) {
         term.refresh(0, term.rows - 1);
       }
       term.focus();
-    });
+    };
+    activateTerminalRef.current = tryActivate;
+    rafId = window.requestAnimationFrame(tryActivate);
 
-    return () => window.cancelAnimationFrame(frameId);
+    return () => {
+      window.cancelAnimationFrame(rafId);
+      activateTerminalRef.current = null;
+    };
   }, [isActive]);
 
   // Context menu handlers


### PR DESCRIPTION
## Root cause (from the #87 symptom set)

Blank + input-dead panes with the badge still **Connected**, SFTP working, System Monitor updating, and tab switching never recovering localizes the failure to the xterm render layer (the WS is loopback and can't silently die; the status badge is React state driven only by WS events). Two defects combined:

1. **One WebGL context per mounted terminal, held for life — including hidden panes.** 10+ tabs exceeded Chromium's live-context budget; the oldest contexts got evicted overnight. Under WebGL, text exists *only as pixels on the GL canvas*, so an evicted pane renders black forever while keystrokes still flow into the dead context — which is exactly why Ctrl+L showed *no visible response* while everything else stayed alive. (Same failure class as xtermjs/xterm.js#2253 / #6015.)
2. **One-shot activation.** The latch was consumed *before* a single rAF that bailed permanently on a 0×0 container, and the ResizeObserver path only ever called `fit()` — never `refresh()` — so tab switching repainted *through the still-registered dead renderer*: black on black.

## Changes (`pty-terminal.tsx`, frontend-only)

- **Lazy WebGL**: the addon loads when a pane becomes visible and is disposed when it hides. Live contexts drop from *mounted panes* to *visible panes* (1–4), below eviction pressure. Hidden panes keep their text via the DOM renderer.
- **Hardened context loss**: dispose wrapped in try/catch, then forced `fit()` + `refresh(0, rows-1)` so the fallback renderer repaints immediately instead of relying on the addon's best-effort dispose path.
- **Deterministic activation**: retries every animation frame until the container has a real size (~2s budget), and only then consumes the latch, ensures a working renderer, and runs fit + full refresh + focus. `wasActiveRef` now starts `false`, so **mount-active panes pass through the same measured path** — previously a terminal that mounted active behind a 0×0 container had no retry at all (a hole the new regression test exposed during development).
- The ResizeObserver completes a still-pending activation on a 0×0 → non-zero transition (wake-from-display-sleep coverage).

## Tests (5 new, `pty-terminal-renderer-lifecycle.test.tsx`)

- Inactive mount creates **no** WebGL context
- Activation loads WebGL + repaints + focuses; deactivation disposes it
- Active mount loads WebGL
- Context-loss handler disposes and force-repaints via fit + full refresh
- **0×0 → sized retry**: five frames at 0×0 (no repaint, latch not consumed) → container becomes visible → fit + `refresh(0, rows-1)` + focus land — the exact regression #87 asked for

Full suite: 54 files / 594 tests pass. `tsc --noEmit` clean, eslint 0 errors on touched files.

## Notes

- Addresses the renderer root cause of #87; the sustained-output bounding (#60 half) already landed in #66, and the per-subsystem health-state tracking from the issue remains open follow-up work.
- Stacked on current `main` (93d37c9). Overlaps trivially with #104's `pty-terminal.tsx` edits (different regions); will rebase if #104 merges first.

🤖 Generated with [ZCode](https://github.com/ZhipuAI/ZCode)