### PR TITLE
feat(settings): launch at login via tauri-plugin-autostart

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "@radix-ui/react-toggle-group": "^1.1.12",
     "@radix-ui/react-tooltip": "^1.2.9",
     "@tauri-apps/api": "^2.11.0",
+    "@tauri-apps/plugin-autostart": "^2.2.0",
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -155,6 +155,9 @@ importers:
       '@tauri-apps/api':
         specifier: ^2.11.0
         version: 2.11.0
+      '@tauri-apps/plugin-autostart':
+        specifier: ^2.2.0
+        version: 2.5.1
       '@tauri-apps/plugin-clipboard-manager':
         specifier: ^2.3.2
         version: 2.3.2
@@ -1567,67 +1570,56 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -1683,35 +1675,30 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-arm64-musl@2.11.2':
     resolution: {integrity: sha512-X1rm0BERqAAggtYTESSgXrS3sz4Sb/OiPiz54UqISlXW+GkR3vNIGnsy/lejNmoXGVqri3Q53BCfQiclOIyRPw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-linux-riscv64-gnu@2.11.2':
     resolution: {integrity: sha512-usbMLJbT3KtkOrBMDVeGYNM35aTHXx38SJSzTMSqqjeUIOQ+iVPjb2yAGNAE+KqmBbAx4FOFIyMeKXx2M/JKGQ==}
     engines: {node: '>= 10'}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-gnu@2.11.2':
     resolution: {integrity: sha512-Ru4gwJKPG0ctVGchRGpRup4Y4lW2SSfFnrbQcyHhCliKy4g8Qz97TrUgCur4CbWyAgKxvGh3SjrkA0LDYzDGiw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tauri-apps/cli-linux-x64-musl@2.11.2':
     resolution: {integrity: sha512-eUm7T6clN1MMmNSRQ9gaWsQdyehQx2Gmn5hht/QUlqZQI/qcP2OJK5dnaxqwFzCr2HdsEo9ydxaqcS1oJzMvUw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tauri-apps/cli-win32-arm64-msvc@2.11.2':
     resolution: {integrity: sha512-HeeZW80jU+gVTOEX4X/hC6NVSAdDVXajwP5fxIZ/3z9WvUC7qrudX2GMTilYq6Dg0e0sk0XgsAJD1hZ5wPBXUA==}
@@ -1735,6 +1722,9 @@ packages:
     resolution: {integrity: sha512-bk3HemqvGRoy+5D/dVMUQHKMYLglD0jVnMm/0iGMH6ufZ+p8r14m6BpIixwij3PBvZdvORUp1YifTD8QxVZ1Nw==}
     engines: {node: '>= 10'}
     hasBin: true
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    resolution: {integrity: sha512-zS/xx7yzveCcotkA+8TqkI2lysmG2wvQXv2HGAVExITmnFfHAdj1arGsbbfs3o6EktRHf6l34pJxc3YGG2mg7w==}
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     resolution: {integrity: sha512-CUlb5Hqi2oZbcZf4VUyUH53XWPPdtpw43EUpCza5HWZJwxEoDowFzNUDt1tRUXA8Uq+XPn17Ysfptip33sG4eQ==}
@@ -4738,6 +4728,10 @@ snapshots:
       '@tauri-apps/cli-win32-arm64-msvc': 2.11.2
       '@tauri-apps/cli-win32-ia32-msvc': 2.11.2
       '@tauri-apps/cli-win32-x64-msvc': 2.11.2
+
+  '@tauri-apps/plugin-autostart@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-clipboard-manager@2.3.2':
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -337,6 +337,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "auto-launch"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f012b8cc0c850f34117ec8252a44418f2e34a2cf501de89e29b241ae5f79471"
+dependencies = [
+ "dirs 4.0.0",
+ "thiserror 1.0.69",
+ "winreg 0.10.1",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1027,6 +1038,15 @@ dependencies = [
 
 [[package]]
 name = "dirs"
+version = "4.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
+dependencies = [
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
@@ -1041,6 +1061,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
  "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
+dependencies = [
+ "libc",
+ "redox_users 0.4.6",
+ "winapi",
 ]
 
 [[package]]
@@ -1256,7 +1287,7 @@ dependencies = [
  "rustc_version",
  "toml 1.1.2+spec-1.1.0",
  "vswhom",
- "winreg",
+ "winreg 0.55.0",
 ]
 
 [[package]]
@@ -3779,6 +3810,7 @@ dependencies = [
  "sys-locale",
  "tauri",
  "tauri-build",
+ "tauri-plugin-autostart",
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
@@ -5158,6 +5190,20 @@ dependencies = [
  "serde_json",
  "tauri-utils",
  "walkdir",
+]
+
+[[package]]
+name = "tauri-plugin-autostart"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "459383cebc193cdd03d1ba4acc40f2c408a7abce419d64bdcd2d745bc2886f70"
+dependencies = [
+ "auto-launch",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -6927,6 +6973,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "80d0f4e272c85def139476380b12f9ac60926689dd2e01d4923222f40580869d"
+dependencies = [
+ "winapi",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
 tauri-plugin-clipboard-manager = "2"
+tauri-plugin-autostart = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -23,6 +23,7 @@
     "process:allow-restart",
     "process:allow-exit",
     "clipboard-manager:allow-read-text",
-    "clipboard-manager:allow-write-text"
+    "clipboard-manager:allow-write-text",
+    "autostart:default"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -258,6 +258,10 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_process::init())
         .plugin(tauri_plugin_clipboard_manager::init())
+        .plugin(tauri_plugin_autostart::init(
+            tauri_plugin_autostart::MacosLauncher::LaunchAgent,
+            None,
+        ))
         .setup({
             let connection_manager_clone = connection_manager.clone();
             move |app| {

--- a/src/__tests__/settings-modal-autostart.test.tsx
+++ b/src/__tests__/settings-modal-autostart.test.tsx
@@ -1,0 +1,135 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+
+// ── Hoisted mocks (must exist before vi.mock factories run) ─────────────────
+
+const { mockEnable, mockDisable, mockIsEnabled, mockToast } = vi.hoisted(() => ({
+  mockEnable: vi.fn(),
+  mockDisable: vi.fn(),
+  mockIsEnabled: vi.fn(),
+  mockToast: {
+    success: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+vi.mock('@tauri-apps/api/core', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tauri-apps/api/core')>();
+  return {
+    ...actual,
+    // Pretend we run inside the Tauri runtime so the autostart path is exercised
+    isTauri: () => true,
+  };
+});
+
+vi.mock('@tauri-apps/plugin-autostart', () => ({
+  enable: () => mockEnable(),
+  disable: () => mockDisable(),
+  isEnabled: () => mockIsEnabled(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: mockToast,
+}));
+
+// Render every tab at once — jsdom + Radix Tabs trigger activation is flaky,
+// and this test targets the launch-at-login logic, not tab behavior
+vi.mock('../components/ui/tabs', () => ({
+  Tabs: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TabsList: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TabsTrigger: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  TabsContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+import { SettingsModal } from '../components/settings-modal';
+
+// jsdom has no ResizeObserver; the modal's scrollable tab bar needs one
+class MockResizeObserver {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+// jsdom also lacks scrollIntoView, used by the tab bar's auto-scroll effect
+Object.defineProperty(Element.prototype, 'scrollIntoView', {
+  configurable: true,
+  value: () => {},
+});
+
+/** Render the modal and return the onOpenChange spy. */
+function renderModal() {
+  const onOpenChange = vi.fn();
+  render(<SettingsModal open onOpenChange={onOpenChange} />);
+  return { onOpenChange };
+}
+
+/** Locate the launch-at-login switch via its description text. */
+function getAutostartSwitch() {
+  const desc = screen.getByText('Start r-shell automatically when you log in');
+  const row = desc.closest('div')!.parentElement as HTMLElement;
+  return within(row).getByRole('switch');
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('SettingsModal launch-at-login', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+    globalThis.ResizeObserver = MockResizeObserver;
+    mockIsEnabled.mockResolvedValue(false);
+    mockEnable.mockResolvedValue(undefined);
+    mockDisable.mockResolvedValue(undefined);
+  });
+
+  it('reflects the OS launch-at-login state when opened', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+
+    renderModal();
+
+    expect(mockIsEnabled).toHaveBeenCalledTimes(1);
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('true'));
+  });
+
+  it('enables launch-at-login when the toggle is turned on and saved', async () => {
+    renderModal();
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('false'));
+
+    fireEvent.click(getAutostartSwitch());
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    await waitFor(() => expect(mockEnable).toHaveBeenCalledTimes(1));
+    expect(mockDisable).not.toHaveBeenCalled();
+  });
+
+  it('disables launch-at-login when the toggle is turned off and saved', async () => {
+    mockIsEnabled.mockResolvedValue(true);
+    renderModal();
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('true'));
+
+    fireEvent.click(getAutostartSwitch());
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    await waitFor(() => expect(mockDisable).toHaveBeenCalledTimes(1));
+    expect(mockEnable).not.toHaveBeenCalled();
+  });
+
+  it('reverts the toggle and shows an error when updating the OS fails', async () => {
+    mockEnable.mockRejectedValue(new Error('autostart failed'));
+
+    renderModal();
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('false'));
+
+    fireEvent.click(getAutostartSwitch());
+    fireEvent.click(screen.getByRole('button', { name: 'Save Settings' }));
+
+    await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
+    expect(mockToast.error).toHaveBeenCalledWith(
+      'Failed to update launch-at-login setting',
+      expect.objectContaining({ description: 'autostart failed' }),
+    );
+    // The toggle must reflect the real (unchanged) OS state
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('false'));
+  });
+});

--- a/src/__tests__/settings-modal-autostart.test.tsx
+++ b/src/__tests__/settings-modal-autostart.test.tsx
@@ -43,6 +43,7 @@ vi.mock('../components/ui/tabs', () => ({
 }));
 
 import { SettingsModal } from '../components/settings-modal';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
 
 // jsdom has no ResizeObserver; the modal's scrollable tab bar needs one
 class MockResizeObserver {
@@ -115,6 +116,22 @@ describe('SettingsModal launch-at-login', () => {
     expect(mockEnable).not.toHaveBeenCalled();
   });
 
+  it('keeps a manual toggle made while the OS state is still loading', async () => {
+    let resolveIsEnabled!: (value: boolean) => void;
+    mockIsEnabled.mockImplementation(
+      () => new Promise<boolean>((resolve) => { resolveIsEnabled = resolve; }),
+    );
+
+    renderModal();
+    await waitFor(() => expect(mockIsEnabled).toHaveBeenCalled());
+
+    // The user flips the toggle before the OS query resolves
+    fireEvent.click(getAutostartSwitch());
+    resolveIsEnabled(false); // OS says "not enabled" — arrives too late
+
+    await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('true'));
+  });
+
   it('reverts the toggle and shows an error when updating the OS fails', async () => {
     mockEnable.mockRejectedValue(new Error('autostart failed'));
 
@@ -131,5 +148,8 @@ describe('SettingsModal launch-at-login', () => {
     );
     // The toggle must reflect the real (unchanged) OS state
     await waitFor(() => expect(getAutostartSwitch().getAttribute('aria-checked')).toBe('false'));
+    // The persisted config must stay truthful even though Save ran first
+    const saved = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? '{}') as Record<string, unknown>;
+    expect(saved.autostart).toBe(false);
   });
 });

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -122,6 +122,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
     autostart: false
   });
 
+  // True once the user has manually changed the autostart toggle (or reset
+  // settings) while the modal is open — the OS state query must not clobber it.
+  const autostartTouchedRef = useRef(false);
+
   // Load settings when modal opens
   useEffect(() => {
     if (open) {
@@ -151,8 +155,15 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
       // the actual launch-at-login configuration, not a cached value.
       // Skip in browser dev mode where the Tauri backend is absent.
       if (isTauri()) {
+        // Each open re-reads the OS state; discard any prior touch flag
+        autostartTouchedRef.current = false;
         isAutostartEnabled()
-          .then((enabled) => setSettings(prev => ({ ...prev, autostart: enabled })))
+          .then((enabled) => {
+            // A manual toggle made while the query was in flight wins
+            if (!autostartTouchedRef.current) {
+              setSettings(prev => ({ ...prev, autostart: enabled }));
+            }
+          })
           .catch(() => {
             // Plugin unavailable — keep stored/default value
           });
@@ -241,7 +252,19 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         }
       } catch (error) {
         const actual = await isAutostartEnabled().catch(() => undefined);
-        setSettings(prev => ({ ...prev, autostart: actual ?? !settings.autostart }));
+        const corrected = actual ?? !settings.autostart;
+        setSettings(prev => ({ ...prev, autostart: corrected }));
+        // Keep the persisted config truthful when the OS update failed
+        try {
+          const saved = JSON.parse(localStorage.getItem(APP_SETTINGS_STORAGE_KEY) ?? '{}') as Record<string, unknown>;
+          localStorage.setItem(
+            APP_SETTINGS_STORAGE_KEY,
+            JSON.stringify({ ...saved, autostart: corrected }),
+          );
+          window.dispatchEvent(new Event(APP_SETTINGS_CHANGED_EVENT));
+        } catch {
+          // Ignore storage errors — the toggle and toast already reflect reality
+        }
         toast.error(t('settings.interface.autostartFailed'), {
           description: error instanceof Error ? error.message : String(error),
         });
@@ -309,7 +332,12 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         telemetry: false,
         autostart: false
       });
-      
+
+      // Resetting is a deliberate change — don't let a pending OS query undo it
+      if (settings.autostart) {
+        autostartTouchedRef.current = true;
+      }
+
       // Apply default theme
       applyTheme('dark');
     }
@@ -1127,7 +1155,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                   </div>
                   <Switch
                     checked={settings.autostart}
-                    onCheckedChange={(checked) => updateSetting('autostart', checked)}
+                    onCheckedChange={(checked) => {
+                      autostartTouchedRef.current = true;
+                      updateSetting('autostart', checked);
+                    }}
                   />
                 </div>
               </CardContent>

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -59,6 +59,8 @@ import {
   importAllConfig,
 } from '@/lib/config-export-import';
 import { normalizeUpdateProxy } from '@/lib/update-proxy';
+import { isTauri } from '@tauri-apps/api/core';
+import { enable as enableAutostart, disable as disableAutostart, isEnabled as isAutostartEnabled } from '@tauri-apps/plugin-autostart';
 import { Checkbox } from './ui/checkbox';
 
 interface SettingsModalProps {
@@ -114,7 +116,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
     maxLogSize: 100,
     checkUpdates: true,
     updateProxy: '',
-    telemetry: false
+    telemetry: false,
+
+    // System settings
+    autostart: false
   });
 
   // Load settings when modal opens
@@ -140,6 +145,17 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         }
       } catch {
         // Ignore parsing errors
+      }
+
+      // Load the real autostart state from the OS so the toggle reflects
+      // the actual launch-at-login configuration, not a cached value.
+      // Skip in browser dev mode where the Tauri backend is absent.
+      if (isTauri()) {
+        isAutostartEnabled()
+          .then((enabled) => setSettings(prev => ({ ...prev, autostart: enabled })))
+          .catch(() => {
+            // Plugin unavailable — keep stored/default value
+          });
       }
     }
   }, [open]);
@@ -212,6 +228,26 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
       return false;
     }
 
+    // Apply the launch-at-login preference to the OS (best effort — revert
+    // the toggle and warn if the plugin call fails so the UI stays truthful).
+    // Skipped in browser dev mode where the Tauri backend is absent.
+    void (async () => {
+      if (!isTauri()) return;
+      try {
+        if (settings.autostart) {
+          await enableAutostart();
+        } else {
+          await disableAutostart();
+        }
+      } catch (error) {
+        const actual = await isAutostartEnabled().catch(() => undefined);
+        setSettings(prev => ({ ...prev, autostart: actual ?? !settings.autostart }));
+        toast.error(t('settings.interface.autostartFailed'), {
+          description: error instanceof Error ? error.message : String(error),
+        });
+      }
+    })();
+
     // Save terminal appearance settings
     saveAppearanceSettings(terminalAppearance);
     
@@ -270,7 +306,8 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         maxLogSize: 100,
         checkUpdates: true,
         updateProxy: '',
-        telemetry: false
+        telemetry: false,
+        autostart: false
       });
       
       // Apply default theme
@@ -1076,6 +1113,21 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                   <Switch
                     checked={settings.enableNotifications}
                     onCheckedChange={(checked) => updateSetting('enableNotifications', checked)}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label>{t('settings.interface.autostart')}</Label>
+                    <p className="text-sm text-muted-foreground">
+                      {t('settings.interface.autostartDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={settings.autostart}
+                    onCheckedChange={(checked) => updateSetting('autostart', checked)}
                   />
                 </div>
               </CardContent>

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -321,7 +321,10 @@
       "systemMonitor": "System Monitor",
       "statusBar": "Status Bar",
       "enableNotifications": "Enable Notifications",
-      "enableNotificationsDesc": "Show system notifications for important events"
+      "enableNotificationsDesc": "Show system notifications for important events",
+      "autostart": "Launch at Login",
+      "autostartDesc": "Start r-shell automatically when you log in",
+      "autostartFailed": "Failed to update launch-at-login setting"
     },
     "keyboard": {
       "title": "Keyboard Shortcuts",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -321,7 +321,10 @@
       "systemMonitor": "系统监视器",
       "statusBar": "状态栏",
       "enableNotifications": "启用通知",
-      "enableNotificationsDesc": "显示重要事件的系统通知"
+      "enableNotificationsDesc": "显示重要事件的系统通知",
+      "autostart": "登录时自动启动",
+      "autostartDesc": "登录系统时自动启动 r-shell",
+      "autostartFailed": "无法更新自动启动设置"
     },
     "keyboard": {
       "title": "键盘快捷键",


### PR DESCRIPTION
## Summary

Adds a **Launch at Login** toggle to *Settings → Interface*, backed by the official [`tauri-plugin-autostart`](https://github.com/tauri-apps/plugins-workspace/tree/v2/plugins/autostart):

- **macOS**: LaunchAgent (`~/Library/LaunchAgents/com.aiden.r-shell.plist`)
- **Windows**: registry `Run` entry
- **Linux**: XDG autostart desktop file

## Changes

| Area | File | What |
|------|------|------|
| Rust | `src-tauri/Cargo.toml` | `tauri-plugin-autostart = "2"` |
| Rust | `src-tauri/src/lib.rs` | register plugin with `MacosLauncher::LaunchAgent` |
| Capability | `src-tauri/capabilities/default.json` | `autostart:default` (enable/disable/is-enabled) |
| Frontend | `package.json` | `@tauri-apps/plugin-autostart` |
| Frontend | `src/components/settings-modal.tsx` | new toggle: loads **real OS state** via `isEnabled()` on open; applies `enable()`/`disable()` on Save; reverts toggle + error toast if the backend call fails; `isTauri()`-guarded so browser dev mode is a silent no-op |
| i18n | `en.json` / `zh-CN.json` | `settings.interface.autostart`, `.autostartDesc`, `.autostartFailed` |
| Tests | `src/__tests__/settings-modal-autostart.test.tsx` | 4 tests: OS state on open, enable on save, disable on save, revert+toast on failure |

The toggle reflects the OS configuration rather than a cached value — it re-queries `isEnabled()` every time the settings modal opens, and Reset-to-defaults turns autostart off.

## Verification

- `pnpm test` — 605/605 pass (56 files, incl. 4 new tests)
- `pnpm i18n:check` — 1098 keys in parity
- `tsc --noEmit` — clean
- `cargo check` + `cargo test` — 150 pass, 0 fail; `autostart:default` validated in generated schema
- ESLint on changed files: no new findings vs. HEAD