### PR TITLE
feat(shortcuts): replace DOM keydown shortcuts with tauri-plugin-global-shortcut

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@tauri-apps/plugin-clipboard-manager": "^2.3.2",
     "@tauri-apps/plugin-dialog": "^2.7.1",
     "@tauri-apps/plugin-fs": "^2.3.0",
+    "@tauri-apps/plugin-global-shortcut": "^2.3.2",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -167,6 +167,9 @@ importers:
       '@tauri-apps/plugin-fs':
         specifier: ^2.3.0
         version: 2.5.1
+      '@tauri-apps/plugin-global-shortcut':
+        specifier: ^2.3.2
+        version: 2.3.2
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -1734,6 +1737,9 @@ packages:
 
   '@tauri-apps/plugin-fs@2.5.1':
     resolution: {integrity: sha512-9Lz+Jopp6QyeEWhlpkMx4R/+P9HgR+AVAI4vOZhlT8Xaymtz8iVI/Ov984/XTqgJz/5gz5NretqPB/XEMS3NhQ==}
+
+  '@tauri-apps/plugin-global-shortcut@2.3.2':
+    resolution: {integrity: sha512-UReHNXrLvpEjylE4jb4oCYiy96uRykPUthoCQCmRXYrd5hs5X9DrW+qOn7GLW57EJN4tdK8bgK5twBTz2NOxzA==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -4742,6 +4748,10 @@ snapshots:
       '@tauri-apps/api': 2.11.0
 
   '@tauri-apps/plugin-fs@2.5.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.0
+
+  '@tauri-apps/plugin-global-shortcut@2.3.2':
     dependencies:
       '@tauri-apps/api': 2.11.0
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -1884,6 +1884,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "global-hotkey"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c386b0a4a70cb2d39fffd74480f985b6f0bfbcb934b6a6b6b7e630e448f242e"
+dependencies = [
+ "crossbeam-channel",
+ "keyboard-types",
+ "objc2",
+ "objc2-app-kit",
+ "once_cell",
+ "serde",
+ "thiserror 2.0.18",
+ "windows-sys 0.59.0",
+ "x11rb",
+ "xkeysym",
+]
+
+[[package]]
 name = "gloo-timers"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3814,6 +3832,7 @@ dependencies = [
  "tauri-plugin-clipboard-manager",
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
+ "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-updater",
@@ -5261,6 +5280,21 @@ dependencies = [
  "thiserror 2.0.18",
  "toml 1.1.2+spec-1.1.0",
  "url",
+]
+
+[[package]]
+name = "tauri-plugin-global-shortcut"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4dd9f4c5136c09cd962da0c86dc4accd4666db2ea591cf16e6597435843bd2b"
+dependencies = [
+ "global-hotkey",
+ "log",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7203,6 +7237,12 @@ dependencies = [
  "libc",
  "rustix",
 ]
+
+[[package]]
+name = "xkeysym"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "yoke"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -26,6 +26,7 @@ tauri-plugin-fs = "2"
 tauri-plugin-process = "2"
 tauri-plugin-clipboard-manager = "2"
 tauri-plugin-autostart = "2"
+tauri-plugin-global-shortcut = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tokio = { version = "1", features = ["full"] }

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -24,6 +24,10 @@
     "process:allow-exit",
     "clipboard-manager:allow-read-text",
     "clipboard-manager:allow-write-text",
-    "autostart:default"
+    "autostart:default",
+    "global-shortcut:allow-register",
+    "global-shortcut:allow-unregister",
+    "global-shortcut:allow-unregister-all",
+    "global-shortcut:allow-is-registered"
   ]
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -262,6 +262,9 @@ pub fn run() {
             tauri_plugin_autostart::MacosLauncher::LaunchAgent,
             None,
         ))
+        // Global shortcuts are registered at runtime from the frontend
+        // (src/lib/keyboard-shortcuts.ts) via the plugin's JS API.
+        .plugin(tauri_plugin_global_shortcut::Builder::new().build())
         .setup({
             let connection_manager_clone = connection_manager.clone();
             move |app| {
@@ -371,4 +374,53 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+#[cfg(test)]
+mod shortcut_accelerator_tests {
+    use std::str::FromStr;
+    use tauri_plugin_global_shortcut::Shortcut;
+
+    /// Every accelerator string the frontend can emit (toAccelerator in
+    /// src/lib/keyboard-shortcuts.ts) must parse on all platforms; the plugin
+    /// rejects unparseable registrations at runtime.
+    #[test]
+    fn frontend_accelerators_parse() {
+        let mut accelerators: Vec<String> = vec![
+            // Default app/layout/split shortcuts
+            "CommandOrControl+N".to_string(),
+            "CommandOrControl+W".to_string(),
+            "CommandOrControl+Tab".to_string(),
+            "CommandOrControl+Shift+Tab".to_string(),
+            "CommandOrControl+B".to_string(),
+            "CommandOrControl+J".to_string(),
+            "CommandOrControl+M".to_string(),
+            "CommandOrControl+Z".to_string(),
+            "CommandOrControl+Backslash".to_string(),
+            "CommandOrControl+Shift+Backslash".to_string(),
+        ];
+        for i in 1..=9 {
+            accelerators.push(format!("CommandOrControl+{i}"));
+        }
+
+        // Named keys and symbols that customizable bindings can produce
+        let keys = [
+            "Escape", "Enter", "Space", "Backspace", "Delete", "Insert", "PageUp", "PageDown",
+            "Home", "End", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Pause",
+            "CapsLock", "PrintScreen", "ScrollLock", "NumLock", "F1", "F5", "F13", "F24",
+            "Backquote", "BracketLeft", "BracketRight", "Comma", "Equal", "Minus", "Period",
+            "Quote", "Semicolon", "Slash", "1", "9", "0",
+        ];
+        for key in keys {
+            accelerators.push(format!("CommandOrControl+{key}"));
+            accelerators.push(format!("Option+Shift+{key}"));
+        }
+
+        for accelerator in accelerators {
+            assert!(
+                Shortcut::from_str(&accelerator).is_ok(),
+                "accelerator failed to parse: {accelerator}"
+            );
+        }
+    }
 }

--- a/src/__tests__/app-ssh-reconnect.test.tsx
+++ b/src/__tests__/app-ssh-reconnect.test.tsx
@@ -127,6 +127,9 @@ vi.mock('@/lib/connection-storage', async (importOriginal) => {
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => lifecycle.invoke(...args),
+  // App's keyboard-shortcut hook branches on this; these tests run in
+  // browser mode where there is no Tauri backend.
+  isTauri: () => false,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({

--- a/src/__tests__/keyboard-shortcuts-global.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-global.test.tsx
@@ -4,8 +4,19 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { useKeyboardShortcuts, type KeyboardShortcut } from '../lib/keyboard-shortcuts';
 import { register, unregister, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
 
+const focusChangedCaptured: { handler?: (payload: boolean) => void } = {};
+
 vi.mock('@tauri-apps/api/core', () => ({
   isTauri: () => true,
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
+    onFocusChanged: vi.fn(async (handler: (event: { payload: boolean }) => void) => {
+      focusChangedCaptured.handler = (payload: boolean) => handler({ payload });
+      return vi.fn();
+    }),
+  }),
 }));
 
 vi.mock('@tauri-apps/plugin-global-shortcut', () => ({
@@ -182,6 +193,53 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     await act(async () => {});
 
     expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+  });
+
+  it('registers everything while the window is blurred, then re-applies the element context on focus', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    // Element context: terminal focused → terminal-critical shortcut dropped.
+    focusElement(document.querySelector<HTMLElement>('[data-testid="terminal-textarea"]')!);
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    mockedUnregister.mockClear();
+
+    // App goes to the background → everything stays registered (global
+    // semantics), even with a terminal still focused inside the webview.
+    window.dispatchEvent(new Event('blur'));
+    expect(mockedUnregister).not.toHaveBeenCalled();
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+
+    // App returns to the foreground → element context applies again.
+    window.dispatchEvent(new Event('focus'));
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    expect(mockedUnregister).not.toHaveBeenCalledWith('CommandOrControl+W');
+  });
+
+  it('re-syncs on the Tauri onFocusChanged signal', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    focusElement(document.querySelector<HTMLElement>('[data-testid="terminal-textarea"]')!);
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    mockedUnregister.mockClear();
+
+    // Window focus lost (authoritative webview signal) → register everything.
+    expect(focusChangedCaptured.handler).toBeTypeOf('function');
+    act(() => {
+      focusChangedCaptured.handler!(false);
+    });
+    expect(mockedUnregister).not.toHaveBeenCalled();
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+
+    // Window focused again while the terminal is still focused → drop the
+    // terminal-critical shortcut again.
+    act(() => {
+      focusChangedCaptured.handler!(true);
+    });
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
   });
 
   it('unregisters all shortcuts on unmount', async () => {

--- a/src/__tests__/keyboard-shortcuts-global.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-global.test.tsx
@@ -1,0 +1,194 @@
+import React from 'react';
+import { act, cleanup, render } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { useKeyboardShortcuts, type KeyboardShortcut } from '../lib/keyboard-shortcuts';
+import { register, unregister, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => true,
+}));
+
+vi.mock('@tauri-apps/plugin-global-shortcut', () => ({
+  register: vi.fn(async () => {}),
+  unregister: vi.fn(async () => {}),
+  unregisterAll: vi.fn(async () => {}),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn() },
+}));
+
+const mockedRegister = vi.mocked(register);
+const mockedUnregister = vi.mocked(unregister);
+const mockedUnregisterAll = vi.mocked(unregisterAll);
+
+function GlobalShortcutHarness({ shortcuts }: { shortcuts: KeyboardShortcut[] }) {
+  useKeyboardShortcuts(shortcuts);
+  return (
+    <div>
+      <input data-testid="input" />
+      <div className="xterm" data-testid="terminal">
+        {/* xterm.js renders its hidden helper textarea inside .xterm */}
+        <textarea data-testid="terminal-textarea" />
+      </div>
+      <button data-testid="plain" type="button">
+        plain
+      </button>
+    </div>
+  );
+}
+
+function layoutCtrlB(handler: () => void): KeyboardShortcut {
+  return { key: 'b', ctrlKey: true, ignoreInTerminal: true, handler, description: 'Toggle sidebar' };
+}
+
+function splitCtrlW(handler: () => void): KeyboardShortcut {
+  return { key: 'w', ctrlKey: true, handler, description: 'Close active tab' };
+}
+
+function focusElement(el: HTMLElement) {
+  el.focus();
+  document.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
+}
+
+function focusBody() {
+  const active = document.activeElement as HTMLElement | null;
+  active?.blur?.();
+  document.dispatchEvent(new FocusEvent('focusout', { bubbles: true }));
+}
+
+afterEach(() => {
+  cleanup();
+  focusBody();
+  vi.clearAllMocks();
+});
+
+describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
+  it('registers each shortcut with the plugin on mount', async () => {
+    const onB = vi.fn();
+    const onW = vi.fn();
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(onB), splitCtrlW(onW)]} />);
+    });
+
+    expect(mockedRegister).toHaveBeenCalledWith(
+      'CommandOrControl+B',
+      expect.any(Function),
+    );
+    expect(mockedRegister).toHaveBeenCalledWith(
+      'CommandOrControl+W',
+      expect.any(Function),
+    );
+  });
+
+  it('unregisters everything while an editable field has focus', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    focusElement(document.querySelector<HTMLElement>('[data-testid="input"]')!);
+
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
+  });
+
+  it('keeps non-terminal shortcuts registered while a terminal has focus', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    focusElement(document.querySelector<HTMLElement>('[data-testid="terminal-textarea"]')!);
+
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    expect(mockedUnregister).not.toHaveBeenCalledWith('CommandOrControl+W');
+  });
+
+  it('re-registers terminal-critical shortcuts after leaving the terminal', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn())]} />);
+    });
+
+    focusElement(document.querySelector<HTMLElement>('[data-testid="terminal-textarea"]')!);
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+
+    focusBody();
+
+    expect(mockedRegister).toHaveBeenLastCalledWith('CommandOrControl+B', expect.any(Function));
+  });
+
+  it('invokes the shortcut handler only on Pressed events', async () => {
+    const onB = vi.fn();
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(onB)]} />);
+    });
+
+    const handler = mockedRegister.mock.calls.find(
+      ([accel]) => accel === 'CommandOrControl+B',
+    )?.[1] as (event: { state: 'Released' | 'Pressed'; shortcut: string; id: number }) => void;
+
+    expect(handler).toBeTypeOf('function');
+    handler({ state: 'Released', shortcut: 'CommandOrControl+B', id: 1 });
+    expect(onB).not.toHaveBeenCalled();
+
+    handler({ state: 'Pressed', shortcut: 'CommandOrControl+B', id: 2 });
+    expect(onB).toHaveBeenCalledOnce();
+  });
+
+  it('registers a duplicated accelerator only once (first shortcut wins)', async () => {
+    await act(async () => {
+      render(
+        <GlobalShortcutHarness
+          shortcuts={[layoutCtrlB(vi.fn()), { key: 'b', ctrlKey: true, handler: vi.fn(), description: 'duplicate' }]}
+        />,
+      );
+    });
+
+    const bCalls = mockedRegister.mock.calls.filter(([accel]) => accel === 'CommandOrControl+B');
+    expect(bCalls).toHaveLength(1);
+  });
+
+  it('skips the macOS-native menu accelerators on macOS', async () => {
+    const platformSpy = vi.spyOn(navigator, 'platform', 'get').mockReturnValue('MacIntel');
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+    platformSpy.mockRestore();
+  });
+
+  it('does not register shortcuts without modifiers', async () => {
+    await act(async () => {
+      render(
+        <GlobalShortcutHarness
+          shortcuts={[{ key: 'x', handler: vi.fn(), description: 'no modifier' }]}
+        />,
+      );
+    });
+
+    expect(mockedRegister).not.toHaveBeenCalledWith('X', expect.any(Function));
+  });
+
+  it('surfaces registration failures without throwing', async () => {
+    mockedRegister.mockRejectedValueOnce(new Error('shortcut is reserved by the OS'));
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn())]} />);
+    });
+    await act(async () => {});
+
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+  });
+
+  it('unregisters all shortcuts on unmount', async () => {
+    const { unmount } = render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn())]} />);
+
+    unmount();
+
+    expect(mockedUnregisterAll).toHaveBeenCalledOnce();
+  });
+});

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -4,12 +4,14 @@ import { afterEach, describe, it, expect, vi } from 'vitest';
 import {
   createLayoutShortcuts,
   createSplitViewShortcuts,
+  DEFAULT_APP_KEYBOARD_SHORTCUTS,
   DEFAULT_LAYOUT_SHORTCUTS,
   DEFAULT_SPLIT_VIEW_SHORTCUTS,
   formatKeyboardShortcut,
   KeyboardShortcut,
   loadKeyboardShortcutSettings,
   parseKeyboardShortcut,
+  toAccelerator,
   useKeyboardShortcuts,
 } from '../lib/keyboard-shortcuts';
 
@@ -311,5 +313,65 @@ describe('formatKeyboardShortcut', () => {
     expect(formatKeyboardShortcut(DEFAULT_LAYOUT_SHORTCUTS.toggleLeftSidebar, false)).toBe('Ctrl+B');
     expect(formatKeyboardShortcut('Ctrl+Shift+ArrowRight', true)).toBe('⌘+⇧+→');
     expect(formatKeyboardShortcut('Alt+W', true)).toBe('⌥+W');
+  });
+});
+
+describe('toAccelerator', () => {
+  it('converts ctrl to CommandOrControl', () => {
+    expect(toAccelerator('Ctrl+N')).toBe('CommandOrControl+N');
+    expect(toAccelerator('ctrl+n')).toBe('CommandOrControl+N');
+  });
+
+  it('converts every default shortcut to a plugin accelerator', () => {
+    expect(toAccelerator(DEFAULT_APP_KEYBOARD_SHORTCUTS.newSession)).toBe('CommandOrControl+N');
+    expect(toAccelerator(DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession)).toBe('CommandOrControl+W');
+    expect(toAccelerator(DEFAULT_APP_KEYBOARD_SHORTCUTS.nextTab)).toBe('CommandOrControl+Tab');
+    expect(toAccelerator(DEFAULT_APP_KEYBOARD_SHORTCUTS.previousTab)).toBe('CommandOrControl+Shift+Tab');
+    expect(toAccelerator(DEFAULT_LAYOUT_SHORTCUTS.toggleLeftSidebar)).toBe('CommandOrControl+B');
+    expect(toAccelerator(DEFAULT_LAYOUT_SHORTCUTS.toggleBottomPanel)).toBe('CommandOrControl+J');
+    expect(toAccelerator(DEFAULT_LAYOUT_SHORTCUTS.toggleRightSidebar)).toBe('CommandOrControl+M');
+    expect(toAccelerator(DEFAULT_LAYOUT_SHORTCUTS.toggleZenMode)).toBe('CommandOrControl+Z');
+  });
+
+  it('maps symbol keys to their accelerator names', () => {
+    expect(toAccelerator('Ctrl+\\')).toBe('CommandOrControl+Backslash');
+    expect(toAccelerator('Ctrl+Space')).toBe('CommandOrControl+Space');
+    expect(toAccelerator('Alt+`')).toBe('Option+Backquote');
+    expect(toAccelerator('Ctrl+-')).toBe('CommandOrControl+Minus');
+    expect(toAccelerator('Ctrl+=')).toBe('CommandOrControl+Equal');
+    expect(toAccelerator('Ctrl+,')).toBe('CommandOrControl+Comma');
+    expect(toAccelerator('Ctrl+.')).toBe('CommandOrControl+Period');
+    expect(toAccelerator('Ctrl+/')).toBe('CommandOrControl+Slash');
+    expect(toAccelerator('Ctrl+;')).toBe('CommandOrControl+Semicolon');
+    expect(toAccelerator('Ctrl+\'')).toBe('CommandOrControl+Quote');
+    expect(toAccelerator('Ctrl+[')).toBe('CommandOrControl+BracketLeft');
+    expect(toAccelerator('Ctrl+]')).toBe('CommandOrControl+BracketRight');
+  });
+
+  it('maps digits and named keys verbatim (uppercased)', () => {
+    expect(toAccelerator('Ctrl+1')).toBe('CommandOrControl+1');
+    expect(toAccelerator('Ctrl+9')).toBe('CommandOrControl+9');
+    expect(toAccelerator('Ctrl+Enter')).toBe('CommandOrControl+Enter');
+    expect(toAccelerator('Ctrl+Escape')).toBe('CommandOrControl+Escape');
+    expect(toAccelerator('Ctrl+PageUp')).toBe('CommandOrControl+PageUp');
+    expect(toAccelerator('Ctrl+ArrowDown')).toBe('CommandOrControl+ArrowDown');
+    expect(toAccelerator('Ctrl+F13')).toBe('CommandOrControl+F13');
+    expect(toAccelerator('Ctrl+Backspace')).toBe('CommandOrControl+Backspace');
+  });
+
+  it('converts global (Meta/Cmd) to Command', () => {
+    expect(toAccelerator('Cmd+X')).toBe('Command+X');
+    expect(toAccelerator('Meta+Shift+X')).toBe('Shift+Command+X');
+  });
+
+  it('keeps modifier order fixed regardless of input order', () => {
+    expect(toAccelerator('Shift+Ctrl+Alt+X')).toBe('CommandOrControl+Shift+Option+X');
+  });
+
+  it('returns null for shortcuts without any modifier', () => {
+    expect(toAccelerator('N')).toBeNull();
+    expect(toAccelerator('F5')).toBeNull();
+    expect(toAccelerator('')).toBeNull();
+    expect(toAccelerator('Nonsense+Input')).toBeNull();
   });
 });

