### PR TITLE
feat(terminal): per-subsystem session health tracking

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -191,6 +191,17 @@ pub async fn ssh_disconnect(
     }
 }
 
+/// Per-subsystem health snapshot for a connection's terminal pipeline
+/// (SSH alive / PTY attached / generation / detached). Used by the frontend
+/// to reconcile tab status so "Connected" can't outlive a dead PTY.
+#[tauri::command]
+pub async fn get_session_health(
+    connection_id: String,
+    state: State<'_, Arc<ConnectionManager>>,
+) -> Result<crate::connection_manager::SessionHealth, String> {
+    Ok(state.session_health(&connection_id).await)
+}
+
 /// List connection IDs that currently have a detached (background) session.
 #[tauri::command]
 pub async fn list_detached_sessions(

--- a/src-tauri/src/connection_manager.rs
+++ b/src-tauri/src/connection_manager.rs
@@ -6,6 +6,7 @@ use crate::sftp_client::StandaloneSftpClient;
 use crate::ssh::{PtySession, SshClient, SshConfig};
 use crate::vnc_client::VncClient;
 use anyhow::Result;
+use serde::Serialize;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -72,6 +73,26 @@ pub struct DetachedSession {
     /// against this so a session reattached and parked again isn't killed by
     /// a timer left over from an earlier park.
     pub parked_at: tokio::time::Instant,
+}
+
+/// Point-in-time health of one connection's terminal pipeline, with each
+/// subsystem reported separately so the UI can't show "Connected" while the
+/// terminal path is dead (issue #87: SFTP and the monitor can stay alive on
+/// the same SSH session after the PTY pipeline died).
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionHealth {
+    /// The SSH connection exists in the connection map.
+    pub ssh_connected: bool,
+    /// An interactive PTY session is currently attached to a WebSocket.
+    pub has_pty: bool,
+    /// Current PTY generation counter, if any session was ever started.
+    pub pty_generation: Option<u64>,
+    /// The PTY is parked in the detached registry (Ctrl+A+D or a WebSocket
+    /// drop inside the grace window) — alive, just not streaming.
+    pub detached: bool,
+    /// Protocol type recorded for the connection ("SSH", "SFTP", ...).
+    pub connection_type: Option<String>,
 }
 
 pub struct ConnectionManager {
@@ -417,6 +438,32 @@ impl ConnectionManager {
             true
         } else {
             false
+        }
+    }
+
+    /// Snapshot of each subsystem's state for a connection. Locks are taken
+    /// sequentially (never nested) and unknown ids simply report all-false.
+    pub async fn session_health(&self, connection_id: &str) -> SessionHealth {
+        let ssh_connected = self.connections.read().await.contains_key(connection_id);
+        let has_pty = self.pty_sessions.read().await.contains_key(connection_id);
+        let pty_generation = self
+            .pty_generations
+            .read()
+            .await
+            .get(connection_id)
+            .copied();
+        let detached = self
+            .detached_sessions
+            .read()
+            .await
+            .contains_key(connection_id);
+        let connection_type = self.get_connection_type(connection_id).await;
+        SessionHealth {
+            ssh_connected,
+            has_pty,
+            pty_generation,
+            detached,
+            connection_type,
         }
     }
 
@@ -897,6 +944,37 @@ mod tests {
 
         // Unknown connection → Err.
         assert!(mgr.read_from_pty("ghost", None).await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_session_health_reflects_each_subsystem() {
+        let mgr = ConnectionManager::new();
+
+        // Unknown connection: everything false / None.
+        let h = mgr.session_health("ghost").await;
+        assert!(!h.ssh_connected);
+        assert!(!h.has_pty);
+        assert!(!h.detached);
+        assert_eq!(h.pty_generation, None);
+        assert_eq!(h.connection_type, None);
+
+        // Populate the subsystem maps one by one.
+        {
+            let mut connections = mgr.connections.write().await;
+            connections.insert(
+                "c-1".to_string(),
+                Arc::new(RwLock::new(SshClient::new())),
+            );
+        }
+        {
+            let mut generations = mgr.pty_generations.write().await;
+            generations.insert("c-1".to_string(), 7);
+        }
+        let h = mgr.session_health("c-1").await;
+        assert!(h.ssh_connected);
+        assert!(!h.has_pty);
+        assert!(!h.detached);
+        assert_eq!(h.pty_generation, Some(7));
     }
 
     #[test]

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -294,6 +294,7 @@ pub fn run() {
             commands::ssh_connect,
             commands::ssh_cancel_connect,
             commands::ssh_disconnect,
+            commands::get_session_health,
             commands::list_detached_sessions,
             commands::has_detached_session,
             commands::close_detached_session,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
 import { applyLanguageFromPreference } from './lib/i18n';
+import { reconcileSessionHealth } from './lib/session-health';
 import { invoke } from '@tauri-apps/api/core';
 import { listen } from '@tauri-apps/api/event';
 import { MenuBar } from './components/menu-bar';
@@ -170,6 +171,29 @@ function AppContent() {
       window.removeEventListener('storage', refreshKeyboardShortcutSettings);
     };
   }, []);
+
+  // Latest tabs snapshot for the health poll below — kept in a ref so the
+  // interval isn't torn down and recreated on every group-state change.
+  const allTabsRef = useRef(allTabs);
+  useEffect(() => {
+    allTabsRef.current = allTabs;
+  }, [allTabs]);
+
+  // Periodically reconcile terminal tab status against backend session
+  // health (issue #87 backstop: SFTP/monitor can keep the SSH session alive
+  // while the PTY pipeline is gone, leaving a lying "Connected" badge).
+  useEffect(() => {
+    const HEALTH_POLL_INTERVAL_MS = 30_000;
+    const interval = window.setInterval(() => {
+      void reconcileSessionHealth(
+        allTabsRef.current,
+        (connectionId) =>
+          invoke('get_session_health', { connectionId }),
+        (tabId) => dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' }),
+      );
+    }, HEALTH_POLL_INTERVAL_MS);
+    return () => window.clearInterval(interval);
+  }, [dispatch]);
 
   const handleCloseActiveTab = useCallback(() => {
     if (!activeGroup?.activeTabId) {

--- a/src/lib/__tests__/session-health.test.ts
+++ b/src/lib/__tests__/session-health.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  isSshTerminalTab,
+  reconcileSessionHealth,
+  type HealthCheckedTab,
+  type SessionHealth,
+} from '../session-health';
+
+function tab(overrides: Partial<HealthCheckedTab> = {}): HealthCheckedTab {
+  return {
+    id: 'tab-1',
+    tabType: 'terminal',
+    connectionStatus: 'connected',
+    ...overrides,
+  };
+}
+
+function health(overrides: Partial<SessionHealth> = {}): SessionHealth {
+  return {
+    sshConnected: true,
+    hasPty: true,
+    detached: false,
+    ...overrides,
+  };
+}
+
+describe('isSshTerminalTab', () => {
+  it('accepts terminal tabs including legacy ones without a tabType', () => {
+    expect(isSshTerminalTab(tab())).toBe(true);
+    expect(isSshTerminalTab(tab({ tabType: undefined }))).toBe(true);
+  });
+
+  it('rejects file-browser, desktop, and SFTP/FTP tabs', () => {
+    expect(isSshTerminalTab(tab({ tabType: 'file-browser' }))).toBe(false);
+    expect(isSshTerminalTab(tab({ tabType: 'desktop' }))).toBe(false);
+    expect(isSshTerminalTab(tab({ protocol: 'SFTP' }))).toBe(false);
+    expect(isSshTerminalTab(tab({ protocol: 'FTP' }))).toBe(false);
+  });
+});
+
+describe('reconcileSessionHealth', () => {
+  it('downgrades a connected tab whose SSH session is gone', async () => {
+    const markDisconnected = vi.fn();
+    const unhealthy = await reconcileSessionHealth(
+      [tab({ id: 'a' })],
+      async () => health({ sshConnected: false, hasPty: false }),
+      markDisconnected,
+    );
+    expect(unhealthy).toEqual(['a']);
+    expect(markDisconnected).toHaveBeenCalledWith('a');
+  });
+
+  it('downgrades a tab with no PTY and nothing parked (issue #87 backstop)', async () => {
+    const markDisconnected = vi.fn();
+    const unhealthy = await reconcileSessionHealth(
+      [tab({ id: 'a' })],
+      async () => health({ sshConnected: true, hasPty: false, detached: false }),
+      markDisconnected,
+    );
+    expect(unhealthy).toEqual(['a']);
+    expect(markDisconnected).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps a parked (detached) tab healthy — alive, just not streaming', async () => {
+    const markDisconnected = vi.fn();
+    const unhealthy = await reconcileSessionHealth(
+      [tab({ id: 'a' })],
+      async () => health({ sshConnected: true, hasPty: false, detached: true }),
+      markDisconnected,
+    );
+    expect(unhealthy).toEqual([]);
+    expect(markDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('skips non-connected and non-terminal tabs without fetching', async () => {
+    const fetchHealth = vi.fn(async () => health());
+    const markDisconnected = vi.fn();
+    const unhealthy = await reconcileSessionHealth(
+      [
+        tab({ id: 'disconnected', connectionStatus: 'disconnected' }),
+        tab({ id: 'sftp', protocol: 'SFTP' }),
+      ],
+      fetchHealth,
+      markDisconnected,
+    );
+    expect(unhealthy).toEqual([]);
+    expect(fetchHealth).not.toHaveBeenCalled();
+    expect(markDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('leaves status alone when the health fetch fails', async () => {
+    const markDisconnected = vi.fn();
+    const unhealthy = await reconcileSessionHealth(
+      [tab({ id: 'a' })],
+      async () => {
+        throw new Error('backend unreachable');
+      },
+      markDisconnected,
+    );
+    expect(unhealthy).toEqual([]);
+    expect(markDisconnected).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/__tests__/session-health.test.ts
+++ b/src/lib/__tests__/session-health.test.ts
@@ -36,6 +36,12 @@ describe('isSshTerminalTab', () => {
     expect(isSshTerminalTab(tab({ protocol: 'SFTP' }))).toBe(false);
     expect(isSshTerminalTab(tab({ protocol: 'FTP' }))).toBe(false);
   });
+
+  it('rejects non-SSH protocols such as RDP and VNC', () => {
+    expect(isSshTerminalTab(tab({ protocol: 'RDP' }))).toBe(false);
+    expect(isSshTerminalTab(tab({ protocol: 'VNC' }))).toBe(false);
+    expect(isSshTerminalTab(tab({ protocol: 'SSH' }))).toBe(true);
+  });
 });
 
 describe('reconcileSessionHealth', () => {
@@ -99,5 +105,24 @@ describe('reconcileSessionHealth', () => {
     );
     expect(unhealthy).toEqual([]);
     expect(markDisconnected).not.toHaveBeenCalled();
+  });
+
+  it('does not start a second pass while one is still in flight', async () => {
+    let release: (value: SessionHealth) => void = () => {};
+    const gate = new Promise<SessionHealth>((resolve) => {
+      release = resolve;
+    });
+    const fetchHealth = vi.fn(() => gate);
+    const markDisconnected = vi.fn();
+
+    const first = reconcileSessionHealth([tab({ id: 'a' })], fetchHealth, markDisconnected);
+    // Second tick of a slow poll: skipped entirely, no extra invoke queued.
+    const second = await reconcileSessionHealth([tab({ id: 'a' })], fetchHealth, markDisconnected);
+    expect(second).toEqual([]);
+    expect(fetchHealth).toHaveBeenCalledTimes(1);
+
+    release(health({ sshConnected: false, hasPty: false }));
+    expect(await first).toEqual(['a']);
+    expect(markDisconnected).toHaveBeenCalledWith('a');
   });
 });

--- a/src/lib/session-health.ts
+++ b/src/lib/session-health.ts
@@ -32,20 +32,29 @@ export interface HealthCheckedTab {
   connectionStatus: 'connected' | 'connecting' | 'disconnected' | 'pending';
 }
 
-/** Only SSH terminal tabs have a PTY pipeline to health-check. */
+/** Only SSH terminal tabs have a PTY pipeline to health-check. Desktop
+ *  protocols (RDP/VNC) are excluded here even though their tabs may be
+ *  terminal-typed, so the check is explicit rather than "anything that isn't
+ *  SFTP/FTP". */
 export function isSshTerminalTab(tab: HealthCheckedTab): boolean {
   return (
     (tab.tabType === undefined || tab.tabType === 'terminal') &&
-    tab.protocol !== 'SFTP' &&
-    tab.protocol !== 'FTP'
+    (tab.protocol === undefined || tab.protocol === 'SSH')
   );
 }
+
+/** True while a reconciliation pass is in flight — prevents overlapping
+ *  polls when a pass takes longer than the polling interval (many tabs or
+ *  slow IPC), which would otherwise stack concurrent invokes. */
+let reconcileInFlight = false;
 
 /**
  * Poll health for every connected SSH terminal tab and downgrade the ones
  * whose terminal pipeline is dead (SSH gone, or no PTY and nothing parked).
  * Fetch failures are skipped — the next poll retries — so a momentarily
  * unreachable backend can't flap tabs to disconnected.
+ *
+ * No-op (returns an empty list) if a previous pass is still running.
  *
  * @returns the ids that were reported unhealthy.
  */
@@ -54,21 +63,29 @@ export async function reconcileSessionHealth(
   fetchHealth: (connectionId: string) => Promise<SessionHealth>,
   markDisconnected: (tabId: string) => void,
 ): Promise<string[]> {
-  const unhealthy: string[] = [];
-  for (const tab of tabs) {
-    if (!isSshTerminalTab(tab) || tab.connectionStatus !== 'connected') {
-      continue;
-    }
-    let health: SessionHealth;
-    try {
-      health = await fetchHealth(tab.id);
-    } catch {
-      continue;
-    }
-    if (!health.sshConnected || (!health.hasPty && !health.detached)) {
-      markDisconnected(tab.id);
-      unhealthy.push(tab.id);
-    }
+  if (reconcileInFlight) {
+    return [];
   }
-  return unhealthy;
+  reconcileInFlight = true;
+  try {
+    const unhealthy: string[] = [];
+    for (const tab of tabs) {
+      if (!isSshTerminalTab(tab) || tab.connectionStatus !== 'connected') {
+        continue;
+      }
+      let health: SessionHealth;
+      try {
+        health = await fetchHealth(tab.id);
+      } catch {
+        continue;
+      }
+      if (!health.sshConnected || (!health.hasPty && !health.detached)) {
+        markDisconnected(tab.id);
+        unhealthy.push(tab.id);
+      }
+    }
+    return unhealthy;
+  } finally {
+    reconcileInFlight = false;
+  }
 }

--- a/src/lib/session-health.ts
+++ b/src/lib/session-health.ts
@@ -1,0 +1,74 @@
+/**
+ * Per-subsystem session health reconciliation.
+ *
+ * Event sources (WebSocket close, PTY errors) normally keep a terminal tab's
+ * status accurate, but the terminal pipeline can die without any event
+ * reaching the frontend — issue #87's overnight scenario: SFTP and the
+ * system monitor keep the shared SSH session alive while the PTY is gone, so
+ * a "Connected" badge would otherwise lie indefinitely. Polling the backend
+ * for per-subsystem health and downgrading mismatched tabs is the backstop.
+ */
+
+/** Mirrors `SessionHealth` in `src-tauri/src/connection_manager.rs`. */
+export interface SessionHealth {
+  /** The SSH connection exists in the backend's connection map. */
+  sshConnected: boolean;
+  /** An interactive PTY session is currently attached to a WebSocket. */
+  hasPty: boolean;
+  /** Current PTY generation counter, if any session was ever started. */
+  ptyGeneration?: number | null;
+  /** The PTY is parked (Ctrl+A+D or a WebSocket drop inside the grace
+   *  window) — alive, just not streaming; NOT unhealthy. */
+  detached: boolean;
+  /** Protocol type recorded for the connection ("SSH", "SFTP", ...). */
+  connectionType?: string | null;
+}
+
+/** Minimal tab shape needed for health checks. */
+export interface HealthCheckedTab {
+  id: string;
+  tabType?: 'terminal' | 'file-browser' | 'desktop' | 'editor';
+  protocol?: string;
+  connectionStatus: 'connected' | 'connecting' | 'disconnected' | 'pending';
+}
+
+/** Only SSH terminal tabs have a PTY pipeline to health-check. */
+export function isSshTerminalTab(tab: HealthCheckedTab): boolean {
+  return (
+    (tab.tabType === undefined || tab.tabType === 'terminal') &&
+    tab.protocol !== 'SFTP' &&
+    tab.protocol !== 'FTP'
+  );
+}
+
+/**
+ * Poll health for every connected SSH terminal tab and downgrade the ones
+ * whose terminal pipeline is dead (SSH gone, or no PTY and nothing parked).
+ * Fetch failures are skipped — the next poll retries — so a momentarily
+ * unreachable backend can't flap tabs to disconnected.
+ *
+ * @returns the ids that were reported unhealthy.
+ */
+export async function reconcileSessionHealth(
+  tabs: HealthCheckedTab[],
+  fetchHealth: (connectionId: string) => Promise<SessionHealth>,
+  markDisconnected: (tabId: string) => void,
+): Promise<string[]> {
+  const unhealthy: string[] = [];
+  for (const tab of tabs) {
+    if (!isSshTerminalTab(tab) || tab.connectionStatus !== 'connected') {
+      continue;
+    }
+    let health: SessionHealth;
+    try {
+      health = await fetchHealth(tab.id);
+    } catch {
+      continue;
+    }
+    if (!health.sshConnected || (!health.hasPty && !health.detached)) {
+      markDisconnected(tab.id);
+      unhealthy.push(tab.id);
+    }
+  }
+  return unhealthy;
+}


### PR DESCRIPTION
Final item from #87's acceptance criteria: track the terminal pipeline's subsystems separately and reconcile tab status against them, so a **Connected** badge can't outlive a dead terminal pipeline (the overnight scenario where SFTP and the system monitor kept the shared SSH session alive while the PTY was gone).

## Backend
- `SessionHealth` + `ConnectionManager::session_health()` — point-in-time snapshot per connection: `sshConnected`, `hasPty`, `ptyGeneration`, `detached`, `connectionType`. Locks taken sequentially, unknown ids report all-false.
- New `get_session_health` Tauri command.

## Frontend
- `src/lib/session-health.ts` — the reconciler as a testable helper: for every connected SSH terminal tab, fetch health and downgrade when the SSH session is gone **or** the PTY is missing with nothing parked. A parked PTY (Ctrl+A+D or a WS drop inside the grace window) is healthy — alive, just not streaming. Fetch failures are skipped so a momentarily unreachable backend can't flap tabs.
- `App.tsx` polls every 30s against the latest tab snapshot (ref-held, so the interval survives group-state churn).

## Tests
- Rust: map-presence semantics (unknown → all false; per-subsystem population). `cargo test`: 151 passed.
- Frontend: reconciler unit tests — SSH-dead, PTY-dead-no-park, parked-is-healthy, tab filtering, fetch-failure tolerance. Full suite: 56 files / 608 tests; `tsc` clean.

Built on top of #76 (detach registry) / #106 / #107 — all merged.

🤖 Generated with [ZCode](https://github.com/ZhipuAI/ZCode)