### PR TITLE
feat(terminal): park PTYs through transient WebSocket drops with reattach

### DIFF
--- a/src-tauri/src/connection_manager.rs
+++ b/src-tauri/src/connection_manager.rs
@@ -8,6 +8,7 @@ use crate::vnc_client::VncClient;
 use anyhow::Result;
 use std::collections::HashMap;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::sync::mpsc;
 use tokio::sync::RwLock;
 use tokio_util::sync::CancellationToken;
@@ -58,14 +59,19 @@ fn is_session_dead_error(e: &anyhow::Error) -> bool {
 }
 
 /// A PTY session that was detached from its WebSocket consumer (Xshell-style
-/// Ctrl+A+D). The SSH connection and PTY channel stay alive so the remote
-/// shell keeps running; only the streaming reader is stopped.
+/// Ctrl+A+D, or a WebSocket drop within the reattach grace period). The SSH
+/// connection and PTY channel stay alive so the remote shell keeps running;
+/// only the streaming reader is stopped.
 pub struct DetachedSession {
     pub session: Arc<PtySession>,
     pub generation: u64,
     /// Cancelled when the session is re-attached or terminated — stops the
     /// background output drain task.
     pub drain_cancel: CancellationToken,
+    /// When this session was (re-)parked. Grace-expiry timers compare
+    /// against this so a session reattached and parked again isn't killed by
+    /// a timer left over from an earlier park.
+    pub parked_at: tokio::time::Instant,
 }
 
 pub struct ConnectionManager {
@@ -198,7 +204,7 @@ impl ConnectionManager {
         connection_id: &str,
         cols: u32,
         rows: u32,
-    ) -> Result<u64, PtyStartError> {
+    ) -> Result<(u64, bool), PtyStartError> {
         // First try to re-attach a detached session.
         if let Some(detached) = self.take_detached_session(connection_id).await {
             tracing::info!("Re-attaching detached PTY session for {}", connection_id);
@@ -212,7 +218,7 @@ impl ConnectionManager {
                 tracing::warn!("Failed to resize re-attached PTY: {}", e);
             }
 
-            return Ok(detached.generation);
+            return Ok((detached.generation, true));
         }
 
         // Get the SSH client. A missing entry means the SSH session is gone
@@ -265,7 +271,7 @@ impl ConnectionManager {
         let mut pty_sessions = self.pty_sessions.write().await;
         pty_sessions.insert(connection_id.to_string(), Arc::new(pty));
 
-        Ok(current_gen)
+        Ok((current_gen, false))
     }
 
     /// Evict a dead SSH connection, guarded by `Arc` identity so a
@@ -373,11 +379,45 @@ impl ConnectionManager {
             let mut detached = self.detached_sessions.write().await;
             detached.insert(
                 connection_id.to_string(),
-                DetachedSession { session, generation, drain_cancel },
+                DetachedSession {
+                    session,
+                    generation,
+                    drain_cancel,
+                    parked_at: tokio::time::Instant::now(),
+                },
             );
             tracing::info!("Detached PTY session for {}", connection_id);
         }
         Ok(())
+    }
+
+    /// Expire a parked session whose reattach grace period elapsed: cancel
+    /// the PTY and remove it from the registry. The SSH connection itself is
+    /// left alone — SFTP/monitoring may still be using it, mirroring the
+    /// semantics of an explicit terminal Close.
+    ///
+    /// Guarded by `parked_at`: if the session was reattached and parked again
+    /// after this expiry timer was created, its `parked_at` is newer than the
+    /// grace window and the timer must leave it alone. Returns whether a
+    /// session was actually expired.
+    pub async fn expire_detached_session(&self, connection_id: &str, grace: Duration) -> bool {
+        let mut detached = self.detached_sessions.write().await;
+        let Some(info) = detached.get(connection_id) else {
+            return false;
+        };
+        if info.parked_at.elapsed() < grace {
+            return false; // reattached and re-parked after this timer started
+        }
+        let info = detached.remove(connection_id);
+        drop(detached);
+        if let Some(info) = info {
+            info.drain_cancel.cancel();
+            info.session.cancel.cancel();
+            tracing::info!("Expired parked PTY session for {}", connection_id);
+            true
+        } else {
+            false
+        }
     }
 
     /// List connection IDs that currently have a detached (background) session.
@@ -766,6 +806,55 @@ mod tests {
 
     // ===== PTY start error classification / stale-session eviction =====
 
+    #[tokio::test]
+    async fn test_expire_detached_session_respects_park_age() {
+        let mgr = ConnectionManager::new();
+        let (tx, _rx) = mpsc::channel::<Vec<u8>>(1);
+        let (rtx, _rrx) = mpsc::channel::<(u32, u32)>(1);
+        let session = PtySession {
+            input_tx: tx,
+            output_rx: Arc::new(tokio::sync::Mutex::new(mpsc::channel::<Vec<u8>>(1).1)),
+            channel_id: unsafe { std::mem::transmute(0u32) },
+            resize_tx: rtx,
+            cancel: CancellationToken::new(),
+        };
+        {
+            let mut detached = mgr.detached_sessions.write().await;
+            detached.insert(
+                "park-1".to_string(),
+                DetachedSession {
+                    session: Arc::new(session),
+                    generation: 1,
+                    drain_cancel: CancellationToken::new(),
+                    parked_at: tokio::time::Instant::now() - Duration::from_secs(600),
+                },
+            );
+        }
+
+        const GRACE: Duration = Duration::from_secs(300);
+
+        // A freshly re-parked session is left alone — this is the stale-timer
+        // guard (reattach + repark must not be killed by an older timer).
+        {
+            let mut detached = mgr.detached_sessions.write().await;
+            detached.get_mut("park-1").unwrap().parked_at = tokio::time::Instant::now();
+        }
+        assert!(!mgr.expire_detached_session("park-1", GRACE).await);
+        assert!(mgr.has_detached_session("park-1").await);
+
+        // A park older than the grace period is expired and removed.
+        {
+            let mut detached = mgr.detached_sessions.write().await;
+            detached.get_mut("park-1").unwrap().parked_at =
+                tokio::time::Instant::now() - Duration::from_secs(600);
+        }
+        assert!(mgr.expire_detached_session("park-1", GRACE).await);
+        assert!(!mgr.has_detached_session("park-1").await);
+
+        // Unknown id → nothing to expire.
+        assert!(!mgr.expire_detached_session("ghost", GRACE).await);
+    }
+
     #[test]
     fn test_session_dead_error_classification() {
         // Transport-gone errors indicate the SSH session itself is dead.
@@ -869,6 +958,7 @@ mod tests {
                     session: Arc::new(session),
                     generation: 1,
                     drain_cancel: CancellationToken::new(),
+                    parked_at: tokio::time::Instant::now(),
                 },
             );
         }
@@ -897,6 +987,7 @@ mod tests {
                     session: Arc::new(session),
                     generation: 1,
                     drain_cancel: CancellationToken::new(),
+                    parked_at: tokio::time::Instant::now(),
                 },
             );
         }

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -77,6 +77,10 @@ pub enum WsMessage {
     PtyStarted {
         connection_id: String,
         generation: u64,
+        /// True when an existing parked/detached session was re-attached
+        /// (same remote shell continues) rather than a fresh shell started.
+        #[serde(default)]
+        reattached: bool,
     },
 
     // ===== Desktop (RDP/VNC) messages =====
@@ -142,6 +146,12 @@ const CONTROL_SEND_TIMEOUT_MS: u64 = 100;
 
 /// Command byte that identifies a binary PTY output frame sent to the frontend.
 const BINARY_OUTPUT_CMD: u8 = 0x01;
+
+/// How long a PTY stays parked after its WebSocket drops, waiting for the
+/// frontend to reconnect and re-attach (issue #95 asked for 1–5 minutes).
+/// Within this window a StartPty resumes the same remote shell; after it,
+/// the session is expired (the SSH connection itself is left for SFTP).
+const PTY_WS_DROP_GRACE: Duration = Duration::from_secs(5 * 60);
 
 // ---------------------------------------------------------------------------
 // Types
@@ -462,20 +472,39 @@ impl WebSocketServer {
             }
         }
 
-        // Clean up all active PTY sessions so the SSH channel and reader task
-        // are torn down promptly when the browser tab closes.
+        // A WebSocket drop is usually transient (the frontend reconnects and
+        // re-issues StartPty), so park each PTY in the detached registry
+        // instead of killing it: the remote shell keeps running and a
+        // reconnect within the grace period re-attaches to the same session.
+        // An explicit Close (or a Detach) was already handled per-message;
+        // anything still active here only lost its transport. If nothing
+        // reattaches before the grace timer fires, the session is expired.
         for (connection_id, generation) in active_pty_generations {
+            // Stop this socket's streaming reader without killing the
+            // underlying SSH/PTY session.
+            if let Some(reader_cancel) = reader_tokens.lock().await.get(&connection_id) {
+                reader_cancel.cancel();
+            }
             if let Err(e) = self
                 .connection_manager
-                .close_pty_connection(&connection_id, Some(generation))
+                .detach_pty_connection(&connection_id, Some(generation))
                 .await
             {
                 tracing::warn!(
-                    "Failed to close PTY session {} on WebSocket cleanup: {}",
+                    "Failed to park PTY session {} on WebSocket cleanup: {}",
                     connection_id,
                     e
                 );
+                continue;
             }
+            let connection_manager = self.connection_manager.clone();
+            let id = connection_id.clone();
+            tokio::spawn(async move {
+                tokio::time::sleep(PTY_WS_DROP_GRACE).await;
+                if connection_manager.expire_detached_session(&id, PTY_WS_DROP_GRACE).await {
+                    tracing::info!("Grace period expired for parked PTY {}", id);
+                }
+            });
         }
         output_controls.lock().await.clear();
         reader_tokens.lock().await.clear();
@@ -505,7 +534,7 @@ impl WebSocketServer {
                     rows
                 );
 
-                let generation = self
+                let (generation, reattached) = self
                     .connection_manager
                     .start_pty_connection(&connection_id, cols, rows)
                     .await?;
@@ -550,6 +579,7 @@ impl WebSocketServer {
                 let started = WsMessage::PtyStarted {
                     connection_id: connection_id.clone(),
                     generation,
+                    reattached,
                 };
                 send_control(&tx, &started).await?;
 
@@ -917,6 +947,26 @@ mod tests {
         match msg {
             WsMessage::Error { code, .. } => assert_eq!(code, None),
             other => panic!("expected Error, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_pty_started_serde_reattached_defaults_false() {
+        let msg: WsMessage =
+            serde_json::from_str(r#"{"type":"PtyStarted","connection_id":"c","generation":1}"#)
+                .unwrap();
+        match msg {
+            WsMessage::PtyStarted { reattached, .. } => assert!(!reattached),
+            other => panic!("expected PtyStarted, got {:?}", other),
+        }
+
+        let msg: WsMessage = serde_json::from_str(
+            r#"{"type":"PtyStarted","connection_id":"c","generation":1,"reattached":true}"#,
+        )
+        .unwrap();
+        match msg {
+            WsMessage::PtyStarted { reattached, .. } => assert!(reattached),
+            other => panic!("expected PtyStarted, got {:?}", other),
         }
     }
 

--- a/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
+++ b/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
@@ -299,6 +299,34 @@ describe('PtyTerminal ssh_session_dead escalation', () => {
     );
   });
 
+  it('prints the session-restored banner when the backend re-attaches a parked session', async () => {
+    const onStatusChange = vi.fn();
+    const webSocket = await mountTerminalWithPty('reattach-1', onStatusChange);
+    const terminal = lastTerminal();
+    terminal.writeln.mockClear();
+
+    // Simulate the reconnect flow: Success first (resets counters, flags the
+    // reconnect), then PtyStarted with reattached: true.
+    webSocket.onmessage({
+      data: JSON.stringify({ type: 'Success', message: 'PTY connection started: reattach-1' }),
+    } as MessageEvent);
+    webSocket.onmessage({
+      data: JSON.stringify({
+        type: 'PtyStarted',
+        connection_id: 'reattach-1',
+        generation: 2,
+        reattached: true,
+      }),
+    } as MessageEvent);
+
+    expect(terminal.writeln).toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.sessionRestored')),
+    );
+    expect(terminal.writeln).not.toHaveBeenCalledWith(
+      expect.stringContaining(i18n.t('ptyTerminal.previousSessionLost')),
+    );
+  });
+
   it('escalates only once per mount even if more coded errors arrive', async () => {
     const onStatusChange = vi.fn();
     const webSocket = await mountTerminalWithPty('ssh-dead-2', onStatusChange);

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -562,6 +562,10 @@ export function PtyTerminal({
     // Set when a drop triggers auto-reconnect, so the Success message can
     // warn the user that a fresh shell was started.
     let isReconnectAfterDrop = false;
+    // Captured by Success ('PTY connection started') and consumed by
+    // PtyStarted, which is the only message that knows whether the backend
+    // re-attached a parked session (reattached: true) or started fresh.
+    let startedAfterReconnect = false;
 
     // RAF write batching state — lifted to effect scope so cleanup can cancel.
     let writeBuffer = '';
@@ -736,12 +740,14 @@ export function PtyTerminal({
             case 'Success':
               console.log(`[PTY Terminal] [${connectionId}]`, msg.message);
               if (msg.message.includes('PTY connection started')) {
+                // Captured for PtyStarted: at that point these flags have
+                // already been reset, but only PtyStarted knows whether the
+                // backend re-attached a parked session or started a fresh
+                // shell.
+                startedAfterReconnect = hasEverConnected || isReconnectAfterDrop;
                 reconnectAttemptsRef.current = 0;
                 autoReconnectAfterDropRef.current = 0; // Reset drop-reconnect counter on success
-                if (hasEverConnected || isReconnectAfterDrop) {
-                  // Reconnected after a drop — warn that a fresh shell was started
-                  term.writeln(`\x1b[33m${i18n.t('ptyTerminal.previousSessionLost')}\x1b[0m`);
-                } else {
+                if (!startedAfterReconnect) {
                   term.writeln(`\x1b[32m${i18n.t('ptyTerminal.ptyStarted')}\x1b[0m`);
                   term.writeln(`\x1b[90m${i18n.t('ptyTerminal.interactiveHint')}\x1b[0m`);
                 }
@@ -754,7 +760,7 @@ export function PtyTerminal({
                 }
               }
               break;
-            
+
             case 'PtyStarted': {
               if (msg.connection_id === connectionId && typeof msg.generation === 'number') {
                 ptyGenerationRef.current = msg.generation;
@@ -765,6 +771,15 @@ export function PtyTerminal({
                 // Ongoing credits are returned by the flush callback above.
                 const INITIAL_WINDOW = 2;
                 grantCredits(INITIAL_WINDOW);
+                if (msg.reattached) {
+                  // The backend re-attached a parked session — the same
+                  // remote shell continues (transient WebSocket drop).
+                  term.writeln(`\x1b[32m${i18n.t('ptyTerminal.sessionRestored')}\x1b[0m`);
+                } else if (startedAfterReconnect) {
+                  // A fresh shell was started after a drop — the previous
+                  // session's state is gone.
+                  term.writeln(`\x1b[33m${i18n.t('ptyTerminal.previousSessionLost')}\x1b[0m`);
+                }
               }
               break;
             }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -1108,6 +1108,7 @@
     "reconnectFailedPermanently": "[Connection failed permanently. Use right-click → Reconnect to retry.]",
     "reconnectingAfterClose": "[Connection closed. Reconnecting in {{seconds}}s (attempt {{attempt}}/{{max}})...]",
     "sshSessionLost": "[SSH session lost. Reconnecting with full authentication...]",
+    "sessionRestored": "[Session restored — reconnected to the same shell]",
     "sshSessionDeadPermanent": "[SSH session lost and automatic recovery limit reached. Use right-click → Reconnect to retry.]"
   },
   "systemMonitor": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -1108,6 +1108,7 @@
     "reconnectFailedPermanently": "[连接永久失败，请使用右键 → 重新连接以重试。]",
     "reconnectingAfterClose": "[连接已关闭。{{seconds}} 秒后重新连接（第 {{attempt}}/{{max}} 次尝试）...]",
     "sshSessionLost": "[SSH 会话已丢失。正在重新进行完整认证并重连...]",
+    "sessionRestored": "[会话已恢复 — 已重新连接到原 Shell]",
     "sshSessionDeadPermanent": "[SSH 会话已丢失且已达自动恢复上限，请使用右键 → 重新连接重试。]"
   },
   "systemMonitor": {


### PR DESCRIPTION
Completes the second #95 failure order on top of #76's detached-session registry.

## The gap

#104 fixed SSH-dies-first (typed `ssh_session_dead` → eviction → full re-auth). This PR fixes **WebSocket-dies-first**: the WS cleanup loop called `close_pty_connection` on every still-active PTY, so the frontend's reconnect could only ever get a *fresh* shell — the running `fstrim`/`fio` was lost even though the SSH session was perfectly alive (the exact `WebSocket connected` → dead-session scenario from #95's report).

## Changes

**Backend**
- WS cleanup now **parks** each active PTY (cancel the socket's reader token → `detach_pty_connection` → registry + drain task keeps the remote process from stalling) and starts a **5-minute grace timer**. `StartPty` within the window re-attaches to the same live shell (the #76 reattach path); after it, `expire_detached_session` tears the session down.
- Expiry is **`parked_at`-guarded**: a session reattached and parked again is never killed by a timer from an earlier park. Expiry cancels the PTY but leaves the SSH connection for SFTP/monitoring — same semantics as an explicit terminal Close.
- Explicit `Close` and Ctrl+A+D `Detach` are unaffected: both were already removed from the cleanup map per-message, so user-intent closes still destroy immediately and explicit detaches still live indefinitely.

**Reattach UX**
- `PtyStarted` gains a backward-compatible `reattached` flag (`#[serde(default)]`). The frontend now prints a green *session restored* banner when the same shell continues, reserving the *previous session lost* warning for genuinely fresh shells — previously every reconnect printed the loss warning even when nothing was lost.

## Tests
- Rust: park-age expiry guard (fresh re-park survives a stale timer, aged park expires and is removed, unknown id no-ops); `PtyStarted` serde with and without the flag. `cargo test`: 148 passed.
- Frontend: restored-banner flow (Success → `PtyStarted{reattached:true}` prints restored, not lost). Full suite: 55 files / 600 tests; `tsc` clean; i18n parity 1095/1095.

## Note

Overlaps trivially with #106 in `websocket_server.rs`/`connection_manager.rs` (different regions); whichever merges second gets a small rebase.

🤖 Generated with [ZCode](https://github.com/ZhipuAI/ZCode)