### PR TITLE
fix(terminal): keep PTY size in sync with xterm to prevent silent display/input divergence (#88)

### DIFF
--- a/src-tauri/src/connection_manager.rs
+++ b/src-tauri/src/connection_manager.rs
@@ -612,6 +612,41 @@ impl ConnectionManager {
             .map_err(|_| anyhow::anyhow!("PTY resize channel closed"))
     }
 
+    /// Resize PTY, tolerating a session that is still being (re)started.
+    ///
+    /// `StartPty` inserts the session only after the SSH channel setup (which
+    /// includes a shell probe that can take seconds), so a `Resize` racing
+    /// that window used to fail with "PTY connection not found" — the size was
+    /// lost permanently and the remote shell kept redrawing wrapped lines with
+    /// a stale width model, silently hiding characters from the display while
+    /// they remained in the input buffer (issue #88). While the session is
+    /// absent we retry briefly; once it appears the resize is applied. A
+    /// session that never appears still fails after the bounded window.
+    pub async fn resize_pty_with_retry(
+        &self,
+        connection_id: &str,
+        cols: u32,
+        rows: u32,
+    ) -> Result<()> {
+        const RETRY_INTERVAL: Duration = Duration::from_millis(100);
+        const RETRY_BUDGET: u32 = 12;
+
+        for attempt in 0..RETRY_BUDGET {
+            match self.resize_pty(connection_id, cols, rows).await {
+                Ok(()) => return Ok(()),
+                Err(e) => {
+                    let session_absent =
+                        !self.pty_sessions.read().await.contains_key(connection_id);
+                    if !session_absent || attempt + 1 >= RETRY_BUDGET {
+                        return Err(e);
+                    }
+                    tokio::time::sleep(RETRY_INTERVAL).await;
+                }
+            }
+        }
+        unreachable!("retry loop always returns within RETRY_BUDGET attempts")
+    }
+
     // ===== Standalone SFTP Connection Management =====
 
     pub async fn create_sftp_connection(
@@ -1077,6 +1112,71 @@ mod tests {
         assert!(matches!(err, PtyStartError::SshSessionDead(_)));
     }
 
+    // ===== Resize retry (issue #88: resize racing session start) =====
+
+    fn fake_pty_session(resize_tx: mpsc::Sender<(u32, u32)>) -> PtySession {
+        let (input_tx, _input_rx) = mpsc::channel::<Vec<u8>>(1);
+        let (_output_tx, output_rx) = mpsc::channel::<Vec<u8>>(8);
+        PtySession {
+            input_tx,
+            output_rx: Arc::new(tokio::sync::Mutex::new(output_rx)),
+            // ChannelId's field is private; tests can't construct it safely.
+            channel_id: unsafe { std::mem::transmute(0u32) },
+            resize_tx,
+            cancel: CancellationToken::new(),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_resize_pty_with_retry_tolerates_session_starting_late() {
+        let mgr = Arc::new(ConnectionManager::new());
+
+        // The session appears 300 ms later — simulating the StartPty SSH
+        // channel setup window during which `pty_sessions` has no entry yet.
+        let late_mgr = mgr.clone();
+        let (resize_tx, mut resize_rx) = mpsc::channel::<(u32, u32)>(16);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(300)).await;
+            let mut sessions = late_mgr.pty_sessions.write().await;
+            sessions.insert("late-1".to_string(), Arc::new(fake_pty_session(resize_tx)));
+        });
+
+        let start = std::time::Instant::now();
+        mgr.resize_pty_with_retry("late-1", 120, 40).await.unwrap();
+        assert!(start.elapsed() >= Duration::from_millis(300));
+        let (cols, rows) = resize_rx.recv().await.unwrap();
+        assert_eq!((cols, rows), (120, 40));
+    }
+
+    #[tokio::test]
+    async fn test_resize_pty_with_retry_immediate_when_session_present() {
+        let mgr = ConnectionManager::new();
+        let (resize_tx, mut resize_rx) = mpsc::channel::<(u32, u32)>(16);
+        {
+            let mut sessions = mgr.pty_sessions.write().await;
+            sessions.insert("live-1".to_string(), Arc::new(fake_pty_session(resize_tx)));
+        }
+
+        let start = std::time::Instant::now();
+        mgr.resize_pty_with_retry("live-1", 100, 30).await.unwrap();
+        assert!(start.elapsed() < Duration::from_millis(100));
+        let (cols, rows) = resize_rx.recv().await.unwrap();
+        assert_eq!((cols, rows), (100, 30));
+    }
+
+    #[tokio::test]
+    async fn test_resize_pty_with_retry_bounded_when_session_never_appears() {
+        let mgr = ConnectionManager::new();
+
+        let start = std::time::Instant::now();
+        assert!(mgr.resize_pty_with_retry("ghost", 80, 24).await.is_err());
+        let elapsed = start.elapsed();
+        // Waited out the bounded retry budget instead of failing instantly or
+        // hanging forever.
+        assert!(elapsed >= Duration::from_millis(1000));
+        assert!(elapsed < Duration::from_secs(5));
+    }
+
     #[tokio::test]
     async fn test_evict_dead_connection_guarded_by_arc_identity() {
         let mgr = ConnectionManager::new();
@@ -1155,7 +1255,10 @@ mod tests {
         }
         assert!(mgr.has_detached_session("det-1").await);
         assert!(!mgr.has_detached_session("det-2").await);
-        assert_eq!(mgr.list_detached_sessions().await, vec!["det-1".to_string()]);
+        assert_eq!(
+            mgr.list_detached_sessions().await,
+            vec!["det-1".to_string()]
+        );
     }
 
     #[tokio::test]

--- a/src-tauri/src/ssh/tests.rs
+++ b/src-tauri/src/ssh/tests.rs
@@ -333,6 +333,54 @@ mod shell_integration_tests {
 
     #[tokio::test]
     #[ignore]
+    async fn docker_ssh_resize_propagates_to_remote_shell() {
+        // Issue #88: the PTY size must track the terminal's size at all
+        // times. A resize that never reaches the remote tty leaves bash
+        // redrawing wrapped command lines with a stale width model — the
+        // display then silently diverges from the remote input buffer (the
+        // user sees one command but executes another). This guards the
+        // end-to-end resize path: window_change must reach the remote shell
+        // and `stty size` must report the new geometry.
+        let (host, port) = test_server_endpoint();
+        let mut client = SshClient::new();
+        client
+            .connect(&SshConfig {
+                host,
+                port,
+                username: "testuser".to_string(),
+                auth_method: AuthMethod::Password {
+                    password: "testpass".to_string(),
+                },
+                compression: true,
+                keepalive_interval: Some(60),
+                keepalive_max: Some(3),
+                proxy: None,
+                tunnel: None,
+            })
+            .await
+            .expect("connect to Docker SSH server");
+
+        let pty = client.create_pty_session(80, 24).await.expect("create PTY");
+        let _ = read_until(&pty, b"\x1b\\").await; // first prompt is up
+
+        pty.resize_tx
+            .send((120, 40))
+            .await
+            .expect("send resize request");
+
+        // `stty size` prints "<rows> <cols>" — expect the new geometry.
+        let mut input = b"stty size".to_vec();
+        input.push(b'\n');
+        pty.input_tx.send(input).await.expect("send stty command");
+        let output = read_until(&pty, b"40 120").await;
+        assert!(
+            String::from_utf8_lossy(&output).contains("40 120"),
+            "remote tty should report the resized geometry"
+        );
+    }
+
+    #[tokio::test]
+    #[ignore]
     async fn docker_ssh_reports_cwd_and_lists_sftp_directories() {
         let mut client = SshClient::new();
         client

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -740,8 +740,12 @@ impl WebSocketServer {
                 rows,
             } => {
                 tracing::info!("Resizing terminal {}: {}x{}", connection_id, cols, rows);
+                // Retry while the session is still being (re)started — a resize
+                // racing StartPty's channel setup must not be lost, or the
+                // remote shell redraws wrapped lines with a stale width and the
+                // display diverges from the input buffer (issue #88).
                 self.connection_manager
-                    .resize_pty(&connection_id, cols, rows)
+                    .resize_pty_with_retry(&connection_id, cols, rows)
                     .await?;
                 let response = WsMessage::Success {
                     message: format!("Terminal resized: {}x{}", cols, rows),

--- a/src/__tests__/pty-terminal-resize-sync.test.tsx
+++ b/src/__tests__/pty-terminal-resize-sync.test.tsx
@@ -1,0 +1,359 @@
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { act, cleanup, render } from '@testing-library/react';
+import { PtyTerminal } from '../components/pty-terminal';
+
+// Issue #88 regression tests: a terminal resize must never be lost between
+// xterm and the PTY. When a resize is observed while the WebSocket is not
+// OPEN it is stashed and flushed on the next open; a fit racing the StartPty
+// handshake is re-synced on PtyStarted. A PTY left at a stale size makes the
+// remote shell redraw wrapped command lines with the old width, so characters
+// silently disappear from the display while they remain in the input buffer —
+// the user then executes a different command than the one they see.
+
+const mocks = vi.hoisted(() => {
+  const terminals: Array<any> = [];
+  const fitAddons: Array<any> = [];
+  const webSockets: Array<any> = [];
+  const resizeHandlers: Array<(dims: { cols: number; rows: number }) => void> = [];
+  const terminalCallbacks = {
+    onWorkingDirectoryChange: vi.fn(),
+  };
+
+  class MockTerminal {
+    cols = 80;
+    rows = 24;
+    options: Record<string, unknown> = {};
+    buffer = {
+      active: {
+        length: 0,
+        getLine: vi.fn(),
+      },
+    };
+    parser = {
+      registerOscHandler: vi.fn(() => ({ dispose: vi.fn() })),
+    };
+
+    loadAddon = vi.fn();
+    open = vi.fn();
+    focus = vi.fn();
+    refresh = vi.fn();
+    writeln = vi.fn();
+    write = vi.fn((_data: string, callback?: () => void) => callback?.());
+    paste = vi.fn();
+    onSelectionChange = vi.fn(() => ({ dispose: vi.fn() }));
+    onLineFeed = vi.fn(() => ({ dispose: vi.fn() }));
+    attachCustomKeyEventHandler = vi.fn();
+    onData = vi.fn(() => ({ dispose: vi.fn() }));
+    onResize = vi.fn((handler: (dims: { cols: number; rows: number }) => void) => {
+      resizeHandlers.push(handler);
+      return { dispose: vi.fn() };
+    });
+    hasSelection = vi.fn(() => false);
+    getSelection = vi.fn(() => '');
+    selectAll = vi.fn();
+    clear = vi.fn();
+    reset = vi.fn();
+    dispose = vi.fn();
+  }
+
+  class MockFitAddon {
+    fit = vi.fn();
+    dispose = vi.fn();
+
+    constructor() {
+      fitAddons.push(this);
+    }
+  }
+
+  class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    readyState = MockWebSocket.OPEN;
+    send = vi.fn();
+    close = vi.fn(() => {
+      this.readyState = MockWebSocket.CLOSED;
+    });
+    onopen: (() => void) | null = null;
+    onmessage: ((event: MessageEvent) => void) | null = null;
+    onerror: ((event: Event) => void) | null = null;
+    onclose: (() => void) | null = null;
+
+    constructor(public url: string) {
+      webSockets.push(this);
+    }
+  }
+
+  const Terminal = vi.fn(function Terminal() {
+    const terminal = new MockTerminal();
+    terminals.push(terminal);
+    return terminal;
+  });
+
+  return {
+    terminals,
+    fitAddons,
+    webSockets,
+    resizeHandlers,
+    terminalCallbacks,
+    Terminal,
+    MockFitAddon,
+    MockWebSocket,
+  };
+});
+
+vi.mock('@xterm/xterm', () => ({
+  Terminal: mocks.Terminal,
+}));
+
+vi.mock('@xterm/addon-fit', () => ({
+  FitAddon: mocks.MockFitAddon,
+}));
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: vi.fn(function WebLinksAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-webgl', () => ({
+  WebglAddon: vi.fn(function WebglAddon() {
+    return { dispose: vi.fn(), onContextLoss: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-search', () => ({
+  SearchAddon: vi.fn(function SearchAddon() {
+    return { findNext: vi.fn(), findPrevious: vi.fn() };
+  }),
+}));
+
+vi.mock('@xterm/addon-clipboard', () => ({
+  ClipboardAddon: vi.fn(function ClipboardAddon() {
+    return { dispose: vi.fn() };
+  }),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+}));
+
+vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({
+  readText: vi.fn().mockResolvedValue(''),
+  writeText: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../lib/terminal-config', () => ({
+  defaultTerminalTheme: { background: '#000000' },
+  terminalThemes: { 'vs-code-dark': { background: '#000000' } },
+  loadAppearanceSettings: vi.fn(() => ({
+    allowTransparency: false,
+    backgroundImage: '',
+    opacity: 100,
+    theme: 'vs-code-dark',
+  })),
+  getThemeAwareTerminalOptions: vi.fn(() => ({
+    cursorBlink: true,
+    cursorStyle: 'block',
+    fontFamily: 'monospace',
+    fontSize: 14,
+    scrollback: 10000,
+    theme: {},
+  })),
+  getThemeAwareTerminalTheme: vi.fn(() => ({ background: '#000000' })),
+}));
+
+vi.mock('../components/terminal/terminal-context-menu', () => ({
+  TerminalContextMenu: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('../components/terminal/terminal-search-bar', () => ({
+  TerminalSearchBar: () => null,
+}));
+
+vi.mock('../lib/restoration-manager', () => ({
+  signalReady: vi.fn(),
+}));
+
+vi.mock('../lib/terminal-callbacks-context', () => ({
+  useTerminalCallbacks: () => mocks.terminalCallbacks,
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+    info: vi.fn(),
+    success: vi.fn(),
+  },
+}));
+
+type SentMessage = Record<string, unknown>;
+
+function sentJsonMessages(webSocket: any): SentMessage[] {
+  return webSocket.send.mock.calls
+    .map(([data]: unknown[]) => data)
+    .filter((data: unknown): data is string => typeof data === 'string')
+    .map((data: string) => JSON.parse(data) as SentMessage);
+}
+
+async function mountTerminal(options: { readyState?: number } = {}) {
+  render(
+    <PtyTerminal
+      connectionId="connection-1"
+      connectionName="SSH Server"
+      host="127.0.0.1"
+      username="root"
+      isActive
+    />,
+  );
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(60);
+  });
+
+  const webSocket = mocks.webSockets[0];
+  expect(webSocket).toBeDefined();
+  if (options.readyState !== undefined) {
+    webSocket.readyState = options.readyState;
+  }
+  return webSocket;
+}
+
+describe('PtyTerminal resize synchronization (issue #88)', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.clearAllMocks();
+    mocks.terminals.length = 0;
+    mocks.fitAddons.length = 0;
+    mocks.webSockets.length = 0;
+    mocks.resizeHandlers.length = 0;
+
+    Object.defineProperty(HTMLElement.prototype, 'offsetWidth', {
+      configurable: true,
+      value: 800,
+    });
+    Object.defineProperty(HTMLElement.prototype, 'offsetHeight', {
+      configurable: true,
+      value: 600,
+    });
+
+    vi.stubGlobal('WebSocket', mocks.MockWebSocket);
+    vi.stubGlobal(
+      'ResizeObserver',
+      class {
+        observe = vi.fn();
+        disconnect = vi.fn();
+      },
+    );
+    vi.stubGlobal(
+      'requestAnimationFrame',
+      vi.fn((callback: FrameRequestCallback) => {
+        return window.setTimeout(() => callback(performance.now()), 0);
+      }),
+    );
+    vi.stubGlobal('cancelAnimationFrame', vi.fn((id: number) => window.clearTimeout(id)));
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  it('flushes a resize observed while the socket was not OPEN right after StartPty', async () => {
+    const webSocket = await mountTerminal({ readyState: mocks.MockWebSocket.CONNECTING });
+
+    // The layout settles while the socket is still CONNECTING: the fit fires
+    // onResize with new dims. Nothing can be delivered yet.
+    expect(mocks.resizeHandlers.length).toBeGreaterThan(0);
+    await act(async () => {
+      mocks.resizeHandlers.forEach((handler) => handler({ cols: 100, rows: 30 }));
+    });
+    expect(sentJsonMessages(webSocket)).toEqual([]);
+
+    // Socket opens: StartPty carries the dims known at open time, and the
+    // stashed resize must follow so the PTY is not left at the stale size.
+    webSocket.readyState = mocks.MockWebSocket.OPEN;
+    await act(async () => {
+      webSocket.onopen?.();
+    });
+
+    const messages = sentJsonMessages(webSocket);
+    expect(messages[0]).toMatchObject({ type: 'StartPty', cols: 80, rows: 24 });
+    expect(messages[1]).toMatchObject({ type: 'Resize', cols: 100, rows: 30 });
+  });
+
+  it('does not re-send the flushed resize and keeps deduplicating afterwards', async () => {
+    const webSocket = await mountTerminal({ readyState: mocks.MockWebSocket.CONNECTING });
+
+    await act(async () => {
+      mocks.resizeHandlers.forEach((handler) => handler({ cols: 100, rows: 30 }));
+    });
+    webSocket.readyState = mocks.MockWebSocket.OPEN;
+    await act(async () => {
+      webSocket.onopen?.();
+    });
+    expect(sentJsonMessages(webSocket).filter((m) => m.type === 'Resize')).toHaveLength(1);
+
+    // The same dims again must not produce a duplicate resize (SIGWINCH noise).
+    await act(async () => {
+      mocks.resizeHandlers.forEach((handler) => handler({ cols: 100, rows: 30 }));
+    });
+    // A genuine change still goes through.
+    await act(async () => {
+      mocks.resizeHandlers.forEach((handler) => handler({ cols: 120, rows: 30 }));
+    });
+
+    const resizes = sentJsonMessages(webSocket).filter((m) => m.type === 'Resize');
+    expect(resizes).toHaveLength(2);
+    expect(resizes[1]).toMatchObject({ cols: 120, rows: 30 });
+  });
+
+  it('re-syncs the PTY when a fit raced the StartPty handshake', async () => {
+    const webSocket = await mountTerminal();
+
+    await act(async () => {
+      webSocket.onopen?.();
+    });
+    expect(sentJsonMessages(webSocket)[0]).toMatchObject({ type: 'StartPty', cols: 80, rows: 24 });
+
+    // The container settles while the backend is still establishing the
+    // session (SSH channel setup + shell probe): the terminal refits, but no
+    // Resize message was produced because onResize fired before open.
+    mocks.terminals[0].cols = 100;
+
+    await act(async () => {
+      webSocket.onmessage?.({
+        data: JSON.stringify({
+          type: 'PtyStarted',
+          connection_id: 'connection-1',
+          generation: 1,
+        }),
+      } as MessageEvent);
+    });
+
+    const resizes = sentJsonMessages(webSocket).filter((m) => m.type === 'Resize');
+    expect(resizes).toHaveLength(1);
+    expect(resizes[0]).toMatchObject({ cols: 100, rows: 24 });
+  });
+
+  it('sends no redundant resize when the dims already match the session', async () => {
+    const webSocket = await mountTerminal();
+
+    await act(async () => {
+      webSocket.onopen?.();
+    });
+    await act(async () => {
+      webSocket.onmessage?.({
+        data: JSON.stringify({
+          type: 'PtyStarted',
+          connection_id: 'connection-1',
+          generation: 1,
+        }),
+      } as MessageEvent);
+    });
+
+    expect(sentJsonMessages(webSocket).filter((m) => m.type === 'Resize')).toHaveLength(0);
+  });
+});

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -568,6 +568,17 @@ export function PtyTerminal({
     term.write('\r\n');
 
     let isRunning = true;
+    // Last dims known to have been delivered to the PTY. The onResize handler
+    // only forwards actual changes, so a resize must always update this —
+    // otherwise every subsequent fit would re-send the same size (issue #88).
+    let lastSentCols = term.cols;
+    let lastSentRows = term.rows;
+    // A resize observed while the WebSocket was not OPEN (reconnect backoff,
+    // initial CONNECTING window). It must be flushed on the next open instead
+    // of being dropped — a PTY left at the old size makes bash redraw wrapped
+    // lines with a stale width model and the display silently loses characters
+    // while the remote input buffer keeps them (issue #88).
+    let pendingResize: { cols: number; rows: number } | null = null;
     // Tracks whether a PTY session has been successfully established in this
     // effect run. Reset to false when we initiate an auto-reconnect after a
     // drop so the reconnect loop can function normally.
@@ -621,6 +632,10 @@ export function PtyTerminal({
 
     // Connect to WebSocket server
     const connectWebSocket = async () => {
+      // Dims carried by the StartPty currently in flight — PtyStarted compares
+      // them against the terminal's dims to detect a fit that raced the
+      // handshake and re-syncs the PTY (issue #88).
+      let startPtyDims: { cols: number; rows: number } | null = null;
       // CRITICAL: Wait for terminal to be properly sized before starting PTY
       await waitForProperSize();
       
@@ -653,16 +668,39 @@ export function PtyTerminal({
       ws.onopen = () => {
         console.log(`[PTY Terminal] [${connectionId}] WebSocket connected`);
         term.writeln(`\x1b[32m${i18n.t('ptyTerminal.webSocketConnected')}\x1b[0m`);
-        
-        // Start PTY session
+
+        // Start PTY session.
+        // Capture the dims the PTY is created with — PtyStarted compares them
+        // against the current terminal dims to detect a fit that raced this
+        // handshake (issue #88).
+        const startCols = term.cols;
+        const startRows = term.rows;
+        startPtyDims = { cols: startCols, rows: startRows };
         const startMsg = {
           type: 'StartPty',
           connection_id: connectionId,
-          cols: term.cols,
-          rows: term.rows,
+          cols: startCols,
+          rows: startRows,
         };
-        console.log(`[PTY Terminal] [${connectionId}] Starting PTY connection with ${term.cols}x${term.rows}`);
+        console.log(`[PTY Terminal] [${connectionId}] Starting PTY connection with ${startCols}x${startRows}`);
         ws.send(JSON.stringify(startMsg));
+
+        // Flush a resize that was observed while this socket was not OPEN yet
+        // (issue #88): dropping it would leave the PTY at a stale size, and
+        // bash keeps redrawing wrapped lines with the old width — characters
+        // then silently disappear from the display while they remain in the
+        // remote input buffer. When the pending dims match the StartPty dims
+        // there is nothing to do — StartPty already created the session at
+        // that size.
+        if (pendingResize) {
+          const { cols, rows } = pendingResize;
+          pendingResize = null;
+          if (cols !== startCols || rows !== startRows) {
+            ws.send(JSON.stringify({ type: 'Resize', connection_id: connectionId, cols, rows }));
+          }
+          lastSentCols = cols;
+          lastSentRows = rows;
+        }
       };
 
       // =========================================================================
@@ -784,6 +822,33 @@ export function PtyTerminal({
                 // Ongoing credits are returned by the flush callback above.
                 const INITIAL_WINDOW = 2;
                 grantCredits(INITIAL_WINDOW);
+                // Issue #88 self-heal: if the terminal was refitted while the
+                // StartPty handshake was in flight (backend applies StartPty
+                // only after the SSH channel setup, which includes a shell
+                // probe), the PTY was created with stale dims. Re-sync now —
+                // otherwise bash redraws wrapped lines with the stale width
+                // and the display diverges from the remote input buffer.
+                // The lastSent guard skips resizes that were already delivered
+                // (directly or via the pending-resize flush) so we never emit
+                // a redundant SIGWINCH here.
+                const needsResizeSync =
+                  startPtyDims !== null &&
+                  (term.cols !== startPtyDims.cols || term.rows !== startPtyDims.rows) &&
+                  (term.cols !== lastSentCols || term.rows !== lastSentRows);
+                if (needsResizeSync) {
+                  const ws = wsRef.current;
+                  if (ws && ws.readyState === WebSocket.OPEN) {
+                    ws.send(JSON.stringify({
+                      type: 'Resize',
+                      connection_id: connectionId,
+                      cols: term.cols,
+                      rows: term.rows,
+                    }));
+                    lastSentCols = term.cols;
+                    lastSentRows = term.rows;
+                  }
+                }
+                startPtyDims = null;
                 if (msg.reattached) {
                   // The backend re-attached a parked session — the same
                   // remote shell continues (transient WebSocket drop).
@@ -971,16 +1036,17 @@ export function PtyTerminal({
     // identical resize signals when the layout is settling (e.g. after closing
     // an adjacent terminal group). Each redundant SIGWINCH causes the remote
     // shell to redraw its prompt, producing the repeated "root@host:~#" lines.
-    let lastSentCols = term.cols;
-    let lastSentRows = term.rows;
     const resizeDisposable = term.onResize(({ cols, rows }) => {
       if (cols === lastSentCols && rows === lastSentRows) return;
-      lastSentCols = cols;
-      lastSentRows = rows;
       checkScrollability(); // row count changed — re-evaluate scrollability
 
       const ws = wsRef.current;
       if (ws && ws.readyState === WebSocket.OPEN) {
+        lastSentCols = cols;
+        lastSentRows = rows;
+        // A direct send supersedes anything stashed for the next open — the
+        // newest dims have already been delivered.
+        pendingResize = null;
         const resizeMsg = {
           type: 'Resize',
           connection_id: connectionId,
@@ -989,6 +1055,14 @@ export function PtyTerminal({
         };
         ws.send(JSON.stringify(resizeMsg));
         console.log(`[PTY Terminal] Terminal resized to ${cols}x${rows}`);
+      } else {
+        // The socket is down (reconnect backoff, CONNECTING window). Stash the
+        // dims — `ws.onopen` flushes them after StartPty. Updating the
+        // lastSent bookkeeping here would make the resize unrecoverable: the
+        // PTY keeps the old size and bash redraws wrapped lines with a stale
+        // width model, so characters silently vanish from the display while
+        // they remain in the remote input buffer (issue #88).
+        pendingResize = { cols, rows };
       }
     });
 


### PR DESCRIPTION
## Summary

Fixes #88 — a terminal can display a command that differs from the command actually executed by the remote shell (e.g. visible `--rw=read`, argv `--rw=rread`).

## Root cause

When a terminal resize is applied by xterm but never delivered to the PTY, the remote shell keeps redrawing wrapped command lines with a **stale width model**. Readline's overlapping redraws then silently hide characters that remain in the remote input buffer — pressing Enter executes a different command than the user sees.

**Reproduced end-to-end** with the app's exact PTY creation path (`SshClient::create_pty_session`, incl. bash probe / ECHO modes / shell integration) + a real xterm.js v6 instance running the issue's edit sequence on a long wrapped command (`argv <96×A> --rw=write` → backspace `write` → type `read` → Enter → compare displayed line vs remote argv):

| Scenario | Result |
|---|---|
| typing, in-place edits (Backspace/Delete/arrows), history recall (↑), resize before/mid/racing typing, tab-away size cycle | display == remote argv (consistent) |
| **one resize xterm applied but the PTY never received** (socket-down window) | **DIVERGENCE: 85 visible chars vs 105 remote argv chars** — exactly the issue's signature; persists through further edits |

The transport itself (russh → WS → xterm) is lossless and ordered; the divergence only occurs through the missed-resize class of paths.

## Where the app could miss a resize

1. **Frontend `onResize`** silently dropped the resize whenever `ws.readyState !== OPEN` (reconnect backoff up to 30 s, initial CONNECTING window, tab-activation fits) **and** updated `lastSentCols/Rows` anyway — the size was unrecoverable, no re-send ever happened.
2. **Backend `Resize` handler** failed with "PTY connection not found" when it raced a session (re)start — `StartPty` inserts the session only after SSH channel setup (incl. a shell probe that can take seconds). The frontend then even treated that error as fatal-ish (marks disconnected, closes the socket).

## Changes

- **`src/components/pty-terminal.tsx`**
  - `onResize` stashes the dims when the socket is not OPEN (without updating the sent-dedup state) and `ws.onopen` flushes them right after `StartPty` (skipped when the StartPty dims already match).
  - `PtyStarted` re-syncs the PTY when a fit raced the StartPty handshake (guarded so already-delivered sizes never send a redundant SIGWINCH).
  - Direct sends supersede a stashed resize.
- **`src-tauri/src/websocket_server.rs` + `connection_manager.rs`**
  - New `resize_pty_with_retry` (bounded 12×100 ms retry while the session is absent) used by the `Resize` handler, so resizes racing `StartPty` are applied instead of lost.

## Regression coverage

- **Frontend** (4 new component tests, `src/__tests__/pty-terminal-resize-sync.test.tsx`): stash-while-CONNECTING → flush-after-open ordering (Resize follows StartPty), no duplicate flush, dedup still works, PtyStarted self-heal, no redundant resize when dims match.
- **Backend** (3 new unit tests): retry tolerates a session appearing late (resize applied), immediate when present, bounded failure for a ghost session.
- **E2E docker** (`#[ignore]`, same infra as the existing docker tests): `resize_pty` → remote `stty size` reports the new geometry.

## Verification

- `cargo test`: 170 passed / 0 failed (plus the docker e2e resize test passed against the local test container; the ignored suite uses `RSHELL_TEST_SSH_*` env).
- `vitest --run`: 716 passed / 0 failed.
- `eslint src/components/pty-terminal.tsx src/__tests__/pty-terminal-resize-sync.test.tsx`: 0 errors (only the documented intentional warning classes).
- `cargo clippy`: no new warnings; new code is rustfmt-clean.

Note: the shell integration/ECHO modes, WS credit flow control, RAF batching, terminfo-driven readline (incl. REP) and the WebGL/DOM renderer paths were all exercised/verified during the investigation; none of them produce the divergence — only the missed-resize class does.