### PR TITLE
feat(security): encrypt stored credentials at rest with keychain-backed master key

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -133,6 +133,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b350bfd03649e07aa05c0a81b3e15934374e585c98204a57e20b9d49f49bb9a"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2722,6 +2733,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72585bb6cc9bc370d1d545b7e23fcce71dfd4461c5e15275e3cf51bdfd9a980a"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "kv-log-macro"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3024,6 +3056,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3051,6 +3097,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3072,6 +3127,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -3985,6 +4051,7 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 name = "r-shell"
 version = "2.9.0"
 dependencies = [
+ "aes-gcm",
  "anyhow",
  "async-std",
  "async-trait",
@@ -3992,7 +4059,9 @@ dependencies = [
  "dirs 6.0.0",
  "env_logger",
  "futures",
+ "keyring",
  "open",
+ "rand 0.8.6",
  "russh",
  "russh-keys",
  "russh-sftp",
@@ -4613,6 +4682,25 @@ dependencies = [
  "pkcs8",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2",
+ "zbus",
 ]
 
 [[package]]
@@ -6837,6 +6925,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7512,6 +7613,17 @@ dependencies = [
  "zbus_macros",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74801d001b9e7729adb4f1825b67b398185fed424749aa3d8bacf70417137d9a"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,9 @@ dirs = "6"
 open = "5"
 base64 = "0.22"
 sys-locale = "0.3"
+keyring = "4"
+aes-gcm = "0.10"
+rand = "0.8"
 
 [dev-dependencies]
 tempfile = "3"

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3559,6 +3559,110 @@ pub fn editor_dirty_changed(app: tauri::AppHandle, label: String, dirty: bool) {
     crate::quit_guard::set_dirty(&app, &label, dirty);
 }
 
+// ========== Credential Encryption (master key + AES-256-GCM) ==========
+
+/// Keychain entry holding the app's data-protection master key. One entry for
+/// the whole app — the OS keychain is touched once (on first use), never per
+/// credential, keeping authorization prompts to a minimum.
+const MASTER_KEY_SERVICE: &str = "com.aiden.r-shell.dataprotection";
+const MASTER_KEY_USER: &str = "connection-secrets";
+
+use aes_gcm::aead::{Aead, KeyInit};
+use aes_gcm::{Aes256Gcm, Nonce};
+use base64::engine::general_purpose::STANDARD as BASE64;
+use base64::Engine as _;
+use std::sync::Mutex;
+
+/// Cached master key so we hit the keychain once per app run, not per call.
+static MASTER_KEY_CACHE: Mutex<Option<Vec<u8>>> = Mutex::new(None);
+
+/// Load (or first-use create) the 32-byte master key from the OS keychain.
+fn master_key() -> Result<Vec<u8>, String> {
+    if let Some(key) = MASTER_KEY_CACHE
+        .lock()
+        .map_err(|e| format!("Key cache lock poisoned: {e}"))?
+        .as_ref()
+    {
+        return Ok(key.clone());
+    }
+
+    let entry = keyring::Entry::new(MASTER_KEY_SERVICE, MASTER_KEY_USER)
+        .map_err(|e| format!("Failed to open keychain entry: {e}"))?;
+
+    let key = match entry.get_password() {
+        Ok(stored) => BASE64
+            .decode(stored)
+            .map_err(|e| format!("Stored master key is corrupt: {e}"))?,
+        Err(keyring::Error::NoEntry) => {
+            // First use: generate a random 32-byte key and persist it.
+            use rand::RngCore;
+            let mut fresh = vec![0u8; 32];
+            rand::thread_rng().fill_bytes(&mut fresh);
+            entry
+                .set_password(&BASE64.encode(&fresh))
+                .map_err(|e| format!("Failed to store master key: {e}"))?;
+            fresh
+        }
+        Err(e) => return Err(format!("Failed to read master key: {e}")),
+    };
+
+    if key.len() != 32 {
+        return Err("Stored master key has wrong length".to_string());
+    }
+
+    if let Ok(mut cache) = MASTER_KEY_CACHE.lock() {
+        *cache = Some(key.clone());
+    }
+    Ok(key)
+}
+
+/// Encrypt a secret with the app master key (AES-256-GCM).
+/// Returns a base64 string: `v1:<nonce>:<ciphertext>` (both parts base64).
+#[tauri::command]
+pub fn credential_seal(secret: String) -> Result<String, String> {
+    let key = master_key()?;
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| format!("Failed to init cipher: {e}"))?;
+
+    use rand::RngCore;
+    let mut nonce_bytes = [0u8; 12];
+    rand::thread_rng().fill_bytes(&mut nonce_bytes);
+
+    let ciphertext = cipher
+        .encrypt(Nonce::from_slice(&nonce_bytes), secret.as_bytes())
+        .map_err(|e| format!("Failed to encrypt secret: {e}"))?;
+
+    Ok(format!(
+        "v1:{}:{}",
+        BASE64.encode(nonce_bytes),
+        BASE64.encode(ciphertext)
+    ))
+}
+
+/// Decrypt a value produced by `credential_seal`.
+#[tauri::command]
+pub fn credential_open(sealed: String) -> Result<String, String> {
+    let key = master_key()?;
+    let parts: Vec<&str> = sealed.splitn(3, ':').collect();
+    if parts.len() != 3 || parts[0] != "v1" {
+        return Err("Unrecognized sealed secret format".to_string());
+    }
+    let nonce_bytes = BASE64
+        .decode(parts[1])
+        .map_err(|e| format!("Corrupt nonce: {e}"))?;
+    let ciphertext = BASE64
+        .decode(parts[2])
+        .map_err(|e| format!("Corrupt ciphertext: {e}"))?;
+
+    let cipher = Aes256Gcm::new_from_slice(&key)
+        .map_err(|e| format!("Failed to init cipher: {e}"))?;
+    let plaintext = cipher
+        .decrypt(Nonce::from_slice(&nonce_bytes), ciphertext.as_ref())
+        .map_err(|e| format!("Failed to decrypt secret: {e}"))?;
+
+    String::from_utf8(plaintext).map_err(|e| format!("Decrypted secret is not UTF-8: {e}"))
+}
+
 // ========== Local Filesystem Tests ==========
 
 #[cfg(test)]

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3650,6 +3650,9 @@ pub fn credential_open(sealed: String) -> Result<String, String> {
     let nonce_bytes = BASE64
         .decode(parts[1])
         .map_err(|e| format!("Corrupt nonce: {e}"))?;
+    if nonce_bytes.len() != 12 {
+        return Err("Corrupt nonce: invalid length".to_string());
+    }
     let ciphertext = BASE64
         .decode(parts[2])
         .map_err(|e| format!("Corrupt ciphertext: {e}"))?;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -470,6 +470,8 @@ pub fn run() {
             commands::request_app_quit,
             commands::cancel_app_quit,
             commands::editor_dirty_changed,
+            commands::credential_seal,
+            commands::credential_open,
             // Note: PTY terminal I/O now uses WebSocket instead of IPC
             // WebSocket server runs on a dynamically assigned port (9001-9010)
         ])

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import { WelcomeScreen } from './components/welcome-screen';
 import { UpdateChecker } from './components/update-checker';
 import { toConnectionConfig } from './lib/connection-config';
 import { ActiveConnectionsManager, ConnectionStorageManager, connectionHasCredentials } from './lib/connection-storage';
+import { openConnectionSecrets, sealLegacySecrets, isLegacyPlaintext, SECRET_FIELDS } from './lib/credential-crypto';
 import type { DetachedSession } from './components/connection-manager';
 import { isDesktopProtocol } from './lib/protocol-config';
 import { buildSftpConnectRequest, buildSshConnectRequest } from './lib/ssh-connect-request';
@@ -314,6 +315,36 @@ function AppContent() {
     }
   }, [allTabs]);
 
+  // One-time migration: encrypt any legacy plaintext secrets still sitting in
+  // localStorage (from app versions before encrypted-at-rest storage). The
+  // restore effect awaits this so restored connections can decrypt them.
+  const legacyMigrationRef = useRef<Promise<void> | null>(null);
+
+  // Kick off the legacy-secret migration on mount.
+  useEffect(() => {
+    legacyMigrationRef.current = (async () => {
+      const connections = ConnectionStorageManager.getConnections();
+      const withPlaintext = connections.filter((c) =>
+        SECRET_FIELDS.some((f) => isLegacyPlaintext(c[f])),
+      );
+      for (const conn of withPlaintext) {
+        try {
+          const migrated = await sealLegacySecrets(conn as unknown as Record<string, unknown> & { id: string });
+          if (migrated) {
+            ConnectionStorageManager.updateConnection(conn.id, conn);
+            console.log(`[Credential] Encrypted stored secrets for ${conn.id}`);
+          }
+        } catch (error) {
+          // Keep the legacy plaintext on failure — never destroy the only copy.
+          console.error(`[Credential] Migration failed for ${conn.id}; keeping plaintext:`, error);
+        }
+      }
+      if (withPlaintext.length > 0) {
+        console.log(`[Credential] Legacy secret encryption checked ${withPlaintext.length} connection(s)`);
+      }
+    })();
+  }, []);
+
   // Restore connections on mount
   useEffect(() => {
     /** Race a promise against a timeout; rejects with a clear message on expiry. */
@@ -344,6 +375,14 @@ function AppContent() {
     let restoreCancelled = false;
 
     const restoreConnections = async () => {
+      // Wait for the one-time legacy-secret encryption so restored
+      // connections can decrypt their stored credentials.
+      try {
+        await legacyMigrationRef.current;
+      } catch (error) {
+        console.error('[Credential] Legacy migration did not complete cleanly; continuing restore:', error);
+      }
+
       const activeConnections = ActiveConnectionsManager.getActiveConnections();
 
       if (activeConnections.length === 0) {
@@ -413,6 +452,10 @@ function AppContent() {
           failedCount++;
           continue;
         }
+
+        // Decrypt stored secrets for the connect requests below (tunnel
+        // credentials included) so the credential check sees plaintext.
+        await openConnectionSecrets(connectionData as unknown as Record<string, unknown>);
 
         const hasCredentials = connectionHasCredentials(connectionData);
 
@@ -654,6 +697,9 @@ function AppContent() {
       const connectionData = ConnectionStorageManager.getConnection(connection.id);
       if (!connectionData) return;
 
+      // Decrypt stored secrets for the connect requests below.
+      await openConnectionSecrets(connectionData as unknown as Record<string, unknown>);
+
       const isSftp = connectionData.protocol === 'SFTP';
       const isFtp = connectionData.protocol === 'FTP';
       const isFileBrowser = isSftp || isFtp;
@@ -855,6 +901,9 @@ function AppContent() {
       return;
     }
 
+    // Decrypt stored secrets for the connect requests below.
+    await openConnectionSecrets(connectionData as unknown as Record<string, unknown>);
+
     const isSftp = tabToDuplicate.protocol === 'SFTP' || connectionData.protocol === 'SFTP';
     const isFtp = tabToDuplicate.protocol === 'FTP' || connectionData.protocol === 'FTP';
     const isFileBrowser = isSftp || isFtp;
@@ -1003,6 +1052,9 @@ function AppContent() {
       });
       return;
     }
+
+    // Decrypt stored secrets for the connect requests below.
+    await openConnectionSecrets(connectionData as unknown as Record<string, unknown>);
 
     const isSftp = tabToReconnect.protocol === 'SFTP' || connectionData.protocol === 'SFTP';
     const isFtp = tabToReconnect.protocol === 'FTP' || connectionData.protocol === 'FTP';
@@ -1671,6 +1723,19 @@ function AppContent() {
   const handleSaveConnection = useCallback(async (config: ConnectionConfig) => {
     if (!config.id) return;
 
+    // A blank password on a saved connection means "keep the stored secret" —
+    // decrypt it from storage so the connect requests below carry the real value.
+    if (!config.password) {
+      const stored = ConnectionStorageManager.getConnection(config.id);
+      if (stored) {
+        const withSecrets: Record<string, unknown> = { ...stored };
+        await openConnectionSecrets(withSecrets);
+        if (typeof withSecrets.password === 'string' && withSecrets.password) {
+          config.password = withSecrets.password;
+        }
+      }
+    }
+
     // Update any open tab name for this connection
     for (const group of Object.values(state.groups)) {
       for (const tab of group.tabs) {
@@ -1875,6 +1940,9 @@ function AppContent() {
       });
       return;
     }
+
+    // Decrypt stored secrets for the connect requests below.
+    await openConnectionSecrets(connectionData as unknown as Record<string, unknown>);
 
     const isSftp = connectionData.protocol === 'SFTP';
     const isFtp = connectionData.protocol === 'FTP';

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1723,15 +1723,18 @@ function AppContent() {
   const handleSaveConnection = useCallback(async (config: ConnectionConfig) => {
     if (!config.id) return;
 
-    // A blank password on a saved connection means "keep the stored secret" —
-    // decrypt it from storage so the connect requests below carry the real value.
-    if (!config.password) {
+    // A blank secret on a saved connection means "keep the stored secret" —
+    // decrypt the stored values so the connect requests below carry the real
+    // values (covers the password, tunnel credentials, etc.).
+    if (SECRET_FIELDS.some((f) => !config[f])) {
       const stored = ConnectionStorageManager.getConnection(config.id);
       if (stored) {
         const withSecrets: Record<string, unknown> = { ...stored };
         await openConnectionSecrets(withSecrets);
-        if (typeof withSecrets.password === 'string' && withSecrets.password) {
-          config.password = withSecrets.password;
+        for (const f of SECRET_FIELDS) {
+          if (!config[f] && typeof withSecrets[f] === 'string' && withSecrets[f]) {
+            (config as unknown as Record<string, unknown>)[f] = withSecrets[f];
+          }
         }
       }
     }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,8 +16,9 @@ import { QuickCommandsPanel } from './components/quick-commands-panel';
 import { WelcomeScreen } from './components/welcome-screen';
 import { UpdateChecker } from './components/update-checker';
 import { toConnectionConfig } from './lib/connection-config';
-import { ActiveConnectionsManager, ConnectionStorageManager, connectionHasCredentials } from './lib/connection-storage';
-import { openConnectionSecrets, sealLegacySecrets, isLegacyPlaintext, SECRET_FIELDS } from './lib/credential-crypto';
+import { ActiveConnectionsManager, ConnectionStorageManager, connectionHasCredentials, markSealFailed, clearSealFailed } from './lib/connection-storage';
+import { ConnectionProfileManager } from './lib/connection-profiles';
+import { openConnectionSecrets, sealLegacySecrets, sealSecret, isLegacyPlaintext, SECRET_FIELDS } from './lib/credential-crypto';
 import type { DetachedSession } from './components/connection-manager';
 import { isDesktopProtocol } from './lib/protocol-config';
 import { buildSftpConnectRequest, buildSshConnectRequest } from './lib/ssh-connect-request';
@@ -331,16 +332,37 @@ function AppContent() {
         try {
           const migrated = await sealLegacySecrets(conn as unknown as Record<string, unknown> & { id: string });
           if (migrated) {
+            clearSealFailed(conn.id);
             ConnectionStorageManager.updateConnection(conn.id, conn);
             console.log(`[Credential] Encrypted stored secrets for ${conn.id}`);
           }
         } catch (error) {
           // Keep the legacy plaintext on failure — never destroy the only copy.
+          // Guard it against persistence writes too: any unrelated write
+          // (updateLastConnected, a folder move) would otherwise strip the
+          // plaintext from storage and destroy that only copy.
+          markSealFailed(conn.id);
           console.error(`[Credential] Migration failed for ${conn.id}; keeping plaintext:`, error);
         }
       }
       if (withPlaintext.length > 0) {
         console.log(`[Credential] Legacy secret encryption checked ${withPlaintext.length} connection(s)`);
+      }
+
+      // Profiles can carry legacy plaintext passwords too (historical stores
+      // and export bundles from before exports were sanitized). Seal them the
+      // same way. On failure keep the plaintext — profile storage has no
+      // strip-on-write path, so the only copy is never at risk here.
+      const profiles = ConnectionProfileManager.getProfiles();
+      for (const profile of profiles) {
+        if (!isLegacyPlaintext(profile.password)) continue;
+        try {
+          const sealed = await sealSecret(profile.password);
+          ConnectionProfileManager.updateProfile(profile.id, { password: sealed });
+          console.log(`[Credential] Encrypted stored password of profile ${profile.id}`);
+        } catch (error) {
+          console.error(`[Credential] Profile migration failed for ${profile.id}; keeping plaintext:`, error);
+        }
       }
     })();
   }, []);

--- a/src/__tests__/config-export-import.test.ts
+++ b/src/__tests__/config-export-import.test.ts
@@ -175,6 +175,40 @@ describe('exportAllConfig', () => {
     expect(bundle.data.language).toBe('zh-CN');
   });
 
+  it('strips secret fields — plaintext and sealed ciphertext — from the bundle', async () => {
+    // Seed a connection whose secrets are already sealed (v1: format, the
+    // normal encrypted-at-rest state) directly into storage.
+    const sealed = ConnectionStorageManager.getConnections();
+    sealed.push({
+      id: 'conn-sealed',
+      name: 'Sealed Server',
+      host: '10.0.0.9',
+      port: 22,
+      username: 'root',
+      protocol: 'SSH',
+      authMethod: 'password',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      password: 'v1:QUJDREVGR0hJSktMTU5P:QUJDREVGR0hJSktMTU5PUVJTVFVW',
+    } as ConnectionData);
+    localStorage.setItem('r-shell-connections', JSON.stringify(sealed));
+
+    mockSave.mockResolvedValue('/tmp/config.json');
+    mockWriteTextFile.mockResolvedValue(undefined);
+
+    const { exportAllConfig } = await import('../lib/config-export-import');
+    await exportAllConfig();
+
+    const bundle = JSON.parse(mockWriteTextFile.mock.calls[0][1] as string);
+    for (const c of bundle.data.connections.connections as ConnectionData[]) {
+      expect(c.password).toBeUndefined();
+      expect(c.passphrase).toBeUndefined();
+      expect(c.proxyPassword).toBeUndefined();
+      expect(c.vncPassword).toBeUndefined();
+      // Non-secret fields survive the strip.
+      expect(c.host).toBeDefined();
+    }
+  });
+
   it('returns false when user cancels the save dialog', async () => {
     mockSave.mockResolvedValue(null); // cancelled
 

--- a/src/__tests__/connection-dialog-advanced-save.test.tsx
+++ b/src/__tests__/connection-dialog-advanced-save.test.tsx
@@ -4,7 +4,7 @@
  * were updated in local component state but never written to storage.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ConnectionDialog, type ConnectionConfig } from '../components/connection-dialog';
 import { ConnectionStorageManager } from '../lib/connection-storage';
 
@@ -69,6 +69,11 @@ describe('ConnectionDialog advanced tab save', () => {
     // Save
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
 
+    // handleSave is async (seals secrets via IPC) — wait for the persist.
+    await waitFor(() => {
+      expect(ConnectionStorageManager.updateConnection).toHaveBeenCalled();
+    });
+
     expect(ConnectionStorageManager.updateConnection).toHaveBeenCalledWith(
       'conn-1',
       expect.objectContaining({
@@ -126,6 +131,11 @@ describe('ConnectionDialog advanced tab save', () => {
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // handleSave is async (seals secrets via IPC) — wait for the persist.
+    await waitFor(() => {
+      expect(ConnectionStorageManager.updateConnection).toHaveBeenCalled();
+    });
 
     expect(ConnectionStorageManager.updateConnection).toHaveBeenCalledWith(
       'conn-2',

--- a/src/__tests__/connection-dialog-edit-roundtrip.test.tsx
+++ b/src/__tests__/connection-dialog-edit-roundtrip.test.tsx
@@ -6,7 +6,7 @@
  * same storage path as the desktop app.
  */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { ConnectionDialog, type ConnectionConfig } from '../components/connection-dialog';
 import { ConnectionStorageManager, type ConnectionData } from '../lib/connection-storage';
 
@@ -88,6 +88,11 @@ describe('edit advanced options round-trip (real storage)', () => {
     expect(switches[0].getAttribute('data-state')).toBe('checked'); // compression starts ON
     fireEvent.click(switches[0]); // compression → OFF
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // handleSave is async (seals secrets via IPC) — wait for the persist.
+    await waitFor(() => {
+      expect(ConnectionStorageManager.getConnection('c1')?.compression).toBe(false);
+    });
     unmount();
 
     // The stored value must now be false.
@@ -136,6 +141,10 @@ describe('edit advanced options round-trip (real storage)', () => {
     const intervalInput = screen.getByLabelText('Interval (seconds)');
     fireEvent.change(intervalInput, { target: { value: '30' } });
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(ConnectionStorageManager.getConnection('c1')?.keepAliveInterval).toBe(30);
+    });
     unmount();
 
     expect(ConnectionStorageManager.getConnection('c1')?.keepAliveInterval).toBe(30);

--- a/src/__tests__/connection-dialog-proxy.test.tsx
+++ b/src/__tests__/connection-dialog-proxy.test.tsx
@@ -4,9 +4,13 @@
  * Bug: a connection configured with a proxy lost its proxy settings after
  * a failed connect — the Edit dialog showed empty proxy fields because the
  * proxy was never persisted to connection storage.
+ *
+ * Secret handling: stored secrets are ciphertext (sealed via the Rust
+ * credential_seal command). The edit dialog never echoes them back — blank
+ * fields mean "keep the stored value", typed values are sealed on save.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConnectionDialog } from '../components/connection-dialog';
 import { ConnectionStorageManager } from '../lib/connection-storage';
 
@@ -16,8 +20,18 @@ beforeAll(() => {
   Element.prototype.scrollIntoView = () => {};
 });
 
+// Deterministic test-double for credential_seal/open.
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(),
+  invoke: vi.fn(async (command: string, args: { secret?: string; sealed?: string }) => {
+    if (command === 'credential_seal') {
+      return `v1:test:${btoa(encodeURIComponent(args.secret ?? ''))}`;
+    }
+    if (command === 'credential_open') {
+      const payload = (args.sealed ?? '').split(':')[2] ?? '';
+      return decodeURIComponent(atob(payload));
+    }
+    return {};
+  }),
 }));
 
 vi.mock('sonner', () => ({
@@ -31,6 +45,7 @@ vi.mock('../lib/connection-profiles', () => ({
 }));
 
 import { invoke } from '@tauri-apps/api/core';
+import { sealSecret } from '../lib/credential-crypto';
 
 const mockInvoke = invoke as ReturnType<typeof vi.fn>;
 
@@ -70,32 +85,66 @@ function activateTab(name: string) {
   fireEvent.mouseDown(screen.getByRole('tab', { name }));
 }
 
+/** The stored value must be ciphertext (v1 sealed), never the plaintext. */
+function expectSealed(value: unknown, plaintext: string): void {
+  expect(typeof value).toBe('string');
+  expect(value as string).toMatch(/^v1:/);
+  expect(value as string).not.toContain(plaintext);
+}
+
 beforeEach(() => {
   localStorage.clear();
   vi.clearAllMocks();
 });
 
 describe('ConnectionDialog proxy persistence', () => {
-  it('persists proxy config when the edited connection is saved', () => {
-    // Seed a connection without proxy (realistic: proxy was never stored before)
-    ConnectionStorageManager.saveConnectionWithId('conn-1', baseConnection);
-
-    renderDialog({
-      editingConnection: { ...baseConnection, ...proxyConfig },
+  it('persists proxy config when the edited connection is saved', async () => {
+    // Seed a connection whose stored secrets are already sealed (the normal
+    // post-migration state) plus a plaintext-free proxy password.
+    ConnectionStorageManager.saveConnectionWithId('conn-1', {
+      ...baseConnection,
+      password: await sealSecret('secret'),
+      proxyPassword: await sealSecret('proxypass'),
     });
 
+    renderDialog({
+      editingConnection: {
+        ...baseConnection,
+        ...proxyConfig,
+        // The dialog model receives the stored (sealed) values.
+        password: await sealSecret('secret'),
+        proxyPassword: await sealSecret('proxypass'),
+      },
+    });
+
+    // Leave the secret fields blank (keep stored values) and save.
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // handleSave is async (seals secrets via IPC) — wait for the persist.
+    await waitFor(() => {
+      expect(ConnectionStorageManager.getConnection('conn-1')?.proxyType).toBe('http');
+    });
 
     const stored = ConnectionStorageManager.getConnection('conn-1');
     expect(stored?.proxyType).toBe('http');
     expect(stored?.proxyHost).toBe('proxy.example.com');
     expect(stored?.proxyPort).toBe(3128);
     expect(stored?.proxyUsername).toBe('proxyuser');
-    expect(stored?.proxyPassword).toBe('proxypass');
+    // Blank field on save = keep the stored (sealed) proxy password.
+    expectSealed(stored?.proxyPassword, 'proxypass');
+    expectSealed(stored?.password, 'secret');
   });
 
   it('keeps proxy config when a new connection fails to connect', async () => {
-    mockInvoke.mockResolvedValueOnce({ success: false, error: 'connection refused' });
+    mockInvoke.mockImplementation(async (command: string, args?: { secret?: string }) => {
+      if (command === 'credential_seal') {
+        return `v1:test:${btoa(encodeURIComponent(args?.secret ?? ''))}`;
+      }
+      if (command === 'ssh_connect') {
+        return { success: false, error: 'connection refused' };
+      }
+      return {};
+    });
 
     renderDialog();
 
@@ -150,12 +199,19 @@ describe('ConnectionDialog proxy persistence', () => {
     expect(connections[0].proxyHost).toBe('proxy.example.com');
     expect(connections[0].proxyPort).toBe(3128);
     expect(connections[0].proxyUsername).toBe('proxyuser');
-    expect(connections[0].proxyPassword).toBe('proxypass');
+    // The typed proxy password was sealed for storage — never plaintext.
+    expectSealed(connections[0].proxyPassword, 'proxypass');
   });
 
-  it('shows saved proxy values in the proxy tab when editing', () => {
+  it('does not echo the stored proxy password back into the form', () => {
     renderDialog({
-      editingConnection: { ...baseConnection, ...proxyConfig },
+      editingConnection: {
+        ...baseConnection,
+        ...proxyConfig,
+        // Stored values arrive sealed (from the stripped storage model).
+        proxyPassword: 'v1:test:cHJveHlwYXNz',
+        password: 'v1:test:c2VjcmV0',
+      },
     });
 
     activateTab('Proxy');
@@ -163,6 +219,7 @@ describe('ConnectionDialog proxy persistence', () => {
     expect((screen.getByLabelText('Proxy Host') as HTMLInputElement).value).toBe('proxy.example.com');
     expect((screen.getByLabelText('Proxy Port') as HTMLInputElement).value).toBe('3128');
     expect((screen.getByLabelText('Proxy Username') as HTMLInputElement).value).toBe('proxyuser');
-    expect((screen.getByLabelText('Proxy Password') as HTMLInputElement).value).toBe('proxypass');
+    // The stored secret is NOT echoed — the field stays blank with a hint.
+    expect((screen.getByLabelText('Proxy Password') as HTMLInputElement).value).toBe('');
   });
 });

--- a/src/__tests__/connection-dialog-stored-secret.test.tsx
+++ b/src/__tests__/connection-dialog-stored-secret.test.tsx
@@ -1,0 +1,148 @@
+/**
+ * Tests for the dialog-side review fixes on PR #114:
+ * - previousSecrets must reset on dialog reopen (editing A then creating B
+ *   would otherwise store A's sealed secrets on B).
+ * - Connecting while editing a saved connection with a blank secret field
+ *   must send the decrypted retained credential — not an empty one.
+ * - Secrets must be sealed as typed (no trimming): whitespace can be part of
+ *   a credential.
+ */
+import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ConnectionDialog } from '../components/connection-dialog';
+import { ConnectionStorageManager } from '../lib/connection-storage';
+
+beforeAll(() => {
+  Element.prototype.scrollIntoView = () => {};
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({
+  toast: { error: vi.fn(), info: vi.fn(), success: vi.fn() },
+}));
+
+vi.mock('../lib/connection-profiles', () => ({
+  ConnectionProfileManager: {
+    getProfiles: vi.fn(() => []),
+  },
+}));
+
+import { invoke } from '@tauri-apps/api/core';
+
+const mockInvoke = invoke as unknown as ReturnType<typeof vi.fn>;
+
+/** Deterministic seal/open test-double (base64 round-trip). */
+function installCredentialMocks() {
+  mockInvoke.mockImplementation(async (command: string, args?: { secret?: string; sealed?: string }) => {
+    if (command === 'credential_seal') {
+      return `v1:test:${btoa(encodeURIComponent(args?.secret ?? ''))}`;
+    }
+    if (command === 'credential_open') {
+      const payload = (args?.sealed ?? '').split(':')[2] ?? '';
+      return decodeURIComponent(atob(payload));
+    }
+    if (command === 'ssh_connect') {
+      return { success: true };
+    }
+    return {};
+  });
+}
+
+const sealedPassword = 'v1:test:cGFzc3dvcmQ='; // openSecret -> "password"
+
+const baseConnection = {
+  id: 'conn-1',
+  name: 'My Server',
+  host: '192.168.1.1',
+  port: 22,
+  username: 'admin',
+  protocol: 'SSH' as const,
+  authMethod: 'password' as const,
+  password: sealedPassword,
+};
+
+function renderDialog(props: Partial<React.ComponentProps<typeof ConnectionDialog>> = {}) {
+  return render(
+    <ConnectionDialog
+      open={true}
+      onOpenChange={vi.fn()}
+      onConnect={vi.fn()}
+      editingConnection={null}
+      {...props}
+    />,
+  );
+}
+
+function fillNewConnectionForm() {
+  fireEvent.change(screen.getByLabelText('Connection Name'), { target: { value: 'Conn B' } });
+  fireEvent.change(screen.getByLabelText('Host'), { target: { value: '10.0.0.5' } });
+  fireEvent.change(screen.getByLabelText('Username'), { target: { value: 'user-b' } });
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+  installCredentialMocks();
+});
+
+describe('ConnectionDialog stored-secret handling', () => {
+  it('does not inherit secrets when a new connection follows an edit', async () => {
+    const { rerender } = renderDialog({
+      editingConnection: baseConnection,
+    });
+    // Close the dialog, then open it for a new connection.
+    rerender(<ConnectionDialog open={false} onOpenChange={vi.fn()} onConnect={vi.fn()} editingConnection={baseConnection} />);
+    rerender(<ConnectionDialog open={true} onOpenChange={vi.fn()} onConnect={vi.fn()} editingConnection={null} />);
+
+    fillNewConnectionForm();
+    fireEvent.click(screen.getByRole('button', { name: 'Connect' }));
+
+    await waitFor(() => {
+      expect(ConnectionStorageManager.getConnection('connection-') !== undefined || true).toBe(true);
+    });
+    const stored = ConnectionStorageManager.getConnections().find((c) => c.name === 'Conn B');
+    expect(stored).toBeDefined();
+    // The blank password must NOT resolve to A's sealed value.
+    expect(stored?.password).toBe('');
+  });
+
+  it('keeps the stored (sealed) password on save with a blank field', async () => {
+    ConnectionStorageManager.saveConnectionWithId('conn-1', baseConnection);
+    const onSave = vi.fn();
+    renderDialog({ editingConnection: baseConnection, onSave });
+
+    // Edit mode has a Save button (no Connect) — save with a blank password.
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalled();
+    });
+    // The stored value stays the sealed secret (blank = keep).
+    expect(ConnectionStorageManager.getConnection('conn-1')?.password).toBe(sealedPassword);
+    // The dialog never hands the ciphertext back to the parent — the parent
+    // resolves retained credentials itself (App.handleSaveConnection).
+    const passedConfig = onSave.mock.calls[0][0] as { password?: string };
+    expect(passedConfig.password).toBe('');
+  });
+
+  it('seals the password as typed, without trimming', async () => {
+    ConnectionStorageManager.saveConnectionWithId('conn-1', baseConnection);
+    renderDialog({ editingConnection: baseConnection });
+
+    // Activate the Auth tab and type a password with surrounding whitespace.
+    fireEvent.mouseDown(screen.getByRole('tab', { name: 'Auth' }));
+    fireEvent.change(screen.getByLabelText('Password'), { target: { value: '  padded  ' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    await waitFor(() => {
+      const sealCall = mockInvoke.mock.calls.find(([cmd]) => cmd === 'credential_seal');
+      expect(sealCall).toBeDefined();
+    });
+    const sealCall = mockInvoke.mock.calls.find(([cmd]) => cmd === 'credential_seal');
+    expect((sealCall?.[1] as { secret: string }).secret).toBe('  padded  ');
+  });
+});

--- a/src/__tests__/connection-dialog-tunnel.test.tsx
+++ b/src/__tests__/connection-dialog-tunnel.test.tsx
@@ -4,7 +4,7 @@
  * configured on a connection is useless if it is dropped on save or reconnect.
  */
 import { beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { ConnectionDialog } from '../components/connection-dialog';
 import { ConnectionStorageManager } from '../lib/connection-storage';
 
@@ -75,7 +75,7 @@ beforeEach(() => {
 });
 
 describe('ConnectionDialog SSH tunnel persistence', () => {
-  it('persists tunnel config when the edited connection is saved', () => {
+  it('persists tunnel config when the edited connection is saved', async () => {
     // Seed a connection without a tunnel (realistic: legacy connection)
     ConnectionStorageManager.saveConnectionWithId('conn-1', baseConnection);
 
@@ -84,6 +84,11 @@ describe('ConnectionDialog SSH tunnel persistence', () => {
     });
 
     fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    // handleSave is async (seals secrets via IPC) — wait for the persist.
+    await waitFor(() => {
+      expect(ConnectionStorageManager.getConnection('conn-1')?.tunnelEnabled).toBe(true);
+    });
 
     const stored = ConnectionStorageManager.getConnection('conn-1');
     expect(stored?.tunnelEnabled).toBe(true);

--- a/src/__tests__/connection-dialog-tunnel.test.tsx
+++ b/src/__tests__/connection-dialog-tunnel.test.tsx
@@ -38,7 +38,9 @@ const tunnelConfig = {
   tunnelPort: 2222,
   tunnelUsername: 'jumpuser',
   tunnelAuthMethod: 'password' as const,
-  tunnelPassword: 'jumppass',
+  // Stored connections hold ciphertext, not plaintext (the dialog never
+  // echoes secrets back into the form).
+  tunnelPassword: 'v1:test:anVtcGFzcw==',
 };
 
 const baseConnection = {
@@ -95,10 +97,17 @@ describe('ConnectionDialog SSH tunnel persistence', () => {
     expect(stored?.tunnelHost).toBe('bastion.example.com');
     expect(stored?.tunnelPort).toBe(2222);
     expect(stored?.tunnelUsername).toBe('jumpuser');
-    expect(stored?.tunnelPassword).toBe('jumppass');
+    // Blank field on save keeps the stored (sealed) tunnel password.
+    expect(stored?.tunnelPassword).toBe('v1:test:anVtcGFzcw==');
   });
 
   it('keeps tunnel config when a new connection fails to connect', async () => {
+    mockInvoke.mockImplementation(async (command: string, args?: { secret?: string }) => {
+      if (command === 'credential_seal') {
+        return `v1:test:${btoa(encodeURIComponent(args?.secret ?? ''))}`;
+      }
+      return undefined;
+    });
     mockInvoke.mockResolvedValueOnce({ success: false, error: 'connection refused' });
 
     renderDialog();
@@ -149,7 +158,9 @@ describe('ConnectionDialog SSH tunnel persistence', () => {
     expect(connections[0].tunnelHost).toBe('bastion.example.com');
     expect(connections[0].tunnelPort).toBe(2222);
     expect(connections[0].tunnelUsername).toBe('jumpuser');
-    expect(connections[0].tunnelPassword).toBe('jumppass');
+    // The typed tunnel password is persisted sealed, never as plaintext.
+    expect(connections[0].tunnelPassword).toMatch(/^v1:/);
+    expect(connections[0].tunnelPassword).not.toContain('jumppass');
   });
 
   it('shows saved tunnel values when editing', () => {
@@ -162,7 +173,8 @@ describe('ConnectionDialog SSH tunnel persistence', () => {
     expect((screen.getByLabelText('Tunnel Host') as HTMLInputElement).value).toBe('bastion.example.com');
     expect((screen.getByLabelText('Tunnel Port') as HTMLInputElement).value).toBe('2222');
     expect((screen.getByLabelText('Tunnel Username') as HTMLInputElement).value).toBe('jumpuser');
-    expect((screen.getByLabelText('Tunnel Password') as HTMLInputElement).value).toBe('jumppass');
+    // Stored secrets are never echoed back — the field stays blank.
+    expect((screen.getByLabelText('Tunnel Password') as HTMLInputElement).value).toBe('');
     expect(screen.getByRole('switch', { name: 'Enable SSH Tunnel' }).getAttribute('data-state')).toBe('checked');
   });
 

--- a/src/__tests__/connection-duplicate-fields.test.tsx
+++ b/src/__tests__/connection-duplicate-fields.test.tsx
@@ -94,9 +94,21 @@ describe('ConnectionManager duplicate', () => {
     expect(copy).toBeTruthy();
     expect(copy!.id).not.toBe(FULL_CONNECTION.id);
 
-    // Every field must be carried over except id/createdAt (and the name).
-    const { id: _srcId, createdAt: _srcCreated, name: _srcName, ...expected } = FULL_CONNECTION;
-    const { id: _copyId, createdAt: _copyCreated, name: _copyName, ...actual } = copy!;
+    // Every field must be carried over except id/createdAt/name and the
+    // secrets — plaintext secrets never round-trip through storage (they are
+    // stripped on read), so a duplicate cannot carry them either.
+    const {
+      id: _srcId, createdAt: _srcCreated, name: _srcName,
+      password: _pw, passphrase: _pp, privateKeyPath: _pkp,
+      proxyPassword: _ppw, vncPassword: _vpw,
+      ...expected
+    } = FULL_CONNECTION;
+    const {
+      id: _copyId, createdAt: _copyCreated, name: _copyName,
+      password: _pw2, passphrase: _pp2, privateKeyPath: _pkp2,
+      proxyPassword: _ppw2, vncPassword: _vpw2,
+      ...actual
+    } = copy!;
     expect(actual).toEqual(expected);
   });
 

--- a/src/__tests__/connection-profiles-import.test.ts
+++ b/src/__tests__/connection-profiles-import.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Profiles must not persist secrets coming from import bundles. Bundles may
+ * predate export sanitization, so importProfiles strips the secret fields;
+ * existing plaintext profiles are sealed by the startup migration (App.tsx).
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConnectionProfileManager } from '../lib/connection-profiles';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('ConnectionProfileManager.importProfiles secret stripping', () => {
+  it('strips secret fields from imported profiles', () => {
+    const count = ConnectionProfileManager.importProfiles(JSON.stringify([
+      {
+        id: 'old-id', name: 'Web', host: 'web.example.com', port: 22,
+        username: 'admin', authMethod: 'password', password: 'legacy-pass',
+        createdAt: '2025-01-01', updatedAt: '2025-01-01',
+      },
+    ]));
+    expect(count).toBe(1);
+
+    const stored = JSON.parse(localStorage.getItem('r-shell-connection-profiles') ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].password).toBeUndefined();
+    expect(stored[0].host).toBe('web.example.com');
+  });
+
+  it('keeps non-secret fields when stripping', () => {
+    ConnectionProfileManager.importProfiles(JSON.stringify([
+      {
+        name: 'Db', host: 'db.example.com', port: 2222, username: 'dbuser',
+        authMethod: 'key', privateKey: '/home/u/id_rsa',
+        createdAt: '2025-01-01', updatedAt: '2025-01-01',
+      },
+    ]));
+    const stored = JSON.parse(localStorage.getItem('r-shell-connection-profiles') ?? '[]');
+    expect(stored[0].privateKey).toBe('/home/u/id_rsa');
+    expect(stored[0].password).toBeUndefined();
+  });
+});

--- a/src/__tests__/connection-storage-advanced-fields.test.ts
+++ b/src/__tests__/connection-storage-advanced-fields.test.ts
@@ -3,16 +3,34 @@
  * Verifies that fields edited in the dialog's Advanced / Proxy tabs survive a
  * save → reload round trip (regression: they were previously dropped).
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ConnectionStorageManager } from '../lib/connection-storage';
+import { sealSecret } from '../lib/credential-crypto';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string, args: { secret?: string }) => {
+    if (command === 'credential_seal') {
+      return `v1:test:${btoa(encodeURIComponent(args.secret ?? ''))}`;
+    }
+    return {};
+  }),
+}));
 
 beforeEach(() => {
   localStorage.clear();
   ConnectionStorageManager.initialize();
 });
 
+
+/** The stored value must be ciphertext (v1 sealed), never the plaintext. */
+function expectSealed(value: unknown, plaintext: string): void {
+  expect(typeof value).toBe('string');
+  expect(value as string).toMatch(/^v1:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/);
+  expect(value as string).not.toContain(plaintext);
+}
+
 describe('connection-storage advanced & proxy field persistence', () => {
-  it('round-trips proxy fields through saveConnectionWithId', () => {
+  it('round-trips proxy fields through saveConnectionWithId', async () => {
     ConnectionStorageManager.saveConnectionWithId('conn-1', {
       name: 'My Server',
       host: 'example.com',
@@ -24,7 +42,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
       proxyHost: 'proxy.example.com',
       proxyPort: 1080,
       proxyUsername: 'user',
-      proxyPassword: 'pass',
+      proxyPassword: await sealSecret('pass'),
     });
 
     const loaded = ConnectionStorageManager.getConnection('conn-1');
@@ -32,7 +50,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
     expect(loaded?.proxyHost).toBe('proxy.example.com');
     expect(loaded?.proxyPort).toBe(1080);
     expect(loaded?.proxyUsername).toBe('user');
-    expect(loaded?.proxyPassword).toBe('pass');
+    expectSealed(loaded?.proxyPassword, 'pass');
   });
 
   it('round-trips advanced SSH fields through saveConnectionWithId', () => {
@@ -56,7 +74,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
     expect(loaded?.serverAliveCountMax).toBe(5);
   });
 
-  it('updateConnection preserves advanced & proxy fields', () => {
+  it('updateConnection preserves advanced & proxy fields', async () => {
     ConnectionStorageManager.saveConnectionWithId('conn-3', {
       name: 'My Server',
       host: 'example.com',
@@ -75,7 +93,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
       proxyHost: 'proxy.example.com',
       proxyPort: 3128,
       proxyUsername: 'user',
-      proxyPassword: 'pass',
+      proxyPassword: await sealSecret('pass'),
     });
 
     const loaded = ConnectionStorageManager.getConnection('conn-3');
@@ -87,7 +105,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
     expect(loaded?.proxyHost).toBe('proxy.example.com');
     expect(loaded?.proxyPort).toBe(3128);
     expect(loaded?.proxyUsername).toBe('user');
-    expect(loaded?.proxyPassword).toBe('pass');
+    expectSealed(loaded?.proxyPassword, 'pass');
   });
 
   it('round-trips SSH tunnel fields through saveConnectionWithId', () => {

--- a/src/__tests__/connection-storage-advanced-fields.test.ts
+++ b/src/__tests__/connection-storage-advanced-fields.test.ts
@@ -108,7 +108,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
     expectSealed(loaded?.proxyPassword, 'pass');
   });
 
-  it('round-trips SSH tunnel fields through saveConnectionWithId', () => {
+  it('round-trips SSH tunnel fields through saveConnectionWithId', async () => {
     ConnectionStorageManager.saveConnectionWithId('conn-4', {
       name: 'My Server',
       host: 'example.com',
@@ -123,7 +123,7 @@ describe('connection-storage advanced & proxy field persistence', () => {
       tunnelAuthMethod: 'publickey',
       tunnelPassword: '',
       tunnelKeyPath: '~/.ssh/id_ed25519',
-      tunnelPassphrase: 'secret',
+      tunnelPassphrase: await sealSecret('secret'),
     });
 
     const loaded = ConnectionStorageManager.getConnection('conn-4');
@@ -133,6 +133,6 @@ describe('connection-storage advanced & proxy field persistence', () => {
     expect(loaded?.tunnelUsername).toBe('jumpuser');
     expect(loaded?.tunnelAuthMethod).toBe('publickey');
     expect(loaded?.tunnelKeyPath).toBe('~/.ssh/id_ed25519');
-    expect(loaded?.tunnelPassphrase).toBe('secret');
+    expectSealed(loaded?.tunnelPassphrase, 'secret');
   });
 });

--- a/src/__tests__/connection-storage-migration.test.ts
+++ b/src/__tests__/connection-storage-migration.test.ts
@@ -1,0 +1,96 @@
+/**
+ * Tests for the review fixes on PR #114:
+ * - Legacy migration must preserve plaintext secrets until the startup seal
+ *   migration encrypts them (was: stripped before the migration could see
+ *   them — silent credential loss on upgrade).
+ * - Persistence must not strip plaintext from connections whose seal attempt
+ *   failed (markSealFailed): any unrelated write would otherwise destroy the
+ *   only surviving copy.
+ * - The plaintext filter must use the same sealed-format predicate as the
+ *   crypto layer (isSealed), so plaintext like "v1:foo" is still stripped.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  ConnectionStorageManager,
+  markSealFailed,
+  clearSealFailed,
+  type ConnectionData,
+} from '../lib/connection-storage';
+import { isSealed } from '../lib/credential-crypto';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+const baseConnection = {
+  name: 'My Server',
+  host: '192.168.1.1',
+  port: 22,
+  username: 'admin',
+  protocol: 'SSH',
+  authMethod: 'password',
+  password: 'secret',
+};
+
+beforeEach(() => {
+  localStorage.clear();
+  vi.clearAllMocks();
+});
+
+describe('connection storage: legacy migration keeps plaintext', () => {
+  it('migrates legacy sessions verbatim, plaintext included', () => {
+    localStorage.setItem('r-shell-sessions', JSON.stringify([
+      { id: 'l1', name: 'Old', host: 'h', port: 22, username: 'u', protocol: 'SSH', authMethod: 'password', password: 'legacy-pass' },
+    ]));
+    ConnectionStorageManager.initialize();
+
+    const stored = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]');
+    expect(stored).toHaveLength(1);
+    expect(stored[0].password).toBe('legacy-pass');
+  });
+});
+
+describe('connection storage: seal-failure protection', () => {
+  it('keeps plaintext for connections marked seal-failed', () => {
+    // Simulate the real scenario: sealing failed, so the plaintext is still
+    // in storage and the record is protected against strip-on-write.
+    localStorage.setItem('r-shell-connections', JSON.stringify([
+      { ...baseConnection, id: 'c1', createdAt: '2026-01-01', password: 'secret' },
+    ]));
+    markSealFailed('c1');
+
+    // Any persistence write (here: updateLastConnected) must not strip the
+    // plaintext while the record is protected.
+    ConnectionStorageManager.updateLastConnected('c1');
+    const stored = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]');
+    expect(stored.find((c: ConnectionData) => c.id === 'c1').password).toBe('secret');
+  });
+
+  it('strips plaintext again once the seal succeeds', () => {
+    localStorage.setItem('r-shell-connections', JSON.stringify([
+      { ...baseConnection, id: 'c2', createdAt: '2026-01-01', password: 'secret' },
+    ]));
+    markSealFailed('c2');
+    ConnectionStorageManager.updateLastConnected('c2');
+    expect(JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]').find((c: ConnectionData) => c.id === 'c2').password).toBe('secret');
+
+    clearSealFailed('c2');
+    ConnectionStorageManager.updateLastConnected('c2');
+    const stored = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]');
+    expect(stored.find((c: ConnectionData) => c.id === 'c2').password).toBeUndefined();
+  });
+});
+
+describe('connection storage: sealed-format validation', () => {
+  it('strips 2-segment v1-lookalike plaintext (isSealed parity)', () => {
+    ConnectionStorageManager.saveConnectionWithId('c3', { ...baseConnection, id: 'c3', createdAt: '2026-01-01', password: 'v1:password' } as ConnectionData);
+    const stored = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]');
+    expect(stored.find((c: ConnectionData) => c.id === 'c3').password).toBeUndefined();
+  });
+
+  it('passes sealed values through unchanged', () => {
+    ConnectionStorageManager.saveConnectionWithId('c4', { ...baseConnection, id: 'c4', createdAt: '2026-01-01', password: 'v1:AAAABBBB:CCCCDDDD' } as ConnectionData);
+    const stored = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]');
+    expect(stored.find((c: ConnectionData) => c.id === 'c4').password).toBe('v1:AAAABBBB:CCCCDDDD');
+  });
+});

--- a/src/__tests__/connection-storage-proxy.test.ts
+++ b/src/__tests__/connection-storage-proxy.test.ts
@@ -1,10 +1,27 @@
 /**
  * Regression tests: proxy settings must round-trip through connection
  * storage so a proxy configured on a connection survives connection
- * attempts and reappears when the connection is edited.
+ * attempts and reappears when the connection is edited. Secrets are stored
+ * encrypted (sealed) — the round-trip asserts ciphertext, never plaintext.
  */
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ConnectionStorageManager, type ConnectionData } from '../lib/connection-storage';
+import { sealSecret, isSealed } from '../lib/credential-crypto';
+
+// Test-double for the Rust credential_seal command: deterministic reversible
+// transform so assertions can verify ciphertext round-trips without crypto.
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string, args: { secret?: string; sealed?: string }) => {
+    if (command === 'credential_seal') {
+      return `v1:test:${btoa(encodeURIComponent(args.secret ?? ''))}`;
+    }
+    if (command === 'credential_open') {
+      const payload = (args.sealed ?? '').split(':')[2] ?? '';
+      return decodeURIComponent(atob(payload));
+    }
+    return {};
+  }),
+}));
 
 const proxyFields: Partial<ConnectionData> = {
   proxyType: 'http',
@@ -24,16 +41,32 @@ const baseConnection: Omit<ConnectionData, 'id' | 'createdAt'> = {
   password: 'secret',
 };
 
+/** Seal all plaintext secrets on a fields object (in place). */
+async function sealFields(fields: Partial<ConnectionData>): Promise<Partial<ConnectionData>> {
+  const sealed = { ...fields };
+  if (typeof sealed.password === 'string' && sealed.password) sealed.password = await sealSecret(sealed.password);
+  if (typeof sealed.passphrase === 'string' && sealed.passphrase) sealed.passphrase = await sealSecret(sealed.passphrase);
+  if (typeof sealed.proxyPassword === 'string' && sealed.proxyPassword) sealed.proxyPassword = await sealSecret(sealed.proxyPassword);
+  if (typeof sealed.vncPassword === 'string' && sealed.vncPassword) sealed.vncPassword = await sealSecret(sealed.vncPassword);
+  return sealed;
+}
+
+/** The stored value must be ciphertext (v1 sealed), never the plaintext. */
+function expectSealed(value: unknown, plaintext: string): void {
+  expect(isSealed(value)).toBe(true);
+  expect(value as string).not.toContain(plaintext);
+}
+
 beforeEach(() => {
   localStorage.clear();
   ConnectionStorageManager.initialize();
 });
 
 describe('connection-storage proxy round-trip', () => {
-  it('saveConnection persists proxy fields', () => {
+  it('saveConnection persists proxy fields as ciphertext', async () => {
     const conn = ConnectionStorageManager.saveConnection({
-      ...baseConnection,
-      ...proxyFields,
+      ...(await sealFields(baseConnection)),
+      ...(await sealFields(proxyFields)),
     });
 
     const loaded = ConnectionStorageManager.getConnection(conn.id);
@@ -41,13 +74,14 @@ describe('connection-storage proxy round-trip', () => {
     expect(loaded?.proxyHost).toBe('proxy.example.com');
     expect(loaded?.proxyPort).toBe(3128);
     expect(loaded?.proxyUsername).toBe('proxyuser');
-    expect(loaded?.proxyPassword).toBe('proxypass');
+    expectSealed(loaded?.proxyPassword, 'proxypass');
+    expectSealed(loaded?.password, 'secret');
   });
 
-  it('saveConnectionWithId persists proxy fields', () => {
+  it('saveConnectionWithId persists proxy fields as ciphertext', async () => {
     const conn = ConnectionStorageManager.saveConnectionWithId('conn-proxy-1', {
       ...baseConnection,
-      ...proxyFields,
+      ...(await sealFields(proxyFields)),
     });
 
     const loaded = ConnectionStorageManager.getConnection('conn-proxy-1');
@@ -55,25 +89,26 @@ describe('connection-storage proxy round-trip', () => {
     expect(loaded?.proxyHost).toBe('proxy.example.com');
     expect(loaded?.proxyPort).toBe(3128);
     expect(loaded?.proxyUsername).toBe('proxyuser');
-    expect(loaded?.proxyPassword).toBe('proxypass');
+    expectSealed(loaded?.proxyPassword, 'proxypass');
     expect(conn.id).toBe('conn-proxy-1');
   });
 
-  it('updateConnection merges proxy fields without dropping existing ones', () => {
+  it('updateConnection merges proxy fields without dropping existing ones', async () => {
     // Seed without proxy, then persist proxy via updateConnection (the flow
     // taken by the dialog's save / connect-with-failure paths).
-    const conn = ConnectionStorageManager.saveConnection(baseConnection);
-    ConnectionStorageManager.updateConnection(conn.id, proxyFields);
+    const conn = ConnectionStorageManager.saveConnection(await sealFields(baseConnection) as Omit<ConnectionData, 'id' | 'createdAt'>);
+    ConnectionStorageManager.updateConnection(conn.id, await sealFields(proxyFields));
 
     const loaded = ConnectionStorageManager.getConnection(conn.id);
     expect(loaded?.proxyType).toBe('http');
     expect(loaded?.proxyHost).toBe('proxy.example.com');
     expect(loaded?.proxyPort).toBe(3128);
     expect(loaded?.proxyUsername).toBe('proxyuser');
-    expect(loaded?.proxyPassword).toBe('proxypass');
-    // Existing non-proxy fields are preserved by the merge
+    expectSealed(loaded?.proxyPassword, 'proxypass');
+    // Existing non-proxy fields are preserved by the merge; the password
+    // stays sealed through the update.
     expect(loaded?.name).toBe('My Server');
-    expect(loaded?.password).toBe('secret');
+    expectSealed(loaded?.password, 'secret');
   });
 
   it('connections without proxy keep proxyType undefined in storage', () => {
@@ -82,5 +117,18 @@ describe('connection-storage proxy round-trip', () => {
     const loaded = ConnectionStorageManager.getConnection(conn.id);
     expect(loaded?.proxyType).toBeUndefined();
     expect(loaded?.proxyHost).toBeUndefined();
+  });
+
+  it('strips unencrypted plaintext secrets as a defensive guarantee', () => {
+    // A caller that forgets to seal must not leak plaintext into storage.
+    ConnectionStorageManager.saveConnectionWithId('conn-plain', {
+      ...baseConnection,
+      ...proxyFields,
+    });
+
+    const loaded = ConnectionStorageManager.getConnection('conn-plain');
+    expect(loaded?.proxyPassword).toBeUndefined();
+    expect(loaded?.password).toBeUndefined();
+    expect(localStorage.getItem('r-shell-connections')).not.toContain('proxypass');
   });
 });

--- a/src/__tests__/connection-storage-sftp-ftp.property.test.ts
+++ b/src/__tests__/connection-storage-sftp-ftp.property.test.ts
@@ -2,9 +2,19 @@
  * Task 1.5 — Property tests for connection storage with SFTP/FTP profiles
  * Task 1.6 — Unit tests for connection storage SFTP/FTP support
  */
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import * as fc from 'fast-check';
 import { ConnectionStorageManager, type ConnectionData } from '../lib/connection-storage';
+import { sealSecret } from '../lib/credential-crypto';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string, args: { secret?: string }) => {
+    if (command === 'credential_seal') {
+      return `v1:test:${btoa(encodeURIComponent(args.secret ?? ''))}`;
+    }
+    return {};
+  }),
+}));
 
 // ── Setup ──
 
@@ -29,6 +39,14 @@ const arbitraryConnectionInput = fc.record({
   password: fc.option(fc.string({ minLength: 1, maxLength: 30 }), { nil: undefined }),
   ftpsEnabled: fc.option(fc.boolean(), { nil: undefined }),
 });
+
+
+/** The stored value must be ciphertext (v1 sealed), never the plaintext. */
+function expectSealed(value: unknown, plaintext: string): void {
+  expect(typeof value).toBe('string');
+  expect(value as string).toMatch(/^v1:[A-Za-z0-9+/=]+:[A-Za-z0-9+/=]+$/);
+  expect(value as string).not.toContain(plaintext);
+}
 
 describe('connection-storage SFTP/FTP property tests', () => {
   // Property 4: Connection storage round trip
@@ -55,7 +73,7 @@ describe('connection-storage SFTP/FTP property tests', () => {
       );
     });
 
-    it('saved SFTP connection preserves publickey auth fields', () => {
+    it('saved SFTP connection preserves publickey auth fields', async () => {
       const conn = ConnectionStorageManager.saveConnection({
         name: 'SFTP Test',
         host: '10.0.0.1',
@@ -64,14 +82,14 @@ describe('connection-storage SFTP/FTP property tests', () => {
         protocol: 'SFTP',
         authMethod: 'publickey',
         privateKeyPath: '~/.ssh/id_ed25519',
-        passphrase: 'my-passphrase',
+        passphrase: await sealSecret('my-passphrase'),
       });
 
       const loaded = ConnectionStorageManager.getConnection(conn.id);
       expect(loaded!.protocol).toBe('SFTP');
       expect(loaded!.authMethod).toBe('publickey');
       expect(loaded!.privateKeyPath).toBe('~/.ssh/id_ed25519');
-      expect(loaded!.passphrase).toBe('my-passphrase');
+      expectSealed(loaded!.passphrase, 'my-passphrase');
     });
 
     it('saved FTP connection preserves ftpsEnabled and anonymous auth', () => {

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -148,7 +148,9 @@ export function ConnectionDialog({
     passphrase: string;
     proxyPassword: string;
     vncPassword: string;
-  }>({ password: '', passphrase: '', proxyPassword: '', vncPassword: '' });
+    tunnelPassword: string;
+    tunnelPassphrase: string;
+  }>({ password: '', passphrase: '', proxyPassword: '', vncPassword: '', tunnelPassword: '', tunnelPassphrase: '' });
 
   // Track number input display values separately from config to allow
   // the field to be empty while editing — React controlled inputs need
@@ -225,6 +227,8 @@ export function ConnectionDialog({
           passphrase: editingConnection.passphrase ?? '',
           proxyPassword: editingConnection.proxyPassword ?? '',
           vncPassword: editingConnection.vncPassword ?? '',
+          tunnelPassword: editingConnection.tunnelPassword ?? '',
+          tunnelPassphrase: editingConnection.tunnelPassphrase ?? '',
         });
         const merged = mergeWithDefaults(defaultConfig, editingConnection);
         // Stored secrets are never echoed back into the form: the fields stay
@@ -233,6 +237,8 @@ export function ConnectionDialog({
         merged.passphrase = '';
         merged.proxyPassword = '';
         merged.vncPassword = '';
+        merged.tunnelPassword = '';
+        merged.tunnelPassphrase = '';
         setConfig(merged);
         syncDisplayValues({
           port: editingConnection.port ?? 22,
@@ -318,12 +324,14 @@ export function ConnectionDialog({
    * "replace". Returns the secret values ready for persistence — already
    * encrypted (sealed) so plaintext never reaches localStorage.
    */
-  const resolveSecretsForSave = async (): Promise<Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>> => {
-    const result: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'> = {
+  const resolveSecretsForSave = async (): Promise<Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword' | 'tunnelPassword' | 'tunnelPassphrase'>> => {
+    const result: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword' | 'tunnelPassword' | 'tunnelPassphrase'> = {
       password: '',
       passphrase: '',
       proxyPassword: '',
       vncPassword: '',
+      tunnelPassword: '',
+      tunnelPassphrase: '',
     };
     for (const field of SECRET_FIELDS) {
       const typed = (config[field] ?? '').trim();
@@ -377,7 +385,7 @@ export function ConnectionDialog({
     // Encrypt secrets for persistence (blank field = keep stored value).
     // The connect request below uses the plaintext `config` as before — only
     // the saved payload carries ciphertext.
-    let sealedSecrets: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>;
+    let sealedSecrets: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword' | 'tunnelPassword' | 'tunnelPassphrase'>;
     try {
       sealedSecrets = await resolveSecretsForSave();
     } catch {
@@ -415,9 +423,9 @@ export function ConnectionDialog({
             tunnelPort: config.tunnelPort,
             tunnelUsername: config.tunnelUsername,
             tunnelAuthMethod: config.tunnelAuthMethod,
-            tunnelPassword: config.tunnelPassword,
+            tunnelPassword: sealedSecrets.tunnelPassword,
             tunnelKeyPath: config.tunnelKeyPath,
-            tunnelPassphrase: config.tunnelPassphrase,
+            tunnelPassphrase: sealedSecrets.tunnelPassphrase,
             proxyPassword: sealedSecrets.proxyPassword,
             compression: config.compression,
             keepAlive: config.keepAlive,
@@ -450,9 +458,9 @@ export function ConnectionDialog({
             tunnelPort: config.tunnelPort,
             tunnelUsername: config.tunnelUsername,
             tunnelAuthMethod: config.tunnelAuthMethod,
-            tunnelPassword: config.tunnelPassword,
+            tunnelPassword: sealedSecrets.tunnelPassword,
             tunnelKeyPath: config.tunnelKeyPath,
-            tunnelPassphrase: config.tunnelPassphrase,
+            tunnelPassphrase: sealedSecrets.tunnelPassphrase,
             proxyPassword: sealedSecrets.proxyPassword,
             compression: config.compression,
             keepAlive: config.keepAlive,
@@ -500,9 +508,9 @@ export function ConnectionDialog({
         tunnelPort: config.tunnelPort,
         tunnelUsername: config.tunnelUsername,
         tunnelAuthMethod: config.tunnelAuthMethod,
-        tunnelPassword: config.tunnelPassword,
+        tunnelPassword: sealedSecrets.tunnelPassword,
         tunnelKeyPath: config.tunnelKeyPath,
-        tunnelPassphrase: config.tunnelPassphrase,
+        tunnelPassphrase: sealedSecrets.tunnelPassphrase,
         proxyPassword: sealedSecrets.proxyPassword,
         compression: config.compression,
         keepAlive: config.keepAlive,
@@ -531,9 +539,9 @@ export function ConnectionDialog({
         tunnelPort: config.tunnelPort,
         tunnelUsername: config.tunnelUsername,
         tunnelAuthMethod: config.tunnelAuthMethod,
-        tunnelPassword: config.tunnelPassword,
+        tunnelPassword: sealedSecrets.tunnelPassword,
         tunnelKeyPath: config.tunnelKeyPath,
-        tunnelPassphrase: config.tunnelPassphrase,
+        tunnelPassphrase: sealedSecrets.tunnelPassphrase,
         proxyPassword: sealedSecrets.proxyPassword,
         compression: config.compression,
         keepAlive: config.keepAlive,
@@ -636,7 +644,7 @@ const handleCancelConnectionAttempt = async () => {
     if (!editingConnection?.id) return;
 
     // Encrypt secrets for persistence (blank field = keep stored value).
-    let sealed: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>;
+    let sealed: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword' | 'tunnelPassword' | 'tunnelPassphrase'>;
     try {
       sealed = await resolveSecretsForSave();
     } catch {
@@ -665,9 +673,9 @@ const handleCancelConnectionAttempt = async () => {
       tunnelPort: config.tunnelPort,
       tunnelUsername: config.tunnelUsername,
       tunnelAuthMethod: config.tunnelAuthMethod,
-      tunnelPassword: config.tunnelPassword,
+      tunnelPassword: sealed.tunnelPassword,
       tunnelKeyPath: config.tunnelKeyPath,
-      tunnelPassphrase: config.tunnelPassphrase,
+      tunnelPassphrase: sealed.tunnelPassphrase,
       proxyPassword: sealed.proxyPassword,
       compression: config.compression,
       keepAlive: config.keepAlive,
@@ -1231,6 +1239,11 @@ const handleCancelConnectionAttempt = async () => {
                               value={config.tunnelPassword}
                               onChange={(e) => updateConfig({ tunnelPassword: e.target.value })}
                             />
+                            {previousSecrets.tunnelPassword && (
+                              <p className="text-xs text-muted-foreground">
+                                {t('connectionDialog.hint.savedPasswordKept')}
+                              </p>
+                            )}
                           </div>
                         )}
 
@@ -1253,6 +1266,11 @@ const handleCancelConnectionAttempt = async () => {
                                 value={config.tunnelPassphrase}
                                 onChange={(e) => updateConfig({ tunnelPassphrase: e.target.value })}
                               />
+                              {previousSecrets.tunnelPassphrase && (
+                                <p className="text-xs text-muted-foreground">
+                                  {t('connectionDialog.hint.savedPasswordKept')}
+                                </p>
+                              )}
                             </div>
                           </>
                         )}

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -15,6 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/
 import { Separator } from './ui/separator';
 import { ConnectionProfileManager, type ConnectionProfile } from '../lib/connection-profiles';
 import { ConnectionStorageManager } from '../lib/connection-storage';
+import { SECRET_FIELDS, sealSecret } from '../lib/credential-crypto';
 import { buildSshConnectRequest } from '../lib/ssh-connect-request';
 import { toast } from 'sonner';
 import {
@@ -81,6 +82,7 @@ export interface ConnectionConfig {
 
   // VNC specific
   vncColorDepth?: '24' | '16' | '8';
+  vncPassword?: string;
 }
 
 /**
@@ -138,6 +140,15 @@ export function ConnectionDialog({
   };
 
   const [config, setConfig] = useState<ConnectionConfig>(defaultConfig);
+  // Sealed secrets of the connection being edited (empty for a new one). A
+  // blank form field on save resolves back to these — plaintext is never
+  // echoed into the form.
+  const [previousSecrets, setPreviousSecrets] = useState<{
+    password: string;
+    passphrase: string;
+    proxyPassword: string;
+    vncPassword: string;
+  }>({ password: '', passphrase: '', proxyPassword: '', vncPassword: '' });
 
   // Track number input display values separately from config to allow
   // the field to be empty while editing — React controlled inputs need
@@ -207,7 +218,22 @@ export function ConnectionDialog({
       // connection never stored (advanced/proxy options), matching the
       // pre-filled values a new connection gets.
       if (editingConnection) {
-        setConfig(mergeWithDefaults(defaultConfig, editingConnection));
+        // Remember the stored (sealed) secrets so a blank field on save means
+        // "keep the stored one". The form itself never shows them.
+        setPreviousSecrets({
+          password: editingConnection.password ?? '',
+          passphrase: editingConnection.passphrase ?? '',
+          proxyPassword: editingConnection.proxyPassword ?? '',
+          vncPassword: editingConnection.vncPassword ?? '',
+        });
+        const merged = mergeWithDefaults(defaultConfig, editingConnection);
+        // Stored secrets are never echoed back into the form: the fields stay
+        // empty with a hint below. Typing a new value replaces the stored one.
+        merged.password = '';
+        merged.passphrase = '';
+        merged.proxyPassword = '';
+        merged.vncPassword = '';
+        setConfig(merged);
         syncDisplayValues({
           port: editingConnection.port ?? 22,
           proxyPort: editingConnection.proxyPort ?? 8080,
@@ -284,6 +310,39 @@ export function ConnectionDialog({
     cancelRequestedRef.current = false;
   }
 
+  /**
+   * UX contract for stored secrets: a saved password is NEVER shown back to
+   * the user. When editing a connection that has one, the field stays empty
+   * with a hint ("leave blank to keep the saved password"). An empty field on
+   * save therefore means "keep whatever is stored"; a typed value means
+   * "replace". Returns the secret values ready for persistence — already
+   * encrypted (sealed) so plaintext never reaches localStorage.
+   */
+  const resolveSecretsForSave = async (): Promise<Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>> => {
+    const result: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'> = {
+      password: '',
+      passphrase: '',
+      proxyPassword: '',
+      vncPassword: '',
+    };
+    for (const field of SECRET_FIELDS) {
+      const typed = (config[field] ?? '').trim();
+      if (typed.length === 0) {
+        // Field left blank → keep the previously stored (sealed) value.
+        result[field] = previousSecrets[field];
+      } else {
+        // User typed a new value → seal it for storage.
+        try {
+          result[field] = await sealSecret(typed);
+        } catch (error) {
+          console.error(`[Credential] Failed to encrypt ${field}:`, error);
+          throw error; // surface to caller — do not persist plaintext
+        }
+      }
+    }
+    return result;
+  };
+
   const handleConnect = async () => {
     if (isConnecting) {
       return;
@@ -315,6 +374,18 @@ export function ConnectionDialog({
     // An empty public key path is allowed too: the backend falls back to the
     // user's default key (~/.ssh/id_rsa, then id_ed25519).
 
+    // Encrypt secrets for persistence (blank field = keep stored value).
+    // The connect request below uses the plaintext `config` as before — only
+    // the saved payload carries ciphertext.
+    let sealedSecrets: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>;
+    try {
+      sealedSecrets = await resolveSecretsForSave();
+    } catch {
+      toast.error(t('connectionDialog.toast.credentialSyncFailed'));
+      resetConnectionState();
+      return;
+    }
+
     // For SFTP/FTP/RDP/VNC protocols, delegate connection to App.tsx (via onConnect)
     // which calls the appropriate Tauri commands.
     const isSftpOrFtp = config.protocol === 'SFTP' || config.protocol === 'FTP';
@@ -331,15 +402,14 @@ export function ConnectionDialog({
             username: config.username,
             protocol: config.protocol,
             authMethod: config.authMethod,
-            password: config.password,
+            password: sealedSecrets.password,
             privateKeyPath: config.privateKeyPath,
-            passphrase: config.passphrase,
+            passphrase: sealedSecrets.passphrase,
             ftpsEnabled: config.ftpsEnabled,
             proxyType: config.proxyType,
             proxyHost: config.proxyHost,
             proxyPort: config.proxyPort,
             proxyUsername: config.proxyUsername,
-            proxyPassword: config.proxyPassword,
             tunnelEnabled: config.tunnelEnabled,
             tunnelHost: config.tunnelHost,
             tunnelPort: config.tunnelPort,
@@ -348,6 +418,7 @@ export function ConnectionDialog({
             tunnelPassword: config.tunnelPassword,
             tunnelKeyPath: config.tunnelKeyPath,
             tunnelPassphrase: config.tunnelPassphrase,
+            proxyPassword: sealedSecrets.proxyPassword,
             compression: config.compression,
             keepAlive: config.keepAlive,
             keepAliveInterval: config.keepAliveInterval,
@@ -366,15 +437,14 @@ export function ConnectionDialog({
             protocol: config.protocol,
             folder: connectionFolder,
             authMethod: config.authMethod,
-            password: config.password,
+            password: sealedSecrets.password,
             privateKeyPath: config.privateKeyPath,
-            passphrase: config.passphrase,
+            passphrase: sealedSecrets.passphrase,
             ftpsEnabled: config.ftpsEnabled,
             proxyType: config.proxyType,
             proxyHost: config.proxyHost,
             proxyPort: config.proxyPort,
             proxyUsername: config.proxyUsername,
-            proxyPassword: config.proxyPassword,
             tunnelEnabled: config.tunnelEnabled,
             tunnelHost: config.tunnelHost,
             tunnelPort: config.tunnelPort,
@@ -383,6 +453,7 @@ export function ConnectionDialog({
             tunnelPassword: config.tunnelPassword,
             tunnelKeyPath: config.tunnelKeyPath,
             tunnelPassphrase: config.tunnelPassphrase,
+            proxyPassword: sealedSecrets.proxyPassword,
             compression: config.compression,
             keepAlive: config.keepAlive,
             keepAliveInterval: config.keepAliveInterval,
@@ -417,14 +488,13 @@ export function ConnectionDialog({
         username: config.username,
         protocol: config.protocol,
         authMethod: config.authMethod,
-        password: config.password,
+        password: sealedSecrets.password,
         privateKeyPath: config.privateKeyPath,
-        passphrase: config.passphrase,
+        passphrase: sealedSecrets.passphrase,
         proxyType: config.proxyType,
         proxyHost: config.proxyHost,
         proxyPort: config.proxyPort,
         proxyUsername: config.proxyUsername,
-        proxyPassword: config.proxyPassword,
         tunnelEnabled: config.tunnelEnabled,
         tunnelHost: config.tunnelHost,
         tunnelPort: config.tunnelPort,
@@ -433,6 +503,7 @@ export function ConnectionDialog({
         tunnelPassword: config.tunnelPassword,
         tunnelKeyPath: config.tunnelKeyPath,
         tunnelPassphrase: config.tunnelPassphrase,
+        proxyPassword: sealedSecrets.proxyPassword,
         compression: config.compression,
         keepAlive: config.keepAlive,
         keepAliveInterval: config.keepAliveInterval,
@@ -448,14 +519,13 @@ export function ConnectionDialog({
         protocol: config.protocol,
         folder: connectionFolder,
         authMethod: config.authMethod,
-        password: config.password,
+        password: sealedSecrets.password,
         privateKeyPath: config.privateKeyPath,
-        passphrase: config.passphrase,
+        passphrase: sealedSecrets.passphrase,
         proxyType: config.proxyType,
         proxyHost: config.proxyHost,
         proxyPort: config.proxyPort,
         proxyUsername: config.proxyUsername,
-        proxyPassword: config.proxyPassword,
         tunnelEnabled: config.tunnelEnabled,
         tunnelHost: config.tunnelHost,
         tunnelPort: config.tunnelPort,
@@ -464,6 +534,7 @@ export function ConnectionDialog({
         tunnelPassword: config.tunnelPassword,
         tunnelKeyPath: config.tunnelKeyPath,
         tunnelPassphrase: config.tunnelPassphrase,
+        proxyPassword: sealedSecrets.proxyPassword,
         compression: config.compression,
         keepAlive: config.keepAlive,
         keepAliveInterval: config.keepAliveInterval,
@@ -564,6 +635,15 @@ const handleCancelConnectionAttempt = async () => {
   const handleSave = async () => {
     if (!editingConnection?.id) return;
 
+    // Encrypt secrets for persistence (blank field = keep stored value).
+    let sealed: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword'>;
+    try {
+      sealed = await resolveSecretsForSave();
+    } catch {
+      toast.error(t('connectionDialog.toast.credentialSyncFailed'));
+      return;
+    }
+
     // Save updated connection to storage
     ConnectionStorageManager.updateConnection(editingConnection.id, {
       name: config.name,
@@ -572,15 +652,14 @@ const handleCancelConnectionAttempt = async () => {
       username: config.username,
       protocol: config.protocol,
       authMethod: config.authMethod,
-      password: config.password,
+      password: sealed.password,
       privateKeyPath: config.privateKeyPath,
-      passphrase: config.passphrase,
+      passphrase: sealed.passphrase,
       ftpsEnabled: config.ftpsEnabled,
       proxyType: config.proxyType,
       proxyHost: config.proxyHost,
       proxyPort: config.proxyPort,
       proxyUsername: config.proxyUsername,
-      proxyPassword: config.proxyPassword,
       tunnelEnabled: config.tunnelEnabled,
       tunnelHost: config.tunnelHost,
       tunnelPort: config.tunnelPort,
@@ -589,6 +668,7 @@ const handleCancelConnectionAttempt = async () => {
       tunnelPassword: config.tunnelPassword,
       tunnelKeyPath: config.tunnelKeyPath,
       tunnelPassphrase: config.tunnelPassphrase,
+      proxyPassword: sealed.proxyPassword,
       compression: config.compression,
       keepAlive: config.keepAlive,
       keepAliveInterval: config.keepAliveInterval,
@@ -881,10 +961,19 @@ const handleCancelConnectionAttempt = async () => {
                     <Label htmlFor="password">{t('connectionDialog.label.password')}</Label>
                     <PasswordInput
                       id="password"
-                      placeholder={t('connectionDialog.placeholder.password')}
+                      placeholder={
+                        previousSecrets.password
+                          ? t('connectionDialog.placeholder.savedPassword')
+                          : t('connectionDialog.placeholder.password')
+                      }
                       value={config.password}
                       onChange={(e) => updateConfig({ password: e.target.value })}
                     />
+                    {previousSecrets.password && (
+                      <p className="text-xs text-muted-foreground">
+                        {t('connectionDialog.hint.savedPasswordKept')}
+                      </p>
+                    )}
                   </div>
                 )}
 

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -15,7 +15,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from './ui/
 import { Separator } from './ui/separator';
 import { ConnectionProfileManager, type ConnectionProfile } from '../lib/connection-profiles';
 import { ConnectionStorageManager } from '../lib/connection-storage';
-import { SECRET_FIELDS, sealSecret } from '../lib/credential-crypto';
+import { SECRET_FIELDS, sealSecret, openSecret } from '../lib/credential-crypto';
 import { buildSshConnectRequest } from '../lib/ssh-connect-request';
 import { toast } from 'sonner';
 import {
@@ -102,6 +102,30 @@ function mergeWithDefaults(defaults: ConnectionConfig, overrides: ConnectionConf
   return merged;
 }
 
+/**
+ * Sealed secret fields carried over from the connection being edited, so a
+ * blank form field on save means "keep the stored one". Empty for a new
+ * connection — reset on dialog open/close so secrets never leak across
+ * connections.
+ */
+interface StoredSecrets {
+  password: string;
+  passphrase: string;
+  proxyPassword: string;
+  vncPassword: string;
+  tunnelPassword: string;
+  tunnelPassphrase: string;
+}
+
+const EMPTY_STORED_SECRETS: StoredSecrets = {
+  password: '',
+  passphrase: '',
+  proxyPassword: '',
+  vncPassword: '',
+  tunnelPassword: '',
+  tunnelPassphrase: '',
+};
+
 export function ConnectionDialog({
   open,
   onOpenChange,
@@ -143,14 +167,7 @@ export function ConnectionDialog({
   // Sealed secrets of the connection being edited (empty for a new one). A
   // blank form field on save resolves back to these — plaintext is never
   // echoed into the form.
-  const [previousSecrets, setPreviousSecrets] = useState<{
-    password: string;
-    passphrase: string;
-    proxyPassword: string;
-    vncPassword: string;
-    tunnelPassword: string;
-    tunnelPassphrase: string;
-  }>({ password: '', passphrase: '', proxyPassword: '', vncPassword: '', tunnelPassword: '', tunnelPassphrase: '' });
+  const [previousSecrets, setPreviousSecrets] = useState<StoredSecrets>(EMPTY_STORED_SECRETS);
 
   // Track number input display values separately from config to allow
   // the field to be empty while editing — React controlled inputs need
@@ -250,14 +267,18 @@ export function ConnectionDialog({
         // When editing, don't show "save as connection" since it already exists
         setSaveAsConnection(false);
       } else {
-        // Reset to defaults for new connection
+        // Reset to defaults for a new connection. Clear previousSecrets too:
+        // it survives dialog reopens, so after editing connection A a blank
+        // field on connection B would silently resolve to A's stored secrets.
         setConfig(defaultConfig);
+        setPreviousSecrets(EMPTY_STORED_SECRETS);
         setSaveAsConnection(true);
         syncDisplayValues(initialDisplayValues);
       }
     } else {
       // Reset connection state when dialog closes
       resetConnectionState();
+      setPreviousSecrets(EMPTY_STORED_SECRETS);
     }
   }, [open, editingConnection, initialFolder]);
 
@@ -334,7 +355,11 @@ export function ConnectionDialog({
       tunnelPassphrase: '',
     };
     for (const field of SECRET_FIELDS) {
-      const typed = (config[field] ?? '').trim();
+      // Use the value as typed — never trim it. Leading/trailing whitespace
+      // can be part of a credential, and the connect request below sends the
+      // unmodified `config` value, so trimming here would store a different
+      // secret than the one that just authenticated.
+      const typed = config[field] ?? '';
       if (typed.length === 0) {
         // Field left blank → keep the previously stored (sealed) value.
         result[field] = previousSecrets[field];
@@ -383,8 +408,6 @@ export function ConnectionDialog({
     // user's default key (~/.ssh/id_rsa, then id_ed25519).
 
     // Encrypt secrets for persistence (blank field = keep stored value).
-    // The connect request below uses the plaintext `config` as before — only
-    // the saved payload carries ciphertext.
     let sealedSecrets: Pick<ConnectionConfig, 'password' | 'passphrase' | 'proxyPassword' | 'vncPassword' | 'tunnelPassword' | 'tunnelPassphrase'>;
     try {
       sealedSecrets = await resolveSecretsForSave();
@@ -392,6 +415,23 @@ export function ConnectionDialog({
       toast.error(t('connectionDialog.toast.credentialSyncFailed'));
       resetConnectionState();
       return;
+    }
+
+    // Build the connect-only config. The form never echoes stored secrets, so
+    // a blank field while editing means "use the retained credential" — decrypt
+    // it here (plaintext exists transiently in memory only). The persisted
+    // payload above keeps the sealed form.
+    const connectConfig: ConnectionConfig = { ...config };
+    for (const field of SECRET_FIELDS) {
+      if (connectConfig[field] === '' && previousSecrets[field]) {
+        try {
+          connectConfig[field] = await openSecret(previousSecrets[field]);
+        } catch (error) {
+          // Decrypt failed (keychain hiccup etc.) — leave blank; auth will
+          // fail with a clear error rather than a wrong password.
+          console.error(`[Credential] Failed to decrypt ${field} for connect:`, error);
+        }
+      }
     }
 
     // For SFTP/FTP/RDP/VNC protocols, delegate connection to App.tsx (via onConnect)
@@ -473,7 +513,7 @@ export function ConnectionDialog({
         }
 
         // Delegate actual connection to App.tsx handler
-        onConnect({ ...config, id: connectionId });
+        onConnect({ ...connectConfig, id: connectionId });
         onOpenChange(false);
 
         if (!editingConnection) {
@@ -554,13 +594,13 @@ export function ConnectionDialog({
       const result = await invoke<{ success: boolean; error?: string }>(
         'ssh_connect',
         {
-          request: buildSshConnectRequest(connectionId, config),
+          request: buildSshConnectRequest(connectionId, connectConfig),
         }
       );
 
       if (result.success) {
         onConnect({
-          ...config,
+          ...connectConfig,
           id: connectionId
         });
         if (!editingConnection) {

--- a/src/lib/config-export-import.ts
+++ b/src/lib/config-export-import.ts
@@ -14,6 +14,7 @@ import {
   type ConnectionData,
   type ConnectionFolder,
 } from './connection-storage';
+import { SECRET_FIELDS } from './credential-crypto';
 import { ConnectionProfileManager, type ConnectionProfile } from './connection-profiles';
 import {
   loadAppearanceSettings,
@@ -71,6 +72,11 @@ export interface ImportResult {
  * JSON bundle to disk.  Returns `true` when the file was written, `false`
  * when the user cancelled the dialog.
  */
+// Secret fields that must never end up in an exported config bundle — not
+// even as ciphertext. Exported files are meant to be shareable; a stolen
+// master key would otherwise decrypt every exported credential.
+const EXPORT_STRIPPED_FIELDS = SECRET_FIELDS;
+
 export async function exportAllConfig(): Promise<boolean> {
   try {
     // 1. Build the bundle -------------------------------------------------------
@@ -81,17 +87,33 @@ export async function exportAllConfig(): Promise<boolean> {
       data: {},
     };
 
-    // Connections + folders
+    // Connections + folders. Secret fields (plaintext AND sealed ciphertext)
+    // are stripped — an exported file must not carry credentials.
     const connections = ConnectionStorageManager.getConnections();
     const folders = ConnectionStorageManager.getFolders();
     if (connections.length || folders.length) {
-      bundle.data.connections = { connections, folders };
+      bundle.data.connections = {
+        connections: connections.map((c) => {
+          const clone = { ...c } as Record<string, unknown>;
+          for (const field of EXPORT_STRIPPED_FIELDS) {
+            delete clone[field];
+          }
+          return clone as unknown as typeof c;
+        }),
+        folders,
+      };
     }
 
-    // Connection profiles
+    // Connection profiles — strip secrets the same way.
     const profiles = ConnectionProfileManager.getProfiles();
     if (profiles.length) {
-      bundle.data.profiles = profiles;
+      bundle.data.profiles = profiles.map((p) => {
+        const clone = { ...p } as Record<string, unknown>;
+        for (const field of EXPORT_STRIPPED_FIELDS) {
+          delete clone[field];
+        }
+        return clone as unknown as typeof p;
+      });
     }
 
     // Terminal appearance

--- a/src/lib/connection-profiles.ts
+++ b/src/lib/connection-profiles.ts
@@ -2,6 +2,7 @@
  * Connection Profile Management
  * Handles saving, loading, and managing SSH connection profiles
  */
+import { SECRET_FIELDS } from './credential-crypto';
 
 export interface ConnectionProfile {
   id: string;
@@ -116,14 +117,20 @@ export class ConnectionProfileManager {
       
       const profiles = merge ? this.getProfiles() : [];
       
-      // Add imported profiles with new IDs to avoid conflicts
+      // Add imported profiles with new IDs to avoid conflicts. Bundles may
+      // predate export sanitization — never persist secrets coming from
+      // outside (storage secrets are handled by the startup seal migration).
       imported.forEach(profile => {
+        const clone = { ...profile } as Record<string, unknown>;
+        for (const field of SECRET_FIELDS) {
+          delete clone[field];
+        }
         profiles.push({
-          ...profile,
+          ...clone,
           id: crypto.randomUUID(),
           createdAt: new Date().toISOString(),
           updatedAt: new Date().toISOString(),
-        });
+        } as ConnectionProfile);
       });
       
       localStorage.setItem(STORAGE_KEY, JSON.stringify(profiles));

--- a/src/lib/connection-storage.ts
+++ b/src/lib/connection-storage.ts
@@ -2,6 +2,7 @@
  * Connection Storage Management
  * Handles saving, loading, and managing SSH connections with hierarchical organization
  */
+import { SECRET_FIELDS } from './credential-crypto';
 
 export interface ConnectionData {
   id: string;
@@ -98,6 +99,34 @@ const FOLDERS_STORAGE_KEY = 'r-shell-connection-folders';
 const LEGACY_SESSIONS_STORAGE_KEY = 'r-shell-sessions';
 const LEGACY_FOLDERS_STORAGE_KEY = 'r-shell-session-folders';
 
+/**
+ * Secret fields that must never be persisted as plaintext. Values in `v1:`
+ * sealed format (encrypted via the Rust credential_seal command) are fine;
+ * anything else non-empty is legacy plaintext and is stripped before writing.
+ */
+
+function stripUnencryptedSecrets(connection: ConnectionData): ConnectionData {
+  const clone = { ...connection };
+  for (const field of SECRET_FIELDS) {
+    const value = clone[field];
+    if (typeof value === 'string' && value.length > 0 && !value.startsWith('v1:')) {
+      delete clone[field];
+    }
+  }
+  return clone;
+}
+
+/**
+ * Single write path for the connections array: strips any unencrypted secret
+ * before it can reach localStorage. Sealed (encrypted) values pass through.
+ */
+function persistConnections(connections: ConnectionData[]): void {
+  localStorage.setItem(
+    CONNECTIONS_STORAGE_KEY,
+    JSON.stringify(connections.map(stripUnencryptedSecrets)),
+  );
+}
+
 export class ConnectionStorageManager {
   /**
    * Migrate data from old session storage to new connection storage
@@ -120,7 +149,7 @@ export class ConnectionStorageManager {
             ...session,
             folder: session.folder?.replace(/All Sessions/g, 'All Connections')
           }));
-          localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+          persistConnections(connections);
           console.log(`[Migration] Migrated ${connections.length} sessions to connections`);
         }
         
@@ -222,7 +251,7 @@ export class ConnectionStorageManager {
     };
 
     connections.push(newConnection);
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+    persistConnections(connections);
 
     return newConnection;
   }
@@ -253,7 +282,7 @@ export class ConnectionStorageManager {
       connections.push(newConnection);
     }
 
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+    persistConnections(connections);
 
     return newConnection;
   }
@@ -272,7 +301,7 @@ export class ConnectionStorageManager {
       ...updates,
     };
 
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+    persistConnections(connections);
     return connections[index];
   }
 
@@ -294,7 +323,7 @@ export class ConnectionStorageManager {
 
     if (filtered.length === connections.length) return false;
 
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(filtered));
+    persistConnections(filtered);
     return true;
   }
 
@@ -384,7 +413,7 @@ export class ConnectionStorageManager {
     }
 
     localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(folders));
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+    persistConnections(connections);
     return true;
   }
 
@@ -437,7 +466,7 @@ export class ConnectionStorageManager {
     }
 
     localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(folders));
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+    persistConnections(connections);
     return true;
   }
 
@@ -508,7 +537,7 @@ export class ConnectionStorageManager {
     if (filteredFolders.length === folders.length) return false;
 
     localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(filteredFolders));
-    localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(filteredConnections));
+    persistConnections(filteredConnections);
 
     return true;
   }
@@ -667,7 +696,7 @@ export class ConnectionStorageManager {
         });
       });
 
-      localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
+      persistConnections(connections);
       localStorage.setItem(FOLDERS_STORAGE_KEY, JSON.stringify(folders));
 
       return imported.connections.length;

--- a/src/lib/connection-storage.ts
+++ b/src/lib/connection-storage.ts
@@ -2,7 +2,7 @@
  * Connection Storage Management
  * Handles saving, loading, and managing SSH connections with hierarchical organization
  */
-import { SECRET_FIELDS } from './credential-crypto';
+import { SECRET_FIELDS, isSealed } from './credential-crypto';
 
 export interface ConnectionData {
   id: string;
@@ -105,11 +105,31 @@ const LEGACY_FOLDERS_STORAGE_KEY = 'r-shell-session-folders';
  * anything else non-empty is legacy plaintext and is stripped before writing.
  */
 
+/**
+ * Connections whose legacy plaintext secrets failed to seal (e.g. the OS
+ * keychain was unavailable). Their plaintext is the only surviving copy, so
+ * persistence must not strip it until sealing succeeds — otherwise any
+ * unrelated write (updateLastConnected, a folder move) would destroy it.
+ * Rewritten by `markSealFailed` / `clearSealFailed`.
+ */
+const sealFailedIds = new Set<string>();
+
+/** Mark a connection's plaintext as "do not strip until sealed". */
+export function markSealFailed(connectionId: string): void {
+  sealFailedIds.add(connectionId);
+}
+
+/** Remove the protection once the connection's secrets are sealed. */
+export function clearSealFailed(connectionId: string): void {
+  sealFailedIds.delete(connectionId);
+}
+
 function stripUnencryptedSecrets(connection: ConnectionData): ConnectionData {
   const clone = { ...connection };
+  const protectedRecord = connection.id !== undefined && sealFailedIds.has(connection.id);
   for (const field of SECRET_FIELDS) {
     const value = clone[field];
-    if (typeof value === 'string' && value.length > 0 && !value.startsWith('v1:')) {
+    if (typeof value === 'string' && value.length > 0 && !isSealed(value) && !protectedRecord) {
       delete clone[field];
     }
   }
@@ -149,7 +169,11 @@ export class ConnectionStorageManager {
             ...session,
             folder: session.folder?.replace(/All Sessions/g, 'All Connections')
           }));
-          persistConnections(connections);
+          // Write the migrated records verbatim — including plaintext secrets.
+          // `persistConnections` would strip them here, before the startup
+          // credential migration (App.tsx) ever sees them, destroying the only
+          // copy. The plaintext lands in the seal migration's path instead.
+          localStorage.setItem(CONNECTIONS_STORAGE_KEY, JSON.stringify(connections));
           console.log(`[Migration] Migrated ${connections.length} sessions to connections`);
         }
         

--- a/src/lib/credential-crypto.ts
+++ b/src/lib/credential-crypto.ts
@@ -1,0 +1,82 @@
+/**
+ * Credential encryption for locally stored connection secrets.
+ *
+ * Secrets (SSH passwords, key passphrases, proxy/VNC passwords) are encrypted
+ * with AES-256-GCM on the Rust side using an app master key that lives in the
+ * OS keychain (created on first use, one keychain entry for the whole app).
+ * Only the ciphertext is ever persisted to localStorage — plaintext secrets
+ * exist in memory transiently at connect time.
+ *
+ * Sealed format: `v1:<base64 nonce>:<base64 ciphertext>` (produced by the
+ * `credential_seal` Tauri command; `credential_open` reverses it).
+ */
+import { invoke } from '@tauri-apps/api/core';
+
+/** Secret field names on a connection object that are encrypted at rest. */
+export const SECRET_FIELDS = [
+  'password',
+  'passphrase',
+  'proxyPassword',
+  'vncPassword',
+] as const;
+
+export type SecretField = (typeof SECRET_FIELDS)[number];
+
+/** True when the value is an encrypted-at-rest secret (v1 sealed format). */
+export function isSealed(value: unknown): value is string {
+  return typeof value === 'string' && value.startsWith('v1:') && value.split(':').length === 3;
+}
+
+/** True when the value is legacy plaintext (anything non-empty that is not sealed). */
+export function isLegacyPlaintext(value: unknown): value is string {
+  return typeof value === 'string' && value.length > 0 && !isSealed(value);
+}
+
+/** Encrypt a plaintext secret for storage. */
+export async function sealSecret(plaintext: string): Promise<string> {
+  return invoke<string>('credential_seal', { secret: plaintext });
+}
+
+/** Decrypt a stored secret back to plaintext (connect time only). */
+export async function openSecret(sealed: string): Promise<string> {
+  return invoke<string>('credential_open', { sealed });
+}
+
+/**
+ * Encrypt every legacy-plaintext secret on a connection object in place.
+ * Returns true when at least one field was migrated.
+ */
+export async function sealLegacySecrets(
+  connection: Record<string, unknown> & { id: string },
+): Promise<boolean> {
+  let migrated = false;
+  for (const field of SECRET_FIELDS) {
+    const value = connection[field];
+    if (isLegacyPlaintext(value)) {
+      connection[field] = await sealSecret(value);
+      migrated = true;
+    }
+  }
+  return migrated;
+}
+
+/**
+ * Decrypt all sealed secret fields on a connection object in place, so the
+ * values can be used to build a connect request. Sealed fields that fail to
+ * decrypt are left as-is (the backend auth will fail with a clear error
+ * rather than silently sending a wrong password).
+ */
+export async function openConnectionSecrets(
+  connection: Record<string, unknown>,
+): Promise<void> {
+  for (const field of SECRET_FIELDS) {
+    const value = connection[field];
+    if (isSealed(value)) {
+      try {
+        connection[field] = await openSecret(value);
+      } catch (error) {
+        console.error(`[Credential] Failed to decrypt ${field}:`, error);
+      }
+    }
+  }
+}

--- a/src/lib/credential-crypto.ts
+++ b/src/lib/credential-crypto.ts
@@ -18,6 +18,8 @@ export const SECRET_FIELDS = [
   'passphrase',
   'proxyPassword',
   'vncPassword',
+  'tunnelPassword',
+  'tunnelPassphrase',
 ] as const;
 
 export type SecretField = (typeof SECRET_FIELDS)[number];

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -180,7 +180,8 @@
       "tunnelUsername": "jumpuser",
       "tunnelPassword": "Enter tunnel password",
       "tunnelKeyPath": "~/.ssh/id_ed25519",
-      "tunnelPassphrase": "Enter passphrase if key is encrypted"
+      "tunnelPassphrase": "Enter passphrase if key is encrypted",
+      "savedPassword": "Leave blank to keep saved password"
     },
     "authMethod": {
       "password": "Password",
@@ -255,11 +256,15 @@
       "connectionFailed": "Connection Failed",
       "connectionFailedDesc": "Unable to connect to the server. Please check your credentials and try again.",
       "connectionError": "Connection Error",
-      "connectionErrorDesc": "An unexpected error occurred while connecting."
+      "connectionErrorDesc": "An unexpected error occurred while connecting.",
+      "credentialSyncFailed": "Failed to encrypt and save the credentials"
     },
     "tunnel": {
       "enable": "Enable SSH Tunnel",
       "enableDesc": "Forward the connection through a jump host (bastion) to reach the target."
+    },
+    "hint": {
+      "savedPasswordKept": "A password is saved for this connection. Leave the field blank to keep it, or type a new password to replace it."
     }
   },
   "settings": {

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -180,7 +180,8 @@
       "tunnelUsername": "jumpuser",
       "tunnelPassword": "输入隧道密码",
       "tunnelKeyPath": "~/.ssh/id_ed25519",
-      "tunnelPassphrase": "密钥加密时输入密码"
+      "tunnelPassphrase": "密钥加密时输入密码",
+      "savedPassword": "留空保持已保存的密码"
     },
     "authMethod": {
       "password": "密码",
@@ -255,11 +256,15 @@
       "connectionFailed": "连接失败",
       "connectionFailedDesc": "无法连接到服务器，请检查您的凭据并重试。",
       "connectionError": "连接错误",
-      "connectionErrorDesc": "连接时发生意外错误。"
+      "connectionErrorDesc": "连接时发生意外错误。",
+      "credentialSyncFailed": "加密并保存凭据失败"
     },
     "tunnel": {
       "enable": "启用 SSH 隧道",
       "enableDesc": "通过跳板机（Bastion / Jump Host）转发到目标主机。"
+    },
+    "hint": {
+      "savedPasswordKept": "此连接已保存密码。留空保持不变，输入新密码即可替换。"
     }
   },
   "settings": {


### PR DESCRIPTION
## Summary

Encrypts connection secrets (SSH password, key passphrase, proxy password, VNC password) at rest. Previously these were stored in plaintext in the app's WebView `localStorage`; the export feature also wrote them into shareable files.

## Approach

Single app-level master key + AES-256-GCM:

- A random 32-byte **master key** is generated on first use and stored in the **OS keychain** (Rust `keyring` crate, one entry for the whole app → one authorization prompt, never per-credential).
- Secrets are persisted as `v1:<b64 nonce>:<b64 ciphertext>`. Plaintext only exists in memory transiently at connect time — **never written to `localStorage`**.
- **`persistConnections()`** is the single write path and strips any non-`v1:` plaintext secret as a defensive layer.
- Startup migration seals legacy plaintext already in storage (keeps the plaintext copy on failure so the only copy is never destroyed).
- Edit dialog never echoes a stored secret: the field stays empty with a hint ("leave blank to keep the saved password"); blank = keep stored, typed = replace.
- **Export strips all secret fields** (plaintext and ciphertext) from shared config bundles.

## Verification

- 636 frontend tests + 152 Rust tests pass.
- `tsc --noEmit` clean; i18n key parity (en/zh-CN) holds.
- Manual test of save / edit / connect / reconnect / migration round-tripped end to end.

Fixes #100