--- a/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
+++ b/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
@@ -129,6 +129,9 @@ vi.mock('@xterm/addon-clipboard', () => ({
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  // App's keyboard-shortcut hook branches on this; these tests run in
+  // browser mode where there is no Tauri backend.
+  isTauri: () => false,
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/restore-timeout-cancellation.test.tsx
+++ b/src/__tests__/restore-timeout-cancellation.test.tsx
@@ -94,6 +94,9 @@ vi.mock('@/lib/connection-storage', async (importOriginal) => {
 
 vi.mock('@tauri-apps/api/core', () => ({
   invoke: (...args: unknown[]) => lifecycle.invoke(...args),
+  // App's keyboard-shortcut hook branches on this; the restore path runs in
+  // browser mode where there is no Tauri backend.
+  isTauri: () => false,
 }));
 
 vi.mock('@tauri-apps/api/event', () => ({

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, type RefObject } from 'react';
 import { isTauri } from '@tauri-apps/api/core';
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import { register, unregister, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
 import { toast } from 'sonner';
 import i18n from '@/lib/i18n';
@@ -367,14 +368,22 @@ function currentFocusContext(): FocusContext {
  * semantics) and so editable fields (settings inputs, dialogs) keep receiving
  * their keystrokes: while such an element has focus no shortcut is
  * registered, and while a terminal has focus only shortcuts without
- * `ignoreInTerminal` are. Accelerator duplicates are resolved in array order
- * — the first shortcut wins, on both registration and `ignoreInTerminal`
- * exclusion — which reproduces the DOM handler's first-match-wins behavior.
+ * `ignoreInTerminal` are. Element focus only applies while the app window is
+ * focused — when the app is in the background everything is registered so
+ * the shortcuts keep firing globally. Accelerator duplicates are resolved in
+ * array order — the first shortcut wins, on both registration and
+ * `ignoreInTerminal` exclusion — which reproduces the DOM handler's
+ * first-match-wins behavior.
  */
 function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
   const registered = new Map<string, KeyboardShortcut>();
   const failed = new Set<string>();
   const isMac = navigator.platform.toUpperCase().includes('MAC');
+  // Element focus (terminal/editable) only matters while the app window is
+  // focused; when another app is in the foreground the shortcuts must stay
+  // registered so they keep firing globally.
+  let appFocused = true;
+  let unlistenFocusChanged: (() => void) | undefined;
 
   const desiredAccelerators = (): Map<string, KeyboardShortcut> => {
     const byAccelerator = new Map<string, KeyboardShortcut>();
@@ -391,7 +400,7 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       }
     }
 
-    const focus = currentFocusContext();
+    const focus = appFocused ? currentFocusContext() : 'app';
     if (focus === 'editable') {
       return new Map();
     }
@@ -440,6 +449,41 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
     }
   };
 
+  const handleWindowBlur = () => {
+    appFocused = false;
+    sync();
+  };
+  const handleWindowFocus = () => {
+    appFocused = true;
+    sync();
+  };
+  const handleVisibilityChange = () => {
+    appFocused = !document.hidden;
+    sync();
+  };
+
+  window.addEventListener('blur', handleWindowBlur);
+  window.addEventListener('focus', handleWindowFocus);
+  document.addEventListener('visibilitychange', handleVisibilityChange);
+
+  // Authoritative focus signal for the webview window: some webview
+  // runtimes do not translate OS window focus changes into DOM
+  // focus/blur/visibility events.
+  try {
+    getCurrentWindow()
+      .onFocusChanged(({ payload }) => {
+        appFocused = payload;
+        sync();
+      })
+      .then((unlisten) => {
+        unlistenFocusChanged = unlisten;
+      })
+      .catch(() => {});
+  } catch {
+    // Not running inside a Tauri webview (e.g. tests): the DOM window
+    // focus/blur and visibilitychange listeners above still track app focus.
+  }
+
   sync();
   document.addEventListener('focusin', sync);
   document.addEventListener('focusout', sync);
@@ -447,6 +491,10 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
   return () => {
     document.removeEventListener('focusin', sync);
     document.removeEventListener('focusout', sync);
+    window.removeEventListener('blur', handleWindowBlur);
+    window.removeEventListener('focus', handleWindowFocus);
+    document.removeEventListener('visibilitychange', handleVisibilityChange);
+    unlistenFocusChanged?.();
     void unregisterAll().catch(() => {});
   };
 }

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -1,4 +1,8 @@
-import { useEffect } from 'react';
+import { useEffect, useMemo, useRef, type RefObject } from 'react';
+import { isTauri } from '@tauri-apps/api/core';
+import { register, unregister, unregisterAll } from '@tauri-apps/plugin-global-shortcut';
+import { toast } from 'sonner';
+import i18n from '@/lib/i18n';
 
 export interface KeyboardShortcut {
   key: string;
@@ -244,56 +248,305 @@ export function isEditableTarget(target: EventTarget | null): boolean {
   return contentEditable === '' || contentEditable?.toLowerCase() !== 'false';
 }
 
+// ── tauri-plugin-global-shortcut integration ────────────────────────────────
+
+/**
+ * Single-character keys that need a name when expressed as a plugin
+ * accelerator (the parser accepts these symbols as bare characters, but the
+ * named forms are unambiguous). Multi-character keys are passed through
+ * uppercased — the global-hotkey parser matches names case-insensitively.
+ */
+const ACCELERATOR_SYMBOL_KEYS: Record<string, string> = {
+  ' ': 'Space',
+  '`': 'Backquote',
+  '\\': 'Backslash',
+  '[': 'BracketLeft',
+  ']': 'BracketRight',
+  ',': 'Comma',
+  '=': 'Equal',
+  '-': 'Minus',
+  '.': 'Period',
+  "'": 'Quote',
+  ';': 'Semicolon',
+  '/': 'Slash',
+};
+
+function toAcceleratorKey(key: string): string {
+  if (key === ' ') {
+    // normalizeShortcutKey trims, which would collapse the space key to ''
+    return 'Space';
+  }
+  const normalized = normalizeShortcutKey(key);
+  if (normalized.length === 1) {
+    return ACCELERATOR_SYMBOL_KEYS[normalized] ?? normalized.toUpperCase();
+  }
+  // Named keys keep their canonical (mixed-case) form; anything else is
+  // uppercased — the plugin parser matches key names case-insensitively.
+  return KEY_ALIASES[normalized.toLowerCase()] ?? normalized.toUpperCase();
+}
+
+/**
+ * Converts a parsed shortcut to a tauri-plugin-global-shortcut accelerator.
+ * `ctrl` becomes `CommandOrControl` (Cmd on macOS, Ctrl elsewhere), matching
+ * the DOM fallback's ctrlOrCmd matching. Returns null when no modifier is
+ * present — OS global shortcuts must include at least one modifier.
+ */
+function toAcceleratorFromParsed(parsed: ParsedKeyboardShortcut): string | null {
+  const parts: string[] = [];
+  if (parsed.ctrlKey) {
+    parts.push('CommandOrControl');
+  }
+  if (parsed.shiftKey) {
+    parts.push('Shift');
+  }
+  if (parsed.altKey) {
+    parts.push('Option');
+  }
+  if (parsed.metaKey) {
+    parts.push('Command');
+  }
+  if (parts.length === 0) {
+    return null;
+  }
+
+  parts.push(toAcceleratorKey(parsed.key));
+  return parts.join('+');
+}
+
+export function toAccelerator(shortcut: string): string | null {
+  const parsed = parseKeyboardShortcut(shortcut);
+  return parsed ? toAcceleratorFromParsed(parsed) : null;
+}
+
+function acceleratorForShortcut(shortcut: KeyboardShortcut): string | null {
+  const parsed: ParsedKeyboardShortcut = {
+    key: shortcut.key,
+    ctrlKey: shortcut.ctrlKey ?? false,
+    shiftKey: shortcut.shiftKey ?? false,
+    altKey: shortcut.altKey ?? false,
+    metaKey: shortcut.metaKey ?? false,
+  };
+  return toAcceleratorFromParsed(parsed);
+}
+
+/**
+ * Native macOS menu key equivalents (defined in `src-tauri/src/lib.rs`
+ * `build_app_menu`). macOS processes those through its menu system whenever
+ * the app is focused, so also registering them as global shortcuts would
+ * trigger both the menu item action and the shortcut handler.
+ */
+const MACOS_NATIVE_MENU_ACCELERATORS = new Set([
+  'CommandOrControl+N',
+  'CommandOrControl+S',
+  'CommandOrControl+W',
+  'CommandOrControl+T',
+  'CommandOrControl+D',
+  'CommandOrControl+F',
+  'CommandOrControl+L',
+  'F5',
+]);
+
+type FocusContext = 'app' | 'terminal' | 'editable';
+
+function currentFocusContext(): FocusContext {
+  const target = document.activeElement;
+  if (isTerminalInputTarget(target)) {
+    return 'terminal';
+  }
+  if (isEditableTarget(target)) {
+    return 'editable';
+  }
+  return 'app';
+}
+
+/**
+ * Registers shortcuts with the OS through tauri-plugin-global-shortcut.
+ *
+ * Registration is focus-aware so keys keep reaching the remote shell while
+ * typing in a terminal (mirroring the DOM fallback's `ignoreInTerminal`
+ * semantics) and so editable fields (settings inputs, dialogs) keep receiving
+ * their keystrokes: while such an element has focus no shortcut is
+ * registered, and while a terminal has focus only shortcuts without
+ * `ignoreInTerminal` are. Accelerator duplicates are resolved in array order
+ * — the first shortcut wins, on both registration and `ignoreInTerminal`
+ * exclusion — which reproduces the DOM handler's first-match-wins behavior.
+ */
+function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
+  const registered = new Map<string, KeyboardShortcut>();
+  const failed = new Set<string>();
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+
+  const desiredAccelerators = (): Map<string, KeyboardShortcut> => {
+    const byAccelerator = new Map<string, KeyboardShortcut>();
+    for (const shortcut of shortcutsRef.current) {
+      const accel = acceleratorForShortcut(shortcut);
+      if (!accel) {
+        continue;
+      }
+      if (isMac && MACOS_NATIVE_MENU_ACCELERATORS.has(accel)) {
+        continue;
+      }
+      if (!byAccelerator.has(accel)) {
+        byAccelerator.set(accel, shortcut);
+      }
+    }
+
+    const focus = currentFocusContext();
+    if (focus === 'editable') {
+      return new Map();
+    }
+    if (focus === 'terminal') {
+      for (const [accel, shortcut] of byAccelerator) {
+        if (shortcut.ignoreInTerminal) {
+          byAccelerator.delete(accel);
+        }
+      }
+    }
+    return byAccelerator;
+  };
+
+  const sync = () => {
+    const desired = desiredAccelerators();
+
+    for (const [accel] of registered) {
+      if (!desired.has(accel)) {
+        registered.delete(accel);
+        void unregister(accel).catch(() => {});
+      }
+    }
+
+    for (const [accel, shortcut] of desired) {
+      if (registered.has(accel)) {
+        continue;
+      }
+      registered.set(accel, shortcut);
+      register(accel, (event) => {
+        if (event.state !== 'Pressed') {
+          return;
+        }
+        // Resolve the handler at event time so the OS registration survives
+        // re-renders without re-registering (the effect only re-runs when the
+        // accelerator set changes).
+        const shortcut = shortcutsRef.current.find((s) => acceleratorForShortcut(s) === accel);
+        shortcut?.handler();
+      }).catch(() => {
+        registered.delete(accel);
+        if (failed.has(accel)) {
+          return;
+        }
+        failed.add(accel);
+        toast.error(i18n.t('settings.keyboard.registerFailed', { shortcut: accel }));
+      });
+    }
+  };
+
+  sync();
+  document.addEventListener('focusin', sync);
+  document.addEventListener('focusout', sync);
+
+  return () => {
+    document.removeEventListener('focusin', sync);
+    document.removeEventListener('focusout', sync);
+    void unregisterAll().catch(() => {});
+  };
+}
+
+/**
+ * Browser-mode fallback: window keydown listener with the same semantics as
+ * the OS registration — skipped while typing in editable fields (except the
+ * terminal) and while a terminal owns the event for `ignoreInTerminal`
+ * shortcuts.
+ */
+function registerDomKeydown(shortcutsRef: RefObject<KeyboardShortcut[]>) {
+  const isMac = navigator.platform.toUpperCase().includes('MAC');
+
+  const handleKeyDown = (event: KeyboardEvent) => {
+    const shortcuts = shortcutsRef.current;
+    const terminalInputTarget = isTerminalInputTarget(event.target);
+    if (isEditableTarget(event.target) && !terminalInputTarget) {
+      return;
+    }
+
+    for (const shortcut of shortcuts) {
+      const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
+      // On macOS, treat Cmd (metaKey) as the equivalent of Ctrl for shortcut matching.
+      // This lets shortcuts defined with ctrlKey:true work with both Ctrl and Cmd on Mac.
+      const ctrlOrCmd = isMac ? (event.metaKey || event.ctrlKey) : event.ctrlKey;
+      const usesExplicitMeta = shortcut.metaKey === true && shortcut.ctrlKey !== true;
+      const ctrlMatch = usesExplicitMeta
+        ? (shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey)
+        : (shortcut.ctrlKey === undefined || ctrlOrCmd === shortcut.ctrlKey);
+      const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
+      const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
+      // When ctrlKey is specified on Mac, don't additionally require metaKey matching
+      let metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
+      if (usesExplicitMeta) {
+        metaMatch = event.metaKey === true;
+      } else if (isMac && shortcut.ctrlKey !== undefined) {
+        metaMatch = true;
+      }
+
+      if (keyMatch && ctrlMatch && shiftMatch && altMatch && metaMatch) {
+        if (shortcut.ignoreInTerminal && terminalInputTarget) {
+          return;
+        }
+        event.preventDefault();
+        event.stopPropagation();
+        shortcut.handler();
+        return;
+      }
+    }
+  };
+
+  window.addEventListener('keydown', handleKeyDown, { capture: true });
+  return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
+}
+
 /**
  * Hook to register keyboard shortcuts
  * Similar to VS Code's keyboard shortcuts system
+ *
+ * In the Tauri app shortcuts are registered with the OS through
+ * tauri-plugin-global-shortcut, so they fire even while the app is in the
+ * background (except when a terminal or an editable field has focus, see
+ * `registerGlobalShortcuts`). In browser dev mode (no Tauri backend) a window
+ * keydown listener keeps shortcuts working.
  */
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boolean = true) {
+  const shortcutsRef = useRef(shortcuts);
+
+  // Keep the ref pointing at the latest shortcut list after every render so
+  // the listeners below always dispatch against the current handlers.
   useEffect(() => {
-    if (!enabled) return;
+    shortcutsRef.current = shortcuts;
+  });
 
-    const isMac = navigator.platform.toUpperCase().includes('MAC');
-
-    const handleKeyDown = (event: KeyboardEvent) => {
-      const terminalInputTarget = isTerminalInputTarget(event.target);
-      if (isEditableTarget(event.target) && !terminalInputTarget) {
-        return;
+  // Registration only depends on the accelerator SET, not on the array
+  // identity: App recreates these arrays on every state change and
+  // re-registering the same accelerators would churn the OS registrations.
+  const acceleratorSetKey = useMemo(() => {
+    const seen = new Set<string>();
+    const accelerators: string[] = [];
+    for (const shortcut of shortcuts) {
+      const accel = acceleratorForShortcut(shortcut);
+      if (accel && !seen.has(accel)) {
+        seen.add(accel);
+        accelerators.push(accel);
       }
+    }
+    return accelerators.join('|');
+  }, [shortcuts]);
 
-      for (const shortcut of shortcuts) {
-        const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
-        // On macOS, treat Cmd (metaKey) as the equivalent of Ctrl for shortcut matching.
-        // This lets shortcuts defined with ctrlKey:true work with both Ctrl and Cmd on Mac.
-        const ctrlOrCmd = isMac ? (event.metaKey || event.ctrlKey) : event.ctrlKey;
-        const usesExplicitMeta = shortcut.metaKey === true && shortcut.ctrlKey !== true;
-        const ctrlMatch = usesExplicitMeta
-          ? (shortcut.ctrlKey === undefined || event.ctrlKey === shortcut.ctrlKey)
-          : (shortcut.ctrlKey === undefined || ctrlOrCmd === shortcut.ctrlKey);
-        const shiftMatch = shortcut.shiftKey === undefined || event.shiftKey === shortcut.shiftKey;
-        const altMatch = shortcut.altKey === undefined || event.altKey === shortcut.altKey;
-        // When ctrlKey is specified on Mac, don't additionally require metaKey matching
-        let metaMatch = shortcut.metaKey === undefined || event.metaKey === shortcut.metaKey;
-        if (usesExplicitMeta) {
-          metaMatch = event.metaKey === true;
-        } else if (isMac && shortcut.ctrlKey !== undefined) {
-          metaMatch = true;
-        }
+  useEffect(() => {
+    if (!enabled) {
+      return;
+    }
 
-        if (keyMatch && ctrlMatch && shiftMatch && altMatch && metaMatch) {
-          if (shortcut.ignoreInTerminal && terminalInputTarget) {
-            return;
-          }
-          event.preventDefault();
-          event.stopPropagation();
-          shortcut.handler();
-          return;
-        }
-      }
-    };
-
-    window.addEventListener('keydown', handleKeyDown, { capture: true });
-    return () => window.removeEventListener('keydown', handleKeyDown, { capture: true });
-  }, [shortcuts, enabled]);
+    if (!isTauri()) {
+      return registerDomKeydown(shortcutsRef);
+    }
+    return registerGlobalShortcuts(shortcutsRef);
+  }, [acceleratorSetKey, enabled]);
 }
 
 /**
@@ -413,4 +666,3 @@ export const createSplitViewShortcuts = (actions: {
     ),
   ];
 };
-

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -333,7 +333,8 @@
       "closeSession": "Close Session",
       "nextTab": "Next Tab",
       "previousTab": "Previous Tab",
-      "note": "Changes to keyboard shortcuts take effect after saving."
+      "note": "Changes to keyboard shortcuts take effect after saving.",
+      "registerFailed": "Failed to register shortcut {{shortcut}}"
     },
     "advanced": {
       "title": "Advanced Settings",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -333,7 +333,8 @@
       "closeSession": "关闭会话",
       "nextTab": "下一个标签页",
       "previousTab": "上一个标签页",
-      "note": "键盘快捷键更改将在保存后生效。"
+      "note": "键盘快捷键更改将在保存后生效。",
+      "registerFailed": "快捷键 {{shortcut}} 注册失败"
     },
     "advanced": {
       "title": "高级设置",


### PR DESCRIPTION
## Summary

Replaces the window `keydown`-based shortcut system (`useKeyboardShortcuts`) with OS-level registration via **tauri-plugin-global-shortcut**, so app shortcuts fire even while R-Shell is in the background. Registration is **focus-aware** (per design decision, "Global, focus-aware"):

- While a **terminal** captures input, `ignoreInTerminal` accelerators (Ctrl+B/J/M/Z/`\`) are unregistered so the keys keep reaching the remote shell.
- While any **editable field** (settings inputs, dialogs) has focus, nothing is registered — keystrokes pass through.
- Otherwise all shortcuts are registered globally and fire regardless of app focus.

Browser dev mode (`pnpm dev` / vitest) keeps the existing window-keydown fallback, so behavior there is unchanged.

## Changes

- **Backend**: `tauri-plugin-global-shortcut` crate (2.3.2) registered in `lib.rs`; capability permissions `global-shortcut:allow-register|allow-unregister|allow-unregister-all|allow-is-registered` added (the plugin's default permission set is empty by design).
- **Frontend**: `toAccelerator()` converts `Ctrl+W`-style bindings to plugin accelerators (`Ctrl` → `CommandOrControl`, symbol keys mapped per the `global-hotkey` grammar — `\` → `Backslash`, space → `Space`, …).
- **macOS**: accelerators owned by the native menu (`Cmd+N/S/W/T/D/F/L`, `F5` — defined in `build_app_menu`) are not registered, avoiding double-fire with menu items.
- Duplicate accelerators resolve first-wins in array order (reproduces the old first-match-wins DOM semantics); the registration effect is keyed on the accelerator *set*, so tab-switch re-renders don't churn OS registrations.
- Registration failures (e.g. OS-reserved or malformed user bindings) surface one toast per shortcut (`settings.keyboard.registerFailed`, en + zh-CN).
- Key aliases keep their canonical names; unknown multi-char keys are uppercased — the parser matches case-insensitively.

## Tests

- New `src/__tests__/keyboard-shortcuts-global.test.tsx` (11 tests): plugin registration, terminal/editable focus transitions, Pressed-only dispatch, duplicate-accelerator dedupe, macOS menu skip, failure handling, unmount cleanup.
- 12 new `toAccelerator` conversion tests.
- New Rust smoke test asserting every emittable accelerator parses via `Shortcut::from_str` (runs against the real vendored `global-hotkey` 0.8 grammar).
- Fixed the `@tauri-apps/api/core` mock contract (`isTauri`) in 3 App-rendering test files — App now transitively calls `isTauri()`.

`pnpm test`: 618/618 · `cargo test`: 152/152 · `pnpm i18n:check` passes · lint/tsc clean on changed files (the `settings-modal.tsx:308` lint error and `vite.config.ts:6` tsc error are pre-existing on main).

## Notes

On macOS, Ctrl+W (physical Control) is no longer a close-tab bind — Cmd+W is served by the native menu (same action), and Control+W passes to the focused app/terminal. A customization set to one of the reserved menu combos falls back to the menu's action on macOS rather than double-firing.