### PR TITLE
feat(quick-commands): Quick Commands / Snippets panel

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { StatusBar } from './components/status-bar';
 import { ConnectionDialog, ConnectionConfig } from './components/connection-dialog';
 import { SettingsModal } from './components/settings-modal';
 import { IntegratedFileBrowser } from './components/integrated-file-browser';
+import { QuickCommandsPanel } from './components/quick-commands-panel';
 import { WelcomeScreen } from './components/welcome-screen';
 import { UpdateChecker } from './components/update-checker';
 import { toConnectionConfig } from './lib/connection-config';
@@ -2092,6 +2093,7 @@ function AppContent() {
                   <TabsList className="inline-flex w-auto mx-1 mt-2">
                     <TabsTrigger value="monitor" className="text-xs px-2">{t('app.monitor')}</TabsTrigger>
                     <TabsTrigger value="logs" className="text-xs px-2">{t('app.logs')}</TabsTrigger>
+                    <TabsTrigger value="commands" className="text-xs px-2">{t('app.quickCommands')}</TabsTrigger>
                   </TabsList>
 
                   <div className="flex-1 mt-0 overflow-hidden relative">
@@ -2115,6 +2117,14 @@ function AppContent() {
                           />
                         </ErrorBoundary>
                       ) : null}
+                    </TabsContent>
+
+                    <TabsContent value="commands" forceMount className="absolute inset-0 mt-0 data-[state=inactive]:hidden">
+                      <div className="h-full overflow-hidden px-1 py-2">
+                        <ErrorBoundary label={t('app.quickCommands')}>
+                          <QuickCommandsPanel activeTerminalId={activeTerminalId} />
+                        </ErrorBoundary>
+                      </div>
                     </TabsContent>
                   </div>
                 </Tabs>

--- a/src/__tests__/pty-terminal-send-text.test.tsx
+++ b/src/__tests__/pty-terminal-send-text.test.tsx
@@ -1,0 +1,325 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { PtyTerminal } from '../components/pty-terminal';
+import { dispatchTerminalText } from '../lib/terminal-commands';
+
+const mocks = vi.hoisted(() => {
+  const terminals: Array<any> = [];
+  const fitAddons: Array<any> = [];
+  const searchAddons: Array<any> = [];
+  const webSockets: Array<any> = [];
+  const terminalCallbacks = {
+    onWorkingDirectoryChange: vi.fn(),
+  };
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    buffer = {
+      active: {
+        length: 0,
+        getLine: vi.fn(),
+      },
+    };
+    oscHandlers = new Map<number, (data: string) => boolean | Promise<boolean>>();
+    parser = {
+      registerOscHandler: vi.fn((identifier: number, handler: (data: string) => boolean | Promise<boolean>) => {
+        this.oscHandlers.set(identifier, handler);
+        return { dispose: vi.fn() };
+      }),
+    };
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    refresh = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
+    paste = vi.fn();
+    onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
+    attachCustomKeyEventHandler = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn(() => ({ dispose: vi.fn() }));
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => '');
+    selectAll = vi.fn();
+    clear = vi.fn();
+    reset = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      fitAddons.push(this);
+    }
+  }
+
+  class MockWebSocket {
+    static OPEN = 1;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = 3;
+    });
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: (() => void) | null = null;
+
+    constructor(public url: string) {
+      webSockets.push(this);
+    }
+  }
+
+  const Terminal = vi.fn(function Terminal() {
+    const terminal = new MockTerminal();
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  return { terminals, fitAddons, searchAddons, webSockets, terminalCallbacks, Terminal, MockFitAddon, MockWebSocket };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.Terminal,
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: mocks.MockFitAddon,
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddon() {
+    return { dispose: vi.fn(), onContextLoss: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: vi.fn(function SearchAddon() {
+    const addon = {
+      findNext: vi.fn(),
+      findPrevious: vi.fn(),
+    };
+    mocks.searchAddons.push(addon);
+    return addon;
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  readText: vi.fn().mockResolvedValue(''),
+  writeText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: {
+    background: '#000000',
+  },
+  terminalThemes: {
+    'vs-code-dark': {
+      background: '#000000',
+    },
+  },
+  loadAppearanceSettings: vi.fn(() => ({
+    allowTransparency: false,
+    backgroundImage: '',
+    opacity: 100,
+    theme: 'vs-code-dark',
+  })),
+  getThemeAwareTerminalOptions: vi.fn(() => ({
+    cursorBlink: true,
+    cursorStyle: 'block',
+    fontFamily: 'monospace',
+    fontSize: 14,
+    scrollback: 10000,
+    theme: {},
+  })),
+  getThemeAwareTerminalTheme: vi.fn(() => ({
+    background: '#000000',
+  })),
+}));
+
+vi.mock('../components/terminal/terminal-context-menu', () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/terminal/terminal-search-bar', () => ({
+  TerminalSearchBar: () => null,
+}));
+
+vi.mock('../lib/restoration-manager', () => ({
+  signalReady: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => mocks.terminalCallbacks,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+import { toast } from 'sonner';
+
+async function mountTerminalWithPty() {
+  render(
+    <PtyTerminal
+      connectionId="connection-1"
+      connectionName="SSH Server"
+      host="127.0.0.1"
+      username="root"
+      isActive
+    />,
+  );
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60);
+  });
+
+  const webSocket = mocks.webSockets[0];
+  expect(webSocket?.onmessage).toBeTypeOf('function');
+  webSocket.onmessage({
+    data: JSON.stringify({
+      type: 'PtyStarted',
+      connection_id: 'connection-1',
+      generation: 1,
+    }),
+  } as MessageEvent);
+  return webSocket;
+}
+
+function binaryFrames(webSocket: { send: { mock: { calls: unknown[][] } } }): Uint8Array[] {
+  return webSocket.send.mock.calls
+    .map(([data]) => data)
+    .filter((data): data is Uint8Array => data instanceof Uint8Array);
+}
+
+describe('PtyTerminal send-text (Quick Commands)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.terminals.length = 0;
+    mocks.fitAddons.length = 0;
+    mocks.searchAddons.length = 0;
+    mocks.webSockets.length = 0;
+    mocks.terminalCallbacks.onWorkingDirectoryChange.mockClear();
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 600,
+    });
+
+    vi.stubGlobal('WebSocket', mocks.MockWebSocket);
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        return window.setTimeout(() => callback(performance.now()), 0);
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => window.clearTimeout(id)));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('pastes the text and sends Enter when executing', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.paste.mockClear();
+    webSocket.send.mockClear();
+
+    await act(async () => {
+      dispatchTerminalText('connection-1', 'sudo systemctl restart nginx');
+    });
+
+    // The text reaches the terminal via xterm's paste path (newline
+    // normalization + bracketed paste), which fires onData in a real xterm.
+    expect(terminal.paste).toHaveBeenCalledWith('sudo systemctl restart nginx');
+
+    // Execute mode appends a raw '\r' input frame for this connection.
+    const frames = binaryFrames(webSocket);
+    expect(frames).toHaveLength(1);
+    const frame = frames[0];
+    const idLength = (frame[1] << 8) | frame[2];
+    expect(new TextDecoder().decode(frame.subarray(3, 3 + idLength))).toBe('connection-1');
+    expect(new TextDecoder().decode(frame.subarray(3 + idLength))).toBe('\r');
+
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it('pastes without Enter when execute is disabled', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.paste.mockClear();
+    webSocket.send.mockClear();
+
+    await act(async () => {
+      dispatchTerminalText('connection-1', 'echo review-me-first', { execute: false });
+    });
+
+    expect(terminal.paste).toHaveBeenCalledWith('echo review-me-first');
+    expect(binaryFrames(webSocket)).toHaveLength(0);
+  });
+
+  it('ignores send-text targeted at another tab', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.paste.mockClear();
+    webSocket.send.mockClear();
+
+    await act(async () => {
+      dispatchTerminalText('connection-other', 'whoami');
+    });
+
+    expect(terminal.paste).not.toHaveBeenCalled();
+    expect(binaryFrames(webSocket)).toHaveLength(0);
+  });
+
+  it('reports an error when the PTY socket is not open', async () => {
+    const webSocket = await mountTerminalWithPty();
+    const terminal = mocks.terminals[0];
+    terminal.paste.mockClear();
+    webSocket.readyState = 3; // CLOSED
+
+    await act(async () => {
+      dispatchTerminalText('connection-1', 'whoami');
+    });
+
+    expect(terminal.paste).not.toHaveBeenCalled();
+    // Locale-independent: another suite's i18n language switch can leak into
+    // this file's shared i18n instance within the same worker.
+    expect(toast.error).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/__tests__/quick-commands-panel.test.tsx
+++ b/src/__tests__/quick-commands-panel.test.tsx
@@ -1,0 +1,312 @@
+import React from 'react';
+import { act, cleanup, fireEvent, render, screen, waitFor, within } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { QuickCommandsPanel } from '../components/quick-commands-panel';
+import { SnippetStorageManager } from '../lib/snippet-storage';
+import { TERMINAL_COMMAND_EVENT, type TerminalCommandDetail } from '../lib/terminal-commands';
+
+const mocks = vi.hoisted(() => ({
+  writeText: vi.fn(),
+  toastError: vi.fn(),
+  toastSuccess: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  writeText: mocks.writeText,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: mocks.toastError,
+    info: vi.fn(),
+    success: mocks.toastSuccess,
+    warning: vi.fn(),
+  },
+}));
+
+vi.mock('../components/ui/scroll-area', () => ({
+  ScrollArea: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+vi.mock('../components/ui/select', () => ({
+  Select: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectItem: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectTrigger: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  SelectValue: () => null,
+}));
+
+vi.mock('../components/ui/alert-dialog', () => ({
+  AlertDialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  AlertDialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogDescription: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  AlertDialogCancel: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button onClick={onClick}>{children}</button>
+  ),
+  AlertDialogAction: ({ children, onClick }: { children: React.ReactNode; onClick?: () => void }) => (
+    <button data-testid="alert-dialog-action" onClick={onClick}>{children}</button>
+  ),
+}));
+
+vi.mock('../components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open: boolean }) =>
+    open ? <div>{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+function seedSnippets() {
+  SnippetStorageManager.saveSnippet({
+    id: '',
+    name: 'Restart nginx',
+    command: 'sudo systemctl restart nginx',
+    tags: ['web'],
+  });
+  SnippetStorageManager.saveSnippet({
+    id: '',
+    name: 'Tail app logs',
+    command: 'tail -f /var/log/app.log',
+    tags: ['logs'],
+  });
+}
+
+function captureTerminalEvents() {
+  const events: TerminalCommandDetail[] = [];
+  const listener = (event: Event) => {
+    events.push((event as CustomEvent<TerminalCommandDetail>).detail);
+  };
+  window.addEventListener(TERMINAL_COMMAND_EVENT, listener);
+  return { events, stop: () => window.removeEventListener(TERMINAL_COMMAND_EVENT, listener) };
+}
+
+/** The snippet card container (role=button with the snippet name as label). */
+function snippetCard(name: string): HTMLElement {
+  return screen.getByRole('button', { name });
+}
+
+describe('QuickCommandsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.writeText.mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  afterEach(cleanup);
+
+  it('renders snippets from storage', () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    expect(screen.getByText('Restart nginx')).toBeTruthy();
+    expect(screen.getByText('Tail app logs')).toBeTruthy();
+    expect(screen.getByText('sudo systemctl restart nginx')).toBeTruthy();
+    expect(screen.getByText('2 snippets')).toBeTruthy();
+  });
+
+  it('shows the empty state when no snippets exist', () => {
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    expect(screen.getByText('No snippets yet')).toBeTruthy();
+    expect(screen.getByRole('button', { name: 'Create snippet' })).toBeTruthy();
+  });
+
+  it('filters snippets by name, command and tag', () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    const search = screen.getByPlaceholderText('Search snippets…');
+    fireEvent.change(search, { target: { value: 'nginx' } });
+    expect(screen.getByText('Restart nginx')).toBeTruthy();
+    expect(screen.queryByText('Tail app logs')).toBeNull();
+
+    fireEvent.change(search, { target: { value: 'app.log' } });
+    expect(screen.getByText('Tail app logs')).toBeTruthy();
+    expect(screen.queryByText('Restart nginx')).toBeNull();
+
+    fireEvent.change(search, { target: { value: 'logs' } }); // tag match
+    expect(screen.getByText('Tail app logs')).toBeTruthy();
+
+    fireEvent.change(search, { target: { value: 'no-such-thing' } });
+    expect(screen.getByText('No snippets match your search')).toBeTruthy();
+  });
+
+  it('warns instead of sending when there is no active terminal', () => {
+    seedSnippets();
+    const { events, stop } = captureTerminalEvents();
+    render(<QuickCommandsPanel activeTerminalId={null} />);
+
+    expect(screen.getByText('No active terminal — connect to a host to run snippets')).toBeTruthy();
+
+    fireEvent.click(screen.getByText('Restart nginx'));
+
+    expect(events).toEqual([]);
+    expect(mocks.toastError).toHaveBeenCalledWith('No active terminal');
+    stop();
+  });
+
+  it('runs a snippet on card click and records usage', () => {
+    seedSnippets();
+    const { events, stop } = captureTerminalEvents();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    fireEvent.click(screen.getByText('Restart nginx'));
+
+    expect(events).toEqual([{
+      tabId: 'tab-1',
+      command: 'send-text',
+      text: 'sudo systemctl restart nginx',
+      execute: true,
+    }]);
+
+    const updated = SnippetStorageManager.getSnippets().find(s => s.name === 'Restart nginx');
+    expect(updated?.usageCount).toBe(1);
+
+    // Most-used sort (default) moves the used snippet to the top of the list.
+    const order = screen.getAllByText(/^(Restart nginx|Tail app logs)$/);
+    expect(order[0].textContent).toBe('Restart nginx');
+    stop();
+  });
+
+  it('inserts without executing via the insert action', () => {
+    seedSnippets();
+    const { events, stop } = captureTerminalEvents();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    const insertButton = within(snippetCard('Restart nginx'))
+      .getByRole('button', { name: 'Insert without running' });
+    fireEvent.click(insertButton);
+
+    expect(events).toEqual([{
+      tabId: 'tab-1',
+      command: 'send-text',
+      text: 'sudo systemctl restart nginx',
+      execute: false,
+    }]);
+    stop();
+  });
+
+  it('copies the command to the clipboard', async () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId={null} />);
+
+    const copyButton = within(snippetCard('Restart nginx'))
+      .getByRole('button', { name: 'Copy to clipboard' });
+    fireEvent.click(copyButton);
+
+    await waitFor(() => {
+      expect(mocks.writeText).toHaveBeenCalledWith('sudo systemctl restart nginx');
+      expect(mocks.toastSuccess).toHaveBeenCalledWith('Copied to clipboard');
+    });
+  });
+
+  it('deletes a snippet after confirmation', () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    const deleteButton = within(snippetCard('Restart nginx'))
+      .getByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButton);
+
+    expect(screen.getByText('Delete snippet')).toBeTruthy();
+    expect(screen.getByText('Delete "Restart nginx"? This cannot be undone.')).toBeTruthy();
+
+    fireEvent.click(screen.getByTestId('alert-dialog-action'));
+
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(1);
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Snippet deleted');
+    expect(screen.queryByText('Restart nginx')).toBeNull();
+  });
+
+  it('keeps the snippet when the delete confirmation is cancelled', () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    const deleteButton = within(snippetCard('Restart nginx'))
+      .getByRole('button', { name: 'Delete' });
+    fireEvent.click(deleteButton);
+    fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(2);
+    expect(screen.getByText('Restart nginx')).toBeTruthy();
+  });
+
+  it('creates a snippet through the dialog', () => {
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New snippet' }));
+
+    expect(screen.getByText('New snippet')).toBeTruthy();
+    fireEvent.change(screen.getByLabelText('Name'), { target: { value: 'Disk usage' } });
+    fireEvent.change(screen.getByLabelText('Command'), {
+      target: { value: 'df -h /var' },
+    });
+    fireEvent.change(screen.getByLabelText('Tags'), { target: { value: 'disk, ops' } });
+
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    const saved = SnippetStorageManager.getSnippets();
+    expect(saved).toHaveLength(1);
+    expect(saved[0]).toMatchObject({
+      name: 'Disk usage',
+      command: 'df -h /var',
+      tags: ['disk', 'ops'],
+    });
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Snippet created');
+    // Dialog closed; the list shows the new snippet.
+    expect(screen.queryByText('New snippet')).toBeNull();
+    expect(screen.getByText('Disk usage')).toBeTruthy();
+  });
+
+  it('validates required fields in the dialog', () => {
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'New snippet' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    expect(screen.getByText('Name is required')).toBeTruthy();
+    expect(screen.getByText('Command is required')).toBeTruthy();
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(0);
+  });
+
+  it('edits an existing snippet through the dialog', () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    const editButton = within(snippetCard('Restart nginx'))
+      .getByRole('button', { name: 'Edit' });
+    fireEvent.click(editButton);
+
+    const nameField = screen.getByLabelText('Name') as HTMLInputElement;
+    expect(nameField.value).toBe('Restart nginx');
+
+    fireEvent.change(nameField, { target: { value: 'Reload nginx' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Save' }));
+
+    const names = SnippetStorageManager.getSnippets().map(s => s.name);
+    expect(names).toContain('Reload nginx');
+    expect(names).not.toContain('Restart nginx');
+    expect(mocks.toastSuccess).toHaveBeenCalledWith('Snippet updated');
+  });
+
+  it('reflects external storage changes via the change event', async () => {
+    seedSnippets();
+    render(<QuickCommandsPanel activeTerminalId="tab-1" />);
+
+    await act(async () => {
+      SnippetStorageManager.saveSnippet({
+        id: '',
+        name: 'Uptime',
+        command: 'uptime',
+        tags: [],
+      });
+    });
+
+    expect(screen.getByText('Uptime')).toBeTruthy();
+  });
+});

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -1283,9 +1283,30 @@ export function PtyTerminal({
     searchStateRef.current = state;
   }, []);
 
+  // Quick Commands panel: type snippet text into this terminal. Uses
+  // term.paste() so multi-line commands get the same newline normalization
+  // and bracketed-paste wrapping as a real clipboard paste; `execute`
+  // appends Enter so the command runs immediately.
+  const handleSendText = React.useCallback((text: string, execute: boolean) => {
+    if (!text) return;
+    const term = xtermRef.current;
+    const ws = wsRef.current;
+    if (!term || !ws || ws.readyState !== WebSocket.OPEN) {
+      toast.error(i18n.t('ptyTerminal.terminalNotConnected'));
+      return;
+    }
+    // Flush a pending Xshell-style Ctrl+A prefix so the buffered \x01 reaches
+    // the remote instead of being swallowed by (or merged into) the snippet.
+    flushPrefixCtrlA();
+    term.paste(text);
+    if (execute) {
+      sendInputToPty('\r');
+    }
+  }, [flushPrefixCtrlA, sendInputToPty]);
+
   React.useEffect(() => {
     const handleTerminalCommand = (event: Event) => {
-      const { tabId, command } = (event as CustomEvent<TerminalCommandDetail>).detail;
+      const { tabId, command, text, execute } = (event as CustomEvent<TerminalCommandDetail>).detail;
       if (tabId !== connectionId) return;
 
       switch (command) {
@@ -1296,12 +1317,13 @@ export function PtyTerminal({
         case 'find-next': handleFindNext(); break;
         case 'find-previous': handleFindPrevious(); break;
         case 'clear-screen': handleClear(); break;
+        case 'send-text': handleSendText(text ?? '', execute !== false); break;
       }
     };
 
     window.addEventListener(TERMINAL_COMMAND_EVENT, handleTerminalCommand);
     return () => window.removeEventListener(TERMINAL_COMMAND_EVENT, handleTerminalCommand);
-  }, [connectionId, handleClear, handleCopy, handleFindNext, handleFindPrevious, handlePaste, handleSearch, handleSelectAll]);
+  }, [connectionId, handleClear, handleCopy, handleFindNext, handleFindPrevious, handlePaste, handleSearch, handleSelectAll, handleSendText]);
 
   const handleReconnect = React.useCallback(() => {
     if (onReconnectTab) {

--- a/src/components/quick-commands-panel.tsx
+++ b/src/components/quick-commands-panel.tsx
@@ -1,0 +1,359 @@
+/**
+ * Quick Commands Panel
+ *
+ * Right-sidebar panel for reusable command snippets (Termius/Xshell-style
+ * quick commands): search, sort, and one-click send to the active terminal.
+ * Sending rides the existing TERMINAL_COMMAND_EVENT bus, so the panel never
+ * touches WebSockets directly — the focused PtyTerminal applies real paste
+ * semantics (bracketed paste) and can press Enter.
+ */
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { writeText as writeClipboardText } from '@tauri-apps/plugin-clipboard-manager';
+import { Copy, Pencil, Plus, Search, Terminal, Trash2, Type } from 'lucide-react';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Badge } from './ui/badge';
+import { ScrollArea } from './ui/scroll-area';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
+import { cn } from '@/lib/utils';
+import { dispatchTerminalText } from '@/lib/terminal-commands';
+import {
+  SNIPPETS_CHANGED_EVENT,
+  SnippetStorageManager,
+  type CommandSnippet,
+} from '@/lib/snippet-storage';
+import { SnippetEditDialog } from './snippet-edit-dialog';
+
+export interface QuickCommandsPanelProps {
+  /** Tab id of the active terminal tab, or null when none is connected. */
+  activeTerminalId: string | null;
+}
+
+type SnippetSort = 'mostUsed' | 'recentlyUsed' | 'name';
+
+function matchesQuery(snippet: CommandSnippet, query: string): boolean {
+  const haystack = [
+    snippet.name,
+    snippet.command,
+    snippet.description ?? '',
+    snippet.tags.join(' '),
+  ].join('\n').toLowerCase();
+  return haystack.includes(query);
+}
+
+function sortSnippets(snippets: CommandSnippet[], sortBy: SnippetSort): CommandSnippet[] {
+  const sorted = [...snippets];
+  switch (sortBy) {
+    case 'mostUsed':
+      sorted.sort((a, b) => b.usageCount - a.usageCount || b.updatedAt.localeCompare(a.updatedAt));
+      break;
+    case 'recentlyUsed':
+      sorted.sort((a, b) =>
+        (b.lastUsedAt ?? b.createdAt).localeCompare(a.lastUsedAt ?? a.createdAt));
+      break;
+    case 'name':
+      sorted.sort((a, b) => a.name.localeCompare(b.name));
+      break;
+  }
+  return sorted;
+}
+
+export function QuickCommandsPanel({ activeTerminalId }: QuickCommandsPanelProps) {
+  const { t } = useTranslation();
+  const [snippets, setSnippets] = useState<CommandSnippet[]>(() => SnippetStorageManager.getSnippets());
+  const [search, setSearch] = useState('');
+  const [sortBy, setSortBy] = useState<SnippetSort>('mostUsed');
+  const [editOpen, setEditOpen] = useState(false);
+  const [editing, setEditing] = useState<CommandSnippet | null>(null);
+  const [pendingDelete, setPendingDelete] = useState<CommandSnippet | null>(null);
+
+  // Keep the list in sync with storage mutations (this window via the custom
+  // event, other webview windows via the DOM storage event).
+  useEffect(() => {
+    const refresh = () => setSnippets(SnippetStorageManager.getSnippets());
+    window.addEventListener(SNIPPETS_CHANGED_EVENT, refresh);
+    window.addEventListener('storage', refresh);
+    return () => {
+      window.removeEventListener(SNIPPETS_CHANGED_EVENT, refresh);
+      window.removeEventListener('storage', refresh);
+    };
+  }, []);
+
+  const visibleSnippets = useMemo(() => {
+    const query = search.trim().toLowerCase();
+    const filtered = query ? snippets.filter(s => matchesQuery(s, query)) : snippets;
+    return sortSnippets(filtered, sortBy);
+  }, [snippets, search, sortBy]);
+
+  const requireTerminal = useCallback((): boolean => {
+    if (activeTerminalId) return true;
+    toast.error(t('quickCommands.toast.noActiveTerminal'));
+    return false;
+  }, [activeTerminalId, t]);
+
+  const sendSnippet = useCallback((snippet: CommandSnippet, execute: boolean) => {
+    if (!requireTerminal() || !activeTerminalId) return;
+    dispatchTerminalText(activeTerminalId, snippet.command, { execute });
+    SnippetStorageManager.recordSnippetUsage(snippet.id);
+  }, [activeTerminalId, requireTerminal]);
+
+  const handleRun = useCallback((snippet: CommandSnippet) => {
+    sendSnippet(snippet, true);
+  }, [sendSnippet]);
+
+  const handleInsert = useCallback((snippet: CommandSnippet) => {
+    sendSnippet(snippet, false);
+  }, [sendSnippet]);
+
+  const handleCopy = useCallback((snippet: CommandSnippet) => {
+    writeClipboardText(snippet.command)
+      .then(() => toast.success(t('quickCommands.toast.copied')))
+      .catch(() => toast.error(t('quickCommands.toast.copyFailed')));
+  }, [t]);
+
+  const handleEdit = useCallback((snippet: CommandSnippet) => {
+    setEditing(snippet);
+    setEditOpen(true);
+  }, []);
+
+  const handleCreate = useCallback(() => {
+    setEditing(null);
+    setEditOpen(true);
+  }, []);
+
+  const handleDeleteConfirmed = useCallback(() => {
+    if (!pendingDelete) return;
+    SnippetStorageManager.deleteSnippet(pendingDelete.id);
+    toast.success(t('quickCommands.toast.deleted'));
+    setPendingDelete(null);
+  }, [pendingDelete, t]);
+
+  return (
+    <div className="flex h-full flex-col gap-2 overflow-hidden">
+      {/* Toolbar: search · sort · new */}
+      <div className="flex items-center gap-1.5">
+        <div className="relative min-w-0 flex-1">
+          <Search className="pointer-events-none absolute left-2 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('quickCommands.searchPlaceholder')}
+            className="h-7 pl-7 text-xs"
+            aria-label={t('quickCommands.searchPlaceholder')}
+          />
+        </div>
+        <Select value={sortBy} onValueChange={(value) => setSortBy(value as SnippetSort)}>
+          <SelectTrigger
+            className="h-7 w-[118px] shrink-0 text-xs"
+            aria-label={t('quickCommands.sort.ariaLabel')}
+          >
+            <SelectValue />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="mostUsed">{t('quickCommands.sort.mostUsed')}</SelectItem>
+            <SelectItem value="recentlyUsed">{t('quickCommands.sort.recentlyUsed')}</SelectItem>
+            <SelectItem value="name">{t('quickCommands.sort.name')}</SelectItem>
+          </SelectContent>
+        </Select>
+        <Button
+          variant="outline"
+          size="icon"
+          className="h-7 w-7 shrink-0"
+          onClick={handleCreate}
+          title={t('quickCommands.newSnippet')}
+          aria-label={t('quickCommands.newSnippet')}
+        >
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+
+      {!activeTerminalId && (
+        <div className="flex items-center gap-1.5 rounded-md border border-dashed px-2 py-1.5 text-muted-foreground">
+          <Terminal className="h-3.5 w-3.5 shrink-0" />
+          <span className="text-[11px] leading-tight">{t('quickCommands.noActiveTerminal')}</span>
+        </div>
+      )}
+
+      {/* Snippet list */}
+      <ScrollArea className="min-h-0 flex-1">
+        {visibleSnippets.length > 0 ? (
+          <div className="flex flex-col gap-1.5 pr-1.5">
+            {visibleSnippets.map((snippet) => (
+              <div
+                key={snippet.id}
+                role="button"
+                tabIndex={0}
+                aria-label={snippet.name}
+                title={t('quickCommands.actions.run')}
+                className={cn(
+                  'group cursor-pointer rounded-md border bg-card/50 px-2.5 py-2 text-left transition-colors',
+                  'hover:border-primary/40 hover:bg-accent/40',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring',
+                )}
+                onClick={() => handleRun(snippet)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter' || e.key === ' ') {
+                    e.preventDefault();
+                    handleRun(snippet);
+                  }
+                }}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <span className="min-w-0 truncate text-xs font-medium text-foreground">
+                    {snippet.name}
+                  </span>
+                  <div className="flex shrink-0 items-center gap-0.5 opacity-0 transition-opacity group-hover:opacity-100 focus-within:opacity-100">
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      title={t('quickCommands.actions.insert')}
+                      aria-label={t('quickCommands.actions.insert')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleInsert(snippet);
+                      }}
+                    >
+                      <Type className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      title={t('quickCommands.actions.copy')}
+                      aria-label={t('quickCommands.actions.copy')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleCopy(snippet);
+                      }}
+                    >
+                      <Copy className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6"
+                      title={t('quickCommands.actions.edit')}
+                      aria-label={t('quickCommands.actions.edit')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        handleEdit(snippet);
+                      }}
+                    >
+                      <Pencil className="h-3.5 w-3.5" />
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="icon"
+                      className="h-6 w-6 text-muted-foreground hover:text-destructive"
+                      title={t('quickCommands.actions.delete')}
+                      aria-label={t('quickCommands.actions.delete')}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        setPendingDelete(snippet);
+                      }}
+                    >
+                      <Trash2 className="h-3.5 w-3.5" />
+                    </Button>
+                  </div>
+                </div>
+                {snippet.tags.length > 0 && (
+                  <div className="mt-1 flex flex-wrap gap-1">
+                    {snippet.tags.map((tag) => (
+                      <Badge key={tag} variant="secondary" className="px-1.5 text-[10px]">
+                        {tag}
+                      </Badge>
+                    ))}
+                  </div>
+                )}
+                <code
+                  className="mt-1 block truncate font-mono text-[11px] text-muted-foreground"
+                  title={snippet.command}
+                >
+                  {snippet.command}
+                </code>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-3 px-4 py-10 text-center">
+            <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary/10 text-primary">
+              <Terminal className="h-5 w-5" />
+            </div>
+            {search.trim() ? (
+              <p className="text-xs text-muted-foreground">
+                {t('quickCommands.emptySearch')}
+              </p>
+            ) : (
+              <>
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {t('quickCommands.emptyTitle')}
+                  </p>
+                  <p className="mt-1 text-xs text-muted-foreground">
+                    {t('quickCommands.emptyDescription')}
+                  </p>
+                </div>
+                <Button variant="outline" size="sm" onClick={handleCreate}>
+                  <Plus className="h-3.5 w-3.5" />
+                  {t('quickCommands.emptyCreate')}
+                </Button>
+              </>
+            )}
+          </div>
+        )}
+      </ScrollArea>
+
+      {snippets.length > 0 && (
+        <p className="shrink-0 text-[11px] text-muted-foreground">
+          {t('quickCommands.snippetCount', { count: snippets.length })}
+        </p>
+      )}
+
+      <SnippetEditDialog open={editOpen} onOpenChange={setEditOpen} snippet={editing} />
+
+      <AlertDialog
+        open={pendingDelete !== null}
+        onOpenChange={(open) => {
+          if (!open) setPendingDelete(null);
+        }}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>{t('quickCommands.deleteConfirm.title')}</AlertDialogTitle>
+            <AlertDialogDescription>
+              {t('quickCommands.deleteConfirm.description', { name: pendingDelete?.name ?? '' })}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>{t('common.cancel')}</AlertDialogCancel>
+            <AlertDialogAction
+              className="bg-destructive text-white hover:bg-destructive/90"
+              onClick={handleDeleteConfirmed}
+            >
+              {t('common.delete')}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/src/components/snippet-edit-dialog.tsx
+++ b/src/components/snippet-edit-dialog.tsx
@@ -1,0 +1,176 @@
+/**
+ * Snippet Edit Dialog
+ *
+ * Create/edit form for Quick Commands snippets: name, command (multi-line,
+ * sent to the terminal as a paste), optional description and tags.
+ */
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Textarea } from './ui/textarea';
+import { SnippetStorageManager, parseTagInput, type CommandSnippet } from '@/lib/snippet-storage';
+
+export interface SnippetEditDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Snippet to edit, or null/undefined to create a new one. */
+  snippet?: CommandSnippet | null;
+}
+
+interface SnippetFormState {
+  name: string;
+  command: string;
+  description: string;
+  tags: string;
+}
+
+const emptyForm: SnippetFormState = {
+  name: '',
+  command: '',
+  description: '',
+  tags: '',
+};
+
+function formFromSnippet(snippet: CommandSnippet | null | undefined): SnippetFormState {
+  if (!snippet) return emptyForm;
+  return {
+    name: snippet.name,
+    command: snippet.command,
+    description: snippet.description ?? '',
+    tags: snippet.tags.join(', '),
+  };
+}
+
+export function SnippetEditDialog({ open, onOpenChange, snippet }: SnippetEditDialogProps) {
+  const { t } = useTranslation();
+  const [form, setForm] = useState<SnippetFormState>(emptyForm);
+  const [errors, setErrors] = useState<{ name?: boolean; command?: boolean }>({});
+
+  // Re-seed the form each time the dialog opens (or switches target snippet).
+  useEffect(() => {
+    if (open) {
+      setForm(formFromSnippet(snippet));
+      setErrors({});
+    }
+  }, [open, snippet]);
+
+  const setField = (field: keyof SnippetFormState, value: string) => {
+    setForm(prev => ({ ...prev, [field]: value }));
+    if (value.trim()) {
+      setErrors(prev => ({ ...prev, [field]: undefined }));
+    }
+  };
+
+  const handleSave = () => {
+    const nameError = !form.name.trim();
+    const commandError = !form.command.trim();
+    if (nameError || commandError) {
+      setErrors({ name: nameError || undefined, command: commandError || undefined });
+      return;
+    }
+
+    const saved = SnippetStorageManager.saveSnippet({
+      id: snippet?.id ?? '',
+      name: form.name,
+      command: form.command,
+      description: form.description,
+      tags: parseTagInput(form.tags),
+      createdAt: snippet?.createdAt,
+      usageCount: snippet?.usageCount,
+      lastUsedAt: snippet?.lastUsedAt,
+    });
+
+    if (!saved) {
+      // Defensive: storage-level validation failed despite the form checks.
+      toast.error(t('quickCommands.dialog.saveFailed'));
+      return;
+    }
+
+    toast.success(snippet ? t('quickCommands.toast.updated') : t('quickCommands.toast.created'));
+    onOpenChange(false);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {snippet ? t('quickCommands.dialog.editTitle') : t('quickCommands.dialog.newTitle')}
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="grid gap-4 py-2">
+          <div className="grid gap-2">
+            <Label htmlFor="snippet-name">{t('quickCommands.dialog.name')}</Label>
+            <Input
+              id="snippet-name"
+              value={form.name}
+              onChange={(e) => setField('name', e.target.value)}
+              placeholder={t('quickCommands.dialog.namePlaceholder')}
+              aria-invalid={errors.name ? true : undefined}
+              autoFocus
+            />
+            {errors.name && (
+              <p className="text-xs text-destructive">{t('quickCommands.dialog.nameRequired')}</p>
+            )}
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="snippet-command">{t('quickCommands.dialog.command')}</Label>
+            <Textarea
+              id="snippet-command"
+              value={form.command}
+              onChange={(e) => setField('command', e.target.value)}
+              placeholder={t('quickCommands.dialog.commandPlaceholder')}
+              className="min-h-24 font-mono text-xs"
+              aria-invalid={errors.command ? true : undefined}
+            />
+            {errors.command && (
+              <p className="text-xs text-destructive">{t('quickCommands.dialog.commandRequired')}</p>
+            )}
+            <p className="text-xs text-muted-foreground">
+              {t('quickCommands.dialog.commandHint')}
+            </p>
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="snippet-description">{t('quickCommands.dialog.description')}</Label>
+            <Input
+              id="snippet-description"
+              value={form.description}
+              onChange={(e) => setField('description', e.target.value)}
+              placeholder={t('quickCommands.dialog.descriptionPlaceholder')}
+            />
+          </div>
+
+          <div className="grid gap-2">
+            <Label htmlFor="snippet-tags">{t('quickCommands.dialog.tags')}</Label>
+            <Input
+              id="snippet-tags"
+              value={form.tags}
+              onChange={(e) => setField('tags', e.target.value)}
+              placeholder={t('quickCommands.dialog.tagsPlaceholder')}
+            />
+          </div>
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" onClick={() => onOpenChange(false)}>
+            {t('common.cancel')}
+          </Button>
+          <Button onClick={handleSave}>{t('common.save')}</Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/lib/__tests__/snippet-storage.test.ts
+++ b/src/lib/__tests__/snippet-storage.test.ts
@@ -1,0 +1,160 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import {
+  SNIPPETS_CHANGED_EVENT,
+  SnippetStorageManager,
+  normalizeTags,
+  parseTagInput,
+  type CommandSnippet,
+} from '../snippet-storage';
+
+const STORAGE_KEY = 'r-shell-command-snippets';
+
+function makeInput(overrides: Partial<CommandSnippet> = {}) {
+  return {
+    id: '',
+    name: 'Restart nginx',
+    command: 'sudo systemctl restart nginx',
+    tags: ['web'],
+    ...overrides,
+  };
+}
+
+describe('snippet-storage', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('creates a snippet with a generated id and timestamps', () => {
+    const snippet = SnippetStorageManager.saveSnippet(makeInput());
+
+    expect(snippet).not.toBeNull();
+    expect(snippet!.id).toMatch(/^snippet-/);
+    expect(snippet!.id).not.toBe('');
+    expect(snippet!.createdAt).toBeTypeOf('string');
+    expect(snippet!.updatedAt).toBeTypeOf('string');
+    expect(snippet!.usageCount).toBe(0);
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(1);
+  });
+
+  it('rejects blank names and commands', () => {
+    expect(SnippetStorageManager.saveSnippet(makeInput({ name: '   ' }))).toBeNull();
+    expect(SnippetStorageManager.saveSnippet(makeInput({ command: '' }))).toBeNull();
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(0);
+  });
+
+  it('round-trips snippets through localStorage', () => {
+    const saved = SnippetStorageManager.saveSnippet(makeInput());
+
+    const loaded = SnippetStorageManager.getSnippet(saved!.id);
+    expect(loaded).toMatchObject({
+      name: 'Restart nginx',
+      command: 'sudo systemctl restart nginx',
+      tags: ['web'],
+    });
+  });
+
+  it('updates an existing snippet in place, preserving createdAt and usageCount', () => {
+    const created = SnippetStorageManager.saveSnippet(makeInput())!;
+    SnippetStorageManager.recordSnippetUsage(created.id);
+    SnippetStorageManager.recordSnippetUsage(created.id);
+
+    const updated = SnippetStorageManager.saveSnippet({
+      ...created,
+      name: 'Restart nginx (hard)',
+      command: 'sudo systemctl restart nginx --force',
+    })!;
+
+    const all = SnippetStorageManager.getSnippets();
+    expect(all).toHaveLength(1);
+    expect(updated.id).toBe(created.id);
+    expect(updated.createdAt).toBe(created.createdAt);
+    expect(updated.usageCount).toBe(2);
+    expect(updated.name).toBe('Restart nginx (hard)');
+  });
+
+  it('does not adopt another id when updating', () => {
+    const a = SnippetStorageManager.saveSnippet(makeInput({ name: 'A' }))!;
+    const b = SnippetStorageManager.saveSnippet(makeInput({ name: 'B' }))!;
+
+    const updated = SnippetStorageManager.saveSnippet({ ...b, name: 'B2' })!;
+
+    expect(updated.id).toBe(b.id);
+    const ids = SnippetStorageManager.getSnippets().map(s => s.id).sort();
+    expect(ids).toEqual([a.id, b.id].sort());
+  });
+
+  it('deletes snippets and reports whether anything was removed', () => {
+    const created = SnippetStorageManager.saveSnippet(makeInput())!;
+
+    expect(SnippetStorageManager.deleteSnippet('missing')).toBe(false);
+    expect(SnippetStorageManager.deleteSnippet(created.id)).toBe(true);
+    expect(SnippetStorageManager.getSnippets()).toHaveLength(0);
+    expect(SnippetStorageManager.deleteSnippet(created.id)).toBe(false);
+  });
+
+  it('records usage by bumping usageCount and lastUsedAt', () => {
+    const created = SnippetStorageManager.saveSnippet(makeInput())!;
+
+    SnippetStorageManager.recordSnippetUsage(created.id);
+
+    const loaded = SnippetStorageManager.getSnippet(created.id)!;
+    expect(loaded.usageCount).toBe(1);
+    expect(loaded.lastUsedAt).toBeTypeOf('string');
+    // Unknown ids are a no-op, not an error.
+    expect(() => SnippetStorageManager.recordSnippetUsage('missing')).not.toThrow();
+  });
+
+  it('normalizes tags: trims, drops empties, de-duplicates', () => {
+    expect(normalizeTags([' docker ', '', 'logs', 'docker', ' '])).toEqual(['docker', 'logs']);
+    expect(normalizeTags(undefined)).toEqual([]);
+    expect(parseTagInput('docker, logs,, web ')).toEqual(['docker', 'logs', 'web']);
+  });
+
+  it('degrades to an empty list on corrupt storage', () => {
+    localStorage.setItem(STORAGE_KEY, '{not json');
+
+    expect(SnippetStorageManager.getSnippets()).toEqual([]);
+  });
+
+  it('drops malformed entries but keeps valid ones on load', () => {
+    const valid = {
+      id: 'snippet-1',
+      name: 'OK',
+      command: 'ls',
+      tags: ['x'],
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+    };
+    localStorage.setItem(STORAGE_KEY, JSON.stringify([
+      valid,
+      { id: 'nope' },
+      'garbage',
+      null,
+    ]));
+
+    const snippets = SnippetStorageManager.getSnippets();
+    expect(snippets).toHaveLength(1);
+    expect(snippets[0].usageCount).toBe(0); // missing usageCount defaults to 0
+  });
+
+  it('emits the change event on every mutation', () => {
+    const listener = vi.fn();
+    window.addEventListener(SNIPPETS_CHANGED_EVENT, listener);
+
+    const created = SnippetStorageManager.saveSnippet(makeInput())!;
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    SnippetStorageManager.recordSnippetUsage(created.id);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    SnippetStorageManager.deleteSnippet(created.id);
+    expect(listener).toHaveBeenCalledTimes(3);
+
+    window.removeEventListener(SNIPPETS_CHANGED_EVENT, listener);
+  });
+
+  it('clears an all-whitespace description to undefined', () => {
+    const created = SnippetStorageManager.saveSnippet(makeInput({ description: '   ' }))!;
+    expect(created.description).toBeUndefined();
+  });
+});

--- a/src/lib/__tests__/terminal-commands.test.ts
+++ b/src/lib/__tests__/terminal-commands.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import {
+  TERMINAL_COMMAND_EVENT,
+  dispatchTerminalCommand,
+  dispatchTerminalText,
+  type TerminalCommandDetail,
+} from '../terminal-commands';
+
+function captureEvents(): { events: TerminalCommandDetail[]; stop: () => void } {
+  const events: TerminalCommandDetail[] = [];
+  const listener = (event: Event) => {
+    events.push((event as CustomEvent<TerminalCommandDetail>).detail);
+  };
+  window.addEventListener(TERMINAL_COMMAND_EVENT, listener);
+  return { events, stop: () => window.removeEventListener(TERMINAL_COMMAND_EVENT, listener) };
+}
+
+describe('terminal-commands dispatchers', () => {
+  const captures: Array<() => void> = [];
+
+  afterEach(() => {
+    captures.splice(0).forEach(stop => stop());
+  });
+
+  it('dispatches plain commands without text payload', () => {
+    const { events, stop } = captureEvents();
+    captures.push(stop);
+
+    dispatchTerminalCommand('tab-1', 'clear-screen');
+
+    expect(events).toEqual([{ tabId: 'tab-1', command: 'clear-screen' }]);
+  });
+
+  it('dispatches send-text with execute defaulting to true', () => {
+    const { events, stop } = captureEvents();
+    captures.push(stop);
+
+    dispatchTerminalText('tab-1', 'echo hello');
+
+    expect(events).toEqual([{
+      tabId: 'tab-1',
+      command: 'send-text',
+      text: 'echo hello',
+      execute: true,
+    }]);
+  });
+
+  it('dispatches send-text with execute disabled on request', () => {
+    const { events, stop } = captureEvents();
+    captures.push(stop);
+
+    dispatchTerminalText('tab-1', 'echo hello', { execute: false });
+
+    expect(events).toEqual([{
+      tabId: 'tab-1',
+      command: 'send-text',
+      text: 'echo hello',
+      execute: false,
+    }]);
+  });
+});
+
+describe('terminal-commands listener hygiene', () => {
+  it('stops delivering events after the listener is removed', () => {
+    const listener = vi.fn();
+    window.addEventListener(TERMINAL_COMMAND_EVENT, listener);
+    window.removeEventListener(TERMINAL_COMMAND_EVENT, listener);
+
+    dispatchTerminalCommand('tab-1', 'copy');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/snippet-storage.ts
+++ b/src/lib/snippet-storage.ts
@@ -1,0 +1,176 @@
+/**
+ * Quick Commands / Snippets Storage
+ *
+ * Persists reusable command snippets to localStorage so they can be sent to
+ * the active terminal in one click. Follows the ConnectionStorageManager
+ * pattern: static manager methods over a single localStorage key, defensive
+ * parsing (corrupt or malformed data degrades to an empty list), and a
+ * window event so mounted panels re-read after every mutation.
+ */
+
+export interface CommandSnippet {
+  id: string;
+  name: string;
+  /** The command text. May be multi-line — sent to the terminal as a paste. */
+  command: string;
+  description?: string;
+  /** Search/grouping aid. Normalized (trimmed, non-empty, de-duplicated). */
+  tags: string[];
+  createdAt: string;
+  updatedAt: string;
+  /** Incremented every time the snippet is sent to a terminal. */
+  usageCount: number;
+  lastUsedAt?: string;
+}
+
+/** Input accepted by saveSnippet — id omitted means "create new". */
+export type CommandSnippetInput = Omit<CommandSnippet, 'createdAt' | 'updatedAt' | 'usageCount'> & {
+  createdAt?: string;
+  updatedAt?: string;
+  usageCount?: number;
+};
+
+const SNIPPETS_STORAGE_KEY = 'r-shell-command-snippets';
+
+/**
+ * Emitted on `window` after any storage mutation so mounted panels can
+ * re-read the list. Also listen to the DOM `storage` event for changes
+ * made from other webview windows.
+ */
+export const SNIPPETS_CHANGED_EVENT = 'rshell-snippets-changed';
+
+function isValidSnippet(value: unknown): value is CommandSnippet {
+  if (typeof value !== 'object' || value === null) return false;
+  const snippet = value as Partial<CommandSnippet>;
+  return (
+    typeof snippet.id === 'string' &&
+    typeof snippet.name === 'string' &&
+    typeof snippet.command === 'string'
+  );
+}
+
+function generateSnippetId(): string {
+  const random = Math.random().toString(36).slice(2, 8);
+  return `snippet-${Date.now().toString(36)}-${random}`;
+}
+
+/** Trim, drop empties, and de-duplicate (case-sensitive) a tag list. */
+export function normalizeTags(tags: string[] | undefined): string[] {
+  if (!Array.isArray(tags)) return [];
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const tag of tags) {
+    if (typeof tag !== 'string') continue;
+    const trimmed = tag.trim();
+    if (!trimmed || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    result.push(trimmed);
+  }
+  return result;
+}
+
+/** Parse a comma-separated tag input ("docker, logs") into normalized tags. */
+export function parseTagInput(input: string): string[] {
+  return normalizeTags(input.split(','));
+}
+
+function persist(snippets: CommandSnippet[]): void {
+  try {
+    localStorage.setItem(SNIPPETS_STORAGE_KEY, JSON.stringify(snippets));
+  } catch (error) {
+    console.error('Failed to save command snippets:', error);
+  }
+}
+
+function notifyChanged(): void {
+  try {
+    window.dispatchEvent(new Event(SNIPPETS_CHANGED_EVENT));
+  } catch {
+    // Non-browser environment (unit tests without jsdom setup) — ignore.
+  }
+}
+
+export class SnippetStorageManager {
+  /**
+   * All snippets, oldest first (stable creation order). Corrupt storage
+   * or malformed entries degrade to an empty/partial list.
+   */
+  static getSnippets(): CommandSnippet[] {
+    try {
+      const stored = localStorage.getItem(SNIPPETS_STORAGE_KEY);
+      if (!stored) return [];
+      const parsed = JSON.parse(stored) as unknown;
+      if (!Array.isArray(parsed)) return [];
+      return parsed
+        .filter(isValidSnippet)
+        .map((snippet) => ({
+          ...snippet,
+          tags: normalizeTags(snippet.tags),
+          usageCount: typeof snippet.usageCount === 'number' ? snippet.usageCount : 0,
+        }));
+    } catch (error) {
+      console.error('Failed to load command snippets:', error);
+      return [];
+    }
+  }
+
+  static getSnippet(id: string): CommandSnippet | undefined {
+    return this.getSnippets().find(s => s.id === id);
+  }
+
+  /**
+   * Create or update a snippet (upsert by id). Returns null when the
+   * trimmed name or command is empty; the dialog layer is responsible
+   * for user-facing validation messages.
+   */
+  static saveSnippet(input: CommandSnippetInput): CommandSnippet | null {
+    const name = input.name.trim();
+    const command = input.command.trim();
+    if (!name || !command) return null;
+
+    const now = new Date().toISOString();
+    const snippets = this.getSnippets();
+    const existingIndex = input.id ? snippets.findIndex(s => s.id === input.id) : -1;
+
+    const snippet: CommandSnippet = {
+      id: input.id || generateSnippetId(),
+      name,
+      command,
+      description: input.description?.trim() || undefined,
+      tags: normalizeTags(input.tags),
+      createdAt: existingIndex >= 0 ? snippets[existingIndex].createdAt : (input.createdAt ?? now),
+      updatedAt: now,
+      usageCount: existingIndex >= 0 ? snippets[existingIndex].usageCount : (input.usageCount ?? 0),
+    };
+
+    if (existingIndex >= 0) {
+      snippets[existingIndex] = snippet;
+    } else {
+      snippets.push(snippet);
+    }
+
+    persist(snippets);
+    notifyChanged();
+    return snippet;
+  }
+
+  static deleteSnippet(id: string): boolean {
+    const snippets = this.getSnippets();
+    const next = snippets.filter(s => s.id !== id);
+    if (next.length === snippets.length) return false;
+    persist(next);
+    notifyChanged();
+    return true;
+  }
+
+  /** Record a "sent to terminal" use: bumps usageCount and lastUsedAt. */
+  static recordSnippetUsage(id: string): void {
+    const snippets = this.getSnippets();
+    const snippet = snippets.find(s => s.id === id);
+    if (!snippet) return;
+    snippet.usageCount += 1;
+    snippet.lastUsedAt = new Date().toISOString();
+    persist(snippets);
+    notifyChanged();
+  }
+}

--- a/src/lib/terminal-commands.ts
+++ b/src/lib/terminal-commands.ts
@@ -7,15 +7,40 @@ export type TerminalCommand =
   | 'find'
   | 'find-next'
   | 'find-previous'
-  | 'clear-screen';
+  | 'clear-screen'
+  | 'send-text';
 
 export interface TerminalCommandDetail {
   tabId: string;
   command: TerminalCommand;
+  /** For 'send-text': the raw text to type into the terminal. */
+  text?: string;
+  /** For 'send-text': press Enter after the text (default true). */
+  execute?: boolean;
 }
 
 export function dispatchTerminalCommand(tabId: string, command: TerminalCommand): void {
   window.dispatchEvent(new CustomEvent<TerminalCommandDetail>(TERMINAL_COMMAND_EVENT, {
     detail: { tabId, command },
+  }));
+}
+
+/**
+ * Send raw text to a terminal as if it were pasted (newline normalization +
+ * bracketed-paste wrapping are applied by xterm's paste path). With
+ * `execute` (the default), an Enter follows so the command runs.
+ */
+export function dispatchTerminalText(
+  tabId: string,
+  text: string,
+  options: { execute?: boolean } = {},
+): void {
+  window.dispatchEvent(new CustomEvent<TerminalCommandDetail>(TERMINAL_COMMAND_EVENT, {
+    detail: {
+      tabId,
+      command: 'send-text',
+      text,
+      execute: options.execute !== false,
+    },
   }));
 }

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -89,6 +89,7 @@
     "noEditorHandler": "Cannot open {{name}}: no editor handler available",
     "monitor": "Monitor",
     "logs": "Logs",
+    "quickCommands": "Commands",
     "systemMonitor": "System Monitor",
     "logMonitor": "Log Monitor",
     "quickConnected": "Quick Connected",
@@ -1276,5 +1277,58 @@
     "noConnection": "No active connection. Connect to view network statistics.",
     "comingSoon": "Advanced network monitoring features coming soon",
     "disabledNotice": "Network Interfaces and Active Connections monitoring is currently disabled. Check the Network Usage and Network Latency charts in the Monitor tab for current network metrics."
+  },
+  "quickCommands": {
+    "title": "Quick Commands",
+    "searchPlaceholder": "Search snippets…",
+    "newSnippet": "New snippet",
+    "noActiveTerminal": "No active terminal — connect to a host to run snippets",
+    "emptyTitle": "No snippets yet",
+    "emptyDescription": "Save frequently used commands and run them in the active terminal with one click.",
+    "emptyCreate": "Create snippet",
+    "emptySearch": "No snippets match your search",
+    "snippetCount_one": "{{count}} snippet",
+    "snippetCount_other": "{{count}} snippets",
+    "sort": {
+      "ariaLabel": "Sort snippets",
+      "mostUsed": "Most used",
+      "recentlyUsed": "Recently used",
+      "name": "Name"
+    },
+    "actions": {
+      "run": "Run in active terminal",
+      "insert": "Insert without running",
+      "copy": "Copy to clipboard",
+      "edit": "Edit",
+      "delete": "Delete"
+    },
+    "deleteConfirm": {
+      "title": "Delete snippet",
+      "description": "Delete \"{{name}}\"? This cannot be undone."
+    },
+    "dialog": {
+      "newTitle": "New snippet",
+      "editTitle": "Edit snippet",
+      "name": "Name",
+      "namePlaceholder": "e.g. Restart nginx",
+      "nameRequired": "Name is required",
+      "command": "Command",
+      "commandPlaceholder": "e.g. sudo systemctl restart nginx",
+      "commandRequired": "Command is required",
+      "commandHint": "Sent to the terminal as a paste; line breaks are preserved.",
+      "description": "Description",
+      "descriptionPlaceholder": "Optional note",
+      "tags": "Tags",
+      "tagsPlaceholder": "Comma-separated, e.g. docker, logs",
+      "saveFailed": "Could not save the snippet"
+    },
+    "toast": {
+      "noActiveTerminal": "No active terminal",
+      "copied": "Copied to clipboard",
+      "copyFailed": "Failed to copy to clipboard",
+      "created": "Snippet created",
+      "updated": "Snippet updated",
+      "deleted": "Snippet deleted"
+    }
   }
 }

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -89,6 +89,7 @@
     "noEditorHandler": "无法打开 {{name}}：没有可用的编辑器",
     "monitor": "监视器",
     "logs": "日志",
+    "quickCommands": "命令",
     "systemMonitor": "系统监视器",
     "logMonitor": "日志监视器",
     "quickConnected": "快速连接成功",
@@ -1276,5 +1277,58 @@
     "noConnection": "无活动连接，连接后即可查看网络统计。",
     "comingSoon": "高级网络监控功能即将推出",
     "disabledNotice": "网络接口和活动连接监控当前已禁用。请查看「监控」选项卡中的网络使用率和网络延迟图表以获取当前网络指标。"
+  },
+  "quickCommands": {
+    "title": "快捷命令",
+    "searchPlaceholder": "搜索命令片段…",
+    "newSnippet": "新建命令片段",
+    "noActiveTerminal": "没有活动终端——请先连接主机才能执行",
+    "emptyTitle": "还没有命令片段",
+    "emptyDescription": "保存常用命令，一键发送到当前终端执行。",
+    "emptyCreate": "创建命令片段",
+    "emptySearch": "没有匹配的命令片段",
+    "snippetCount_one": "{{count}} 个命令片段",
+    "snippetCount_other": "{{count}} 个命令片段",
+    "sort": {
+      "ariaLabel": "排序方式",
+      "mostUsed": "最常用",
+      "recentlyUsed": "最近使用",
+      "name": "按名称"
+    },
+    "actions": {
+      "run": "在当前终端执行",
+      "insert": "仅输入不执行",
+      "copy": "复制到剪贴板",
+      "edit": "编辑",
+      "delete": "删除"
+    },
+    "deleteConfirm": {
+      "title": "删除命令片段",
+      "description": "确定删除“{{name}}”吗？此操作无法撤销。"
+    },
+    "dialog": {
+      "newTitle": "新建命令片段",
+      "editTitle": "编辑命令片段",
+      "name": "名称",
+      "namePlaceholder": "例如：重启 nginx",
+      "nameRequired": "请输入名称",
+      "command": "命令",
+      "commandPlaceholder": "例如：sudo systemctl restart nginx",
+      "commandRequired": "请输入命令",
+      "commandHint": "以粘贴方式发送到终端，换行会被保留。",
+      "description": "描述",
+      "descriptionPlaceholder": "可选备注",
+      "tags": "标签",
+      "tagsPlaceholder": "逗号分隔，例如 docker, logs",
+      "saveFailed": "保存命令片段失败"
+    },
+    "toast": {
+      "noActiveTerminal": "没有活动终端",
+      "copied": "已复制到剪贴板",
+      "copyFailed": "复制到剪贴板失败",
+      "created": "命令片段已创建",
+      "updated": "命令片段已更新",
+      "deleted": "命令片段已删除"
+    }
   }
 }


### PR DESCRIPTION
Closes #115

## Summary

Adds a Termius/Xshell-style **Quick Commands** panel as a third tab ("Commands") in the right sidebar, next to Monitor/Logs. Users save frequently used commands as snippets and send them to the active terminal in one click.

### Features
- **Snippet CRUD** — create/edit via a compact dialog (name, multi-line command, description, comma-separated tags) with inline validation; delete behind an AlertDialog confirm
- **Search** across name / command / description / tags, and **sort** by most-used / recently-used / name; usage tracking (`usageCount` / `lastUsedAt`) reorders the list under the default most-used sort
- **Run** — clicking a card sends the snippet to the active terminal and executes it; **Insert without running** pastes it for review first; **Copy** copies the raw command
- **Guards & states** — a hint row + toast when no terminal is active; empty and no-search-match states; `ErrorBoundary`-wrapped like its sibling tabs

### Design decisions (follows existing app patterns)
- **Send path**: the panel never touches WebSockets. It dispatches a new `send-text` command over the existing `TERMINAL_COMMAND_EVENT` bus; `PtyTerminal` handles it via `term.paste()` + optional `\r`. I verified against the installed xterm source that `paste()` applies newline normalization and bracketed-paste wrapping, so multi-line snippets behave exactly like a real paste. Any pending Xshell-style Ctrl+A prefix is flushed first so it can't merge with the snippet.
- **Persistence**: `SnippetStorageManager` mirrors the `ConnectionStorageManager` pattern — localStorage, defensive parsing (corrupt data degrades to empty, malformed entries filtered), change event for reactivity including other webview windows.
- **i18n**: all strings via `react-i18next`; 55 new keys added to both `en.json` and `zh-CN.json` (`pnpm i18n:check` green).

## Testing

- 32 new tests: storage unit tests (CRUD, validation, usage tracking, corrupt-storage fallback, change events), dispatcher tests, panel behavior tests (search/CRUD/confirm/no-terminal guard), and a `PtyTerminal` integration test asserting `term.paste()` calls and the binary `\r` input frame on the mock WebSocket (execute vs insert, cross-tab isolation, disconnected socket)
- Full suite: 700/701 passing — the one failure (`terminal-group-serializer > warns on localStorage write failure`) reproduces on a clean checkout under Node 26/jsdom 28 (Node file-backed localStorage bypasses the jsdom `Storage.prototype` spy) and is unrelated to this change
- `tsc --noEmit` clean, `vite build` clean, ESLint 0 errors / no new warnings