### PR TITLE
fix(ssh): keep idle connections alive past the russh 1h rekey and stop the reconnect loop

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -77,6 +77,56 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
+
+[[package]]
+name = "anstyle-parse"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+dependencies = [
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+dependencies = [
+ "anstyle",
+ "once_cell_polyfill",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +745,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "colorchoice"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
 name = "combine"
 version = "4.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -969,6 +1025,37 @@ dependencies = [
  "libc",
  "libdbus-sys",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1321,6 +1408,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "env_filter"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.11.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "env_filter",
+ "jiff",
+ "log",
 ]
 
 [[package]]
@@ -2423,6 +2533,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "is_terminal_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2449,6 +2565,42 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "jiff"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
+dependencies = [
+ "defmt",
+ "jiff-core",
+ "jiff-static",
+ "log",
+ "portable-atomic",
+ "portable-atomic-util",
+ "serde_core",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
+]
+
+[[package]]
+name = "jiff-static"
+version = "0.2.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
+dependencies = [
+ "jiff-core",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3172,6 +3324,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "once_cell_polyfill"
+version = "1.70.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
 name = "opaque-debug"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3656,6 +3814,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "portable-atomic"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+
+[[package]]
+name = "portable-atomic-util"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
+dependencies = [
+ "portable-atomic",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3817,6 +3990,7 @@ dependencies = [
  "async-trait",
  "base64 0.22.1",
  "dirs 6.0.0",
+ "env_logger",
  "futures",
  "open",
  "russh",
@@ -6122,6 +6296,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -52,6 +52,7 @@ sys-locale = "0.3"
 
 [dev-dependencies]
 tempfile = "3"
+env_logger = "0.11"
 
 # Performance optimization profiles
 [profile.release]

--- a/src-tauri/examples/rekey_repro.rs
+++ b/src-tauri/examples/rekey_repro.rs
@@ -1,0 +1,104 @@
+//! Rekey repro: verifies whether russh's time-based rekey kills the transport.
+//!
+//! Usage: cargo run -p r-shell --example rekey_repro -- [host] [port] [user] [pass] [rekey_secs] [keepalive_secs] [run_secs]
+//! Defaults target the docker test server: 127.0.0.1 2222 testuser testpass 15 5 60
+use russh::*;
+use russh::client;
+use russh_keys::key;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+#[derive(Clone)]
+struct Handler;
+
+#[async_trait::async_trait]
+impl client::Handler for Handler {
+    type Error = russh::Error;
+
+    async fn check_server_key(
+        &mut self,
+        _server_public_key: &key::PublicKey,
+    ) -> Result<bool, Self::Error> {
+        Ok(true)
+    }
+}
+
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
+    let args: Vec<String> = std::env::args().collect();
+    let host = args.get(1).map(String::as_str).unwrap_or("127.0.0.1").to_string();
+    let port: u16 = args.get(2).map(|s| s.parse().unwrap()).unwrap_or(2222);
+    let user = args.get(3).map(String::as_str).unwrap_or("testuser").to_string();
+    let pass = args.get(4).map(String::as_str).unwrap_or("testpass").to_string();
+    let rekey_s: u64 = args.get(5).map(|s| s.parse().unwrap()).unwrap_or(15);
+    let keepalive_s: u64 = args.get(6).map(|s| s.parse().unwrap()).unwrap_or(5);
+    let run_s: u64 = args.get(7).map(|s| s.parse().unwrap()).unwrap_or(60);
+
+    let config = Arc::new(client::Config {
+        limits: Limits::new(1 << 30, 1 << 30, Duration::from_secs(rekey_s)),
+        keepalive_interval: Some(Duration::from_secs(keepalive_s)),
+        keepalive_max: 3,
+        ..client::Config::default()
+    });
+    eprintln!(
+        "[rekey-repro] {}:{} as {} — rekey_time_limit={rekey_s}s keepalive={keepalive_s}s run={run_s}s",
+        host, port, user
+    );
+
+    let mut session = client::connect(config, (&host[..], port), Handler)
+        .await
+        .expect("connect failed");
+    session
+        .authenticate_password(&user, &pass)
+        .await
+        .expect("auth failed");
+    eprintln!("[rekey-repro] AUTHED t=0");
+
+    let mut ch = session.channel_open_session().await.expect("channel open");
+    ch.request_pty(true, "xterm-256color", 80, 24, 0, 0, &[])
+        .await
+        .expect("pty request");
+    ch.request_shell(true).await.expect("shell request");
+    eprintln!("[rekey-repro] SHELL OPEN");
+
+    let start = Instant::now();
+    let mut last_send = start;
+    let mut closed = false;
+    loop {
+        tokio::select! {
+            msg = ch.wait() => {
+                match msg {
+                    Some(ChannelMsg::Data { data }) => {
+                        let s = String::from_utf8_lossy(&data);
+                        if !s.trim().is_empty() && !s.trim().ends_with('$') && !s.contains("echo r") {
+                            eprintln!("[rekey-repro] data@t={:.1}s: {}", start.elapsed().as_secs_f64(), s.trim().lines().next().unwrap_or(""));
+                        }
+                    }
+                    Some(other) => eprintln!("[rekey-repro] channel msg@t={:.1}s: {:?}", start.elapsed().as_secs_f64(), other),
+                    None => {
+                        closed = true;
+                        eprintln!("[rekey-repro] CHANNEL CLOSED at t={:.1}s", start.elapsed().as_secs_f64());
+                        break;
+                    }
+                }
+            }
+            _ = tokio::time::sleep(Duration::from_millis(500)) => {
+                if start.elapsed().as_secs() >= run_s {
+                    break;
+                }
+                // Keep data flowing so the channel is exercised across rekeys.
+                if last_send.elapsed().as_secs() >= 10 {
+                    last_send = Instant::now();
+                    let _ = ch.data(std::io::Cursor::new("echo r\r".as_bytes())).await;
+                }
+            }
+        }
+    }
+    if !closed {
+        eprintln!(
+            "[rekey-repro] STILL ALIVE at t={:.1}s — survived past the rekey mark",
+            start.elapsed().as_secs_f64()
+        );
+    }
+}

--- a/src-tauri/src/connection_manager.rs
+++ b/src-tauri/src/connection_manager.rs
@@ -8,6 +8,9 @@ use crate::vnc_client::VncClient;
 use anyhow::Result;
 use serde::Serialize;
 use std::collections::HashMap;
+use std::sync::atomic::Ordering;
+#[cfg(test)]
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::mpsc;
@@ -327,11 +330,24 @@ impl ConnectionManager {
 
     /// Remove a detached session from the registry (without cancelling the
     /// session itself), stopping its background drain task.
+    ///
+    /// A session whose PTY output channel has closed (`dead`) is torn down
+    /// instead of returned: re-attaching it would immediately error again and
+    /// lock the tab into an endless reconnect → reattach → error loop (the
+    /// re-park on each WS drop keeps refreshing the 5-minute expiry timer, so
+    /// the zombie never self-expires). Returning `None` lets
+    /// `start_pty_connection` fall through to the SSH session, which reports
+    /// `SshSessionDead` and lets the frontend escalate to a full reconnect.
     async fn take_detached_session(&self, connection_id: &str) -> Option<DetachedSession> {
         let mut detached = self.detached_sessions.write().await;
         let session = detached.remove(connection_id)?;
         // Stop the drain so the re-attached reader gets the output stream.
         session.drain_cancel.cancel();
+        if session.session.dead.load(Ordering::SeqCst) {
+            session.session.cancel.cancel();
+            tracing::info!("Dropped dead detached PTY session for {}", connection_id);
+            return None;
+        }
         Some(session)
     }
 
@@ -368,6 +384,13 @@ impl ConnectionManager {
         };
 
         if let Some(session) = session {
+            if session.dead.load(Ordering::SeqCst) {
+                // The SSH channel is already gone — parking would only keep a
+                // zombie around for StartPty to re-attach and fail again.
+                session.cancel.cancel();
+                tracing::info!("Skipped parking dead PTY session for {}", connection_id);
+                return Ok(());
+            }
             let generation = {
                 let generations = self.pty_generations.read().await;
                 generations.get(connection_id).copied().unwrap_or(0)
@@ -379,6 +402,7 @@ impl ConnectionManager {
             // process — defeating "keep running in the background".
             let drain_cancel = CancellationToken::new();
             let output_rx = session.output_rx.clone();
+            let dead = session.dead.clone();
             let drain_cancel_clone = drain_cancel.clone();
             tokio::spawn(async move {
                 loop {
@@ -390,7 +414,13 @@ impl ConnectionManager {
                         } => {
                             match result {
                                 Some(_) => {} // discard output while detached
-                                None => break, // channel closed → session gone
+                                None => {
+                                    // Channel closed while parked — the SSH
+                                    // channel is gone; mark dead so a later
+                                    // StartPty drops it instead of reattaching.
+                                    dead.store(true, Ordering::SeqCst);
+                                    break;
+                                }
                             }
                         }
                     }
@@ -536,24 +566,33 @@ impl ConnectionManager {
         // deadlocks every later start_pty_connection / close_pty_connection
         // (write lock) process-wide — new connections stall after the first
         // one goes idle.
-        let output_rx = {
+        let (output_rx, dead) = {
             let pty_sessions = self.pty_sessions.read().await;
             let pty = pty_sessions
                 .get(connection_id)
                 .ok_or_else(|| anyhow::anyhow!("PTY connection not found"))?;
-            pty.output_rx.clone()
+            (pty.output_rx.clone(), pty.dead.clone())
         };
 
         let mut rx = output_rx.lock().await;
 
+        // Recv returning None means the output sender was dropped — the SSH
+        // channel is gone. Mark the session dead so it can never be
+        // re-attached from the detached registry (issue: infinite
+        // "Connection lost: PTY connection closed" reconnect loop).
+        let channel_closed = || {
+            dead.store(true, Ordering::SeqCst);
+            anyhow::anyhow!("PTY connection closed")
+        };
+
         match max_wait {
             None => match rx.recv().await {
                 Some(data) => Ok(Some(data)),
-                None => Err(anyhow::anyhow!("PTY connection closed")),
+                None => Err(channel_closed()),
             },
             Some(duration) => match tokio::time::timeout(duration, rx.recv()).await {
                 Ok(Some(data)) => Ok(Some(data)),
-                Ok(None) => Err(anyhow::anyhow!("PTY connection closed")),
+                Ok(None) => Err(channel_closed()),
                 Err(_) => Ok(None), // deadline elapsed — caller should flush
             },
         }
@@ -916,6 +955,7 @@ mod tests {
             channel_id: unsafe { std::mem::transmute(0u32) },
             resize_tx: rtx,
             cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(false)),
         };
         {
             let mut detached = mgr.detached_sessions.write().await;
@@ -967,6 +1007,7 @@ mod tests {
             channel_id: unsafe { std::mem::transmute(0u32) },
             resize_tx,
             cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(false)),
         };
         {
             let mut sessions = mgr.pty_sessions.write().await;
@@ -1071,6 +1112,7 @@ mod tests {
             channel_id: unsafe { std::mem::transmute(0u32) },
             resize_tx,
             cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(false)),
         };
         {
             let mut sessions = mgr.pty_sessions.write().await;
@@ -1124,6 +1166,7 @@ mod tests {
             channel_id: unsafe { std::mem::transmute(0u32) },
             resize_tx,
             cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -1241,6 +1284,7 @@ mod tests {
                 channel_id: unsafe { std::mem::transmute(0u32) },
                 resize_tx: rtx,
                 cancel: CancellationToken::new(),
+                dead: Arc::new(AtomicBool::new(false)),
             };
             let mut detached = mgr.detached_sessions.write().await;
             detached.insert(
@@ -1274,6 +1318,7 @@ mod tests {
                 channel_id: unsafe { std::mem::transmute(0u32) },
                 resize_tx: rtx,
                 cancel: CancellationToken::new(),
+                dead: Arc::new(AtomicBool::new(false)),
             };
             detached.insert(
                 "det-1".to_string(),
@@ -1290,5 +1335,95 @@ mod tests {
         // entry even if disconnect reports nothing to disconnect.
         let _ = mgr.close_detached_session("det-1").await;
         assert!(!mgr.has_detached_session("det-1").await);
+    }
+
+    // ===== Dead-session handling (reconnect-loop regression) =====
+    //
+    // When the SSH transport dies, the PTY output channel closes. A dead
+    // session must never be re-attached from the detached registry, or the
+    // tab loops forever: reconnect → StartPty reattaches the zombie → its
+    // reader errors "PTY connection closed" → WS drops and re-parks the
+    // zombie (refreshing the 5-minute expiry) → repeat.
+
+    fn dead_pty_session() -> PtySession {
+        let (input_tx, _input_rx) = mpsc::channel::<Vec<u8>>(1);
+        let (resize_tx, _resize_rx) = mpsc::channel::<(u32, u32)>(1);
+        PtySession {
+            input_tx,
+            output_rx: Arc::new(tokio::sync::Mutex::new(mpsc::channel::<Vec<u8>>(1).1)),
+            channel_id: unsafe { std::mem::transmute(0u32) },
+            resize_tx,
+            cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(true)),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_dead_detached_session_is_dropped_not_reattached() {
+        let mgr = ConnectionManager::new();
+        {
+            let mut detached = mgr.detached_sessions.write().await;
+            detached.insert(
+                "zombie-1".to_string(),
+                DetachedSession {
+                    session: Arc::new(dead_pty_session()),
+                    generation: 1,
+                    drain_cancel: CancellationToken::new(),
+                    parked_at: tokio::time::Instant::now(),
+                },
+            );
+        }
+
+        // No SSH session exists, so after the zombie is dropped the start must
+        // escalate to SshSessionDead (frontend then does a full reconnect)
+        // instead of reattaching the dead shell.
+        let err = mgr.start_pty_connection("zombie-1", 80, 24).await.unwrap_err();
+        assert!(matches!(err, PtyStartError::SshSessionDead(_)));
+        // The zombie was removed and must not be parked/reattachable again.
+        assert!(!mgr.has_detached_session("zombie-1").await);
+        assert!(!mgr.pty_sessions.read().await.contains_key("zombie-1"));
+    }
+
+    #[tokio::test]
+    async fn test_read_from_pty_marks_session_dead_on_channel_close() {
+        let mgr = ConnectionManager::new();
+        let (input_tx, _input_rx) = mpsc::channel::<Vec<u8>>(1);
+        let (output_tx, output_rx) = mpsc::channel::<Vec<u8>>(8);
+        let (resize_tx, _resize_rx) = mpsc::channel::<(u32, u32)>(1);
+        let session = PtySession {
+            input_tx,
+            output_rx: Arc::new(tokio::sync::Mutex::new(output_rx)),
+            channel_id: unsafe { std::mem::transmute(0u32) },
+            resize_tx,
+            cancel: CancellationToken::new(),
+            dead: Arc::new(AtomicBool::new(false)),
+        };
+        {
+            let mut sessions = mgr.pty_sessions.write().await;
+            sessions.insert("r-dead-1".to_string(), Arc::new(session));
+        }
+
+        // Data flows while the channel is open.
+        output_tx.send(b"hello".to_vec()).await.unwrap();
+        assert_eq!(mgr.read_from_pty("r-dead-1", None).await.unwrap().unwrap(), b"hello");
+
+        // Dropping the sender (SSH channel gone) → next read errors AND marks dead.
+        drop(output_tx);
+        assert!(mgr.read_from_pty("r-dead-1", None).await.is_err());
+        assert!(mgr.pty_sessions.read().await.get("r-dead-1").unwrap().dead.load(Ordering::SeqCst));
+    }
+
+    #[tokio::test]
+    async fn test_detach_skips_parking_dead_session() {
+        let mgr = ConnectionManager::new();
+        {
+            let mut sessions = mgr.pty_sessions.write().await;
+            sessions.insert("dead-act-1".to_string(), Arc::new(dead_pty_session()));
+        }
+        mgr.detach_pty_connection("dead-act-1", None).await.unwrap();
+        // A dead session must not be parked — parking would let a later
+        // StartPty reattach it and re-enter the error loop.
+        assert!(!mgr.has_detached_session("dead-act-1").await);
+        assert!(!mgr.pty_sessions.read().await.contains_key("dead-act-1"));
     }
 }

--- a/src-tauri/src/ssh/mod.rs
+++ b/src-tauri/src/ssh/mod.rs
@@ -5,6 +5,7 @@ use russh_keys::*;
 use russh_sftp::client::SftpSession;
 use serde::{Deserialize, Serialize};
 use std::pin::Pin;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::Duration;
@@ -139,6 +140,11 @@ pub struct PtySession {
     /// Cancellation token — cancelled when this session is torn down.
     /// The WebSocket reader task should select on this to stop promptly.
     pub cancel: CancellationToken,
+    /// Set once the PTY output channel has closed because the SSH channel is
+    /// gone (transport dropped). A dead session must never be re-attached:
+    /// its reader errors instantly with "PTY connection closed" and the tab
+    /// would otherwise loop reconnect → reattach → error forever.
+    pub dead: Arc<AtomicBool>,
 }
 
 pub struct Client;
@@ -356,6 +362,15 @@ impl SshClient {
             // preventing the server from silently dropping idle sessions.
             keepalive_interval,
             keepalive_max: config.keepalive_max.unwrap_or(3) as usize,
+            // russh's default time-based rekey (Limits::default rekeys every
+            // 3600s) reliably kills long-idle connections in russh 0.44.x:
+            // in the multi-hour soak test every idle terminal died at the
+            // ~1-hour mark, right at the rekey exchange, while active
+            // sessions rekeyed fine. Keep the spec's 1 GiB data limits but
+            // lift the time limit so idle terminals never enter the broken
+            // path. OpenSSH servers don't time-rekey by default, so no
+            // server-initiated rekey replaces it.
+            limits: Limits::new(1 << 30, 1 << 30, Duration::from_secs(7 * 24 * 60 * 60)),
             ..client::Config::default()
         };
 
@@ -625,6 +640,7 @@ impl SshClient {
                 channel_id,
                 resize_tx,
                 cancel: CancellationToken::new(),
+                dead: Arc::new(AtomicBool::new(false)),
             })
         } else {
             Err(anyhow::anyhow!("Not connected"))

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -68,6 +68,12 @@ interface ConnectionNode {
   isExpanded?: boolean;
 }
 
+/**
+ * Backoff delays (ms) for the automatic full-reconnect retry (`handleReconnect`).
+ * Module-scope so the callback's dependency identity stays stable.
+ */
+const FULL_RECONNECT_BACKOFF_MS = [2000, 4000, 8000, 16000, 30000];
+
 function AppContent() {
   const { t } = useTranslation();
   const [selectedConnection, setSelectedConnection] = useState<ConnectionNode | null>(null);
@@ -922,13 +928,49 @@ function AppContent() {
     }
   }, [allTabs, state.activeGroupId, dispatch, t]);
 
+  // Automatic full-reconnect retry
+  //
+  // A single-shot ssh_connect (the backend uses a 3s connect timeout) can fail
+  // right after a network blip — previously the tab then sat in a dead
+  // 'disconnected' state until the user clicked Reconnect. Retry with bounded
+  // exponential backoff so a transient outage heals on its own; permanent
+  // failures (bad credentials) skip retrying. Retry state is keyed by tab id
+  // and survives component remounts of the terminal (RECONNECT_TAB).
+  const reconnectRetryState = useRef<Record<string, { failures: number; timer?: ReturnType<typeof setTimeout> }>>({});
+  // Reconnect retry timers re-invoke the callback via this ref: the callback's
+  // own body can't reference `handleReconnect` directly (TDZ before the const
+  // binding exists).
+  const handleReconnectRef = useRef<((tabId: string) => Promise<void>) | null>(null);
+  const clearReconnectRetry = useCallback((tabId: string) => {
+    const entry = reconnectRetryState.current[tabId];
+    if (entry?.timer) clearTimeout(entry.timer);
+    const next = { ...reconnectRetryState.current };
+    delete next[tabId];
+    reconnectRetryState.current = next;
+  }, []);
+
   const handleReconnect = useCallback(async (tabId: string) => {
     const tabToReconnect = allTabs.find(tab => tab.id === tabId);
-    if (!tabToReconnect) return;
+    if (!tabToReconnect) {
+      clearReconnectRetry(tabId);
+      return;
+    }
+
+    // A pending retry timer is superseded by this invocation (manual click or
+    // timer re-entry); keep the failure count so the backoff stays bounded.
+    const pendingRetry = reconnectRetryState.current[tabId];
+    if (pendingRetry?.timer) {
+      clearTimeout(pendingRetry.timer);
+      reconnectRetryState.current = {
+        ...reconnectRetryState.current,
+        [tabId]: { failures: pendingRetry.failures },
+      };
+    }
 
     const originalConnectionId = tabToReconnect.originalConnectionId || tabId;
     const connectionData = ConnectionStorageManager.getConnection(originalConnectionId);
     if (!connectionData) {
+      clearReconnectRetry(tabId);
       toast.error(t('app.cannotReconnect'), {
         description: t('app.cannotReconnectDesc'),
       });
@@ -946,6 +988,7 @@ function AppContent() {
         : !!connectionData.privateKeyPath);
 
     if (!hasCredentials) {
+      clearReconnectRetry(tabId);
       toast.error(t('app.cannotReconnect'), {
         description: t('app.noCredentialsDesc'),
       });
@@ -1012,6 +1055,7 @@ function AppContent() {
         );
 
         if (result.success) {
+          clearReconnectRetry(tabId);
           if (!tabToReconnect.originalConnectionId) {
             ConnectionStorageManager.updateLastConnected(originalConnectionId);
           }
@@ -1022,20 +1066,43 @@ function AppContent() {
             description: t('app.reconnectedDesc', { name: tabToReconnect.name }),
           });
         } else {
-          dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
-          toast.error(t('app.reconnectionFailed'), {
-            description: result.error || t('app.reconnectionFailedDesc'),
-          });
+          // A transient network outage can outlast one connect attempt: keep
+          // retrying with bounded backoff instead of dropping to a dead
+          // 'disconnected' tab. Permanent auth failures are not retried.
+          const permanent = /authentication|credential|password/i.test(result.error || '');
+          const failures = (reconnectRetryState.current[tabId]?.failures ?? 0) + 1;
+          if (!permanent && failures <= FULL_RECONNECT_BACKOFF_MS.length) {
+            const delay = FULL_RECONNECT_BACKOFF_MS[failures - 1];
+            const timer = setTimeout(() => {
+              void handleReconnectRef.current?.(tabId);
+            }, delay);
+            reconnectRetryState.current = {
+              ...reconnectRetryState.current,
+              [tabId]: { failures, timer },
+            };
+            // Stay 'connecting' — the next attempt is already scheduled.
+          } else {
+            clearReconnectRetry(tabId);
+            dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
+            toast.error(t('app.reconnectionFailed'), {
+              description: result.error || t('app.reconnectionFailedDesc'),
+            });
+          }
         }
       }
     } catch (error) {
       console.error('Error reconnecting:', error);
+      clearReconnectRetry(tabId);
       dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
       toast.error(t('app.reconnectionError'), {
         description: error instanceof Error ? error.message : t('app.reconnectionErrorDesc'),
       });
     }
-  }, [allTabs, dispatch, t]);
+  }, [allTabs, dispatch, t, clearReconnectRetry]);
+
+  useEffect(() => {
+    handleReconnectRef.current = handleReconnect;
+  }, [handleReconnect]);
 
   // Handler: Xshell-style detach (Ctrl+A+D). The PtyTerminal already sent the
   // Detach WS message to the backend; here we remove the tab and record the

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -595,6 +595,16 @@ export function PtyTerminal({
     let writeBuffer = '';
     let bufferedFrameCount = 0;
     let rafId: number | null = null;
+
+    // StartPty handshake watchdog. If the backend never confirms the PTY
+    // (Success/PtyStarted) within this window — e.g. the ssh_session_dead
+    // error frame was lost, or the socket silently stalled — trigger the same
+    // full-reconnect escalation the coded error would have, instead of
+    // waiting for the WS retry loop to burn out and leaving the tab unusable
+    // until a manual reconnect.
+    const START_PTY_WATCHDOG_MS = 8000;
+    let startPtyWatchdog: ReturnType<typeof setTimeout> | null = null;
+    let ptyHandshakeDone = false;
     
     // CRITICAL: Wait for terminal to have proper dimensions before connecting
     // Hidden terminals (display: none) may have cols=10, rows=5 which breaks PTY
@@ -684,6 +694,34 @@ export function PtyTerminal({
         };
         console.log(`[PTY Terminal] [${connectionId}] Starting PTY connection with ${startCols}x${startRows}`);
         ws.send(JSON.stringify(startMsg));
+
+        ptyHandshakeDone = false;
+        if (startPtyWatchdog) clearTimeout(startPtyWatchdog);
+        startPtyWatchdog = setTimeout(() => {
+          startPtyWatchdog = null;
+          if (ptyHandshakeDone) return;
+          console.warn(
+            `[PTY Terminal] [${connectionId}] StartPty handshake watchdog fired (no Success/PtyStarted within ${START_PTY_WATCHDOG_MS}ms) — escalating to full reconnect`,
+          );
+          reconnectAttemptsRef.current = MAX_RECONNECT_ATTEMPTS;
+          autoReconnectAfterDropRef.current = MAX_AUTO_RECONNECT_AFTER_DROP;
+          if (connectionStatusRef.current !== 'disconnected') {
+            connectionStatusRef.current = 'disconnected';
+            onConnectionStatusChange?.(connectionId, 'disconnected');
+          }
+          if (!sshDeadEscalatedRef.current) {
+            sshDeadEscalatedRef.current = true;
+            if (onReconnectTab && claimSshDeadEscalation(connectionId)) {
+              term.write(`\r\n\x1b[33m${i18n.t('ptyTerminal.sshSessionLost')}\x1b[0m\r\n`);
+              void onReconnectTab(connectionId);
+            } else {
+              term.write(`\r\n\x1b[31m${i18n.t('ptyTerminal.sshSessionDeadPermanent')}\x1b[0m\r\n`);
+            }
+          }
+          if (ws.readyState === WebSocket.OPEN) {
+            ws.close();
+          }
+        }, START_PTY_WATCHDOG_MS);
 
         // Flush a resize that was observed while this socket was not OPEN yet
         // (issue #88): dropping it would leave the PTY at a stale size, and
@@ -791,6 +829,11 @@ export function PtyTerminal({
             case 'Success':
               console.log(`[PTY Terminal] [${connectionId}]`, msg.message);
               if (msg.message.includes('PTY connection started')) {
+                ptyHandshakeDone = true;
+                if (startPtyWatchdog) {
+                  clearTimeout(startPtyWatchdog);
+                  startPtyWatchdog = null;
+                }
                 // Captured for PtyStarted: at that point these flags have
                 // already been reset, but only PtyStarted knows whether the
                 // backend re-attached a parked session or started a fresh
@@ -814,6 +857,11 @@ export function PtyTerminal({
 
             case 'PtyStarted': {
               if (msg.connection_id === connectionId && typeof msg.generation === 'number') {
+                ptyHandshakeDone = true;
+                if (startPtyWatchdog) {
+                  clearTimeout(startPtyWatchdog);
+                  startPtyWatchdog = null;
+                }
                 ptyGenerationRef.current = msg.generation;
                 console.log(`[PTY Terminal] [${connectionId}] PTY generation: ${msg.generation}`);
                 signalReady(connectionId);
@@ -1133,6 +1181,12 @@ export function PtyTerminal({
     return () => {
       console.log(`[PTY Terminal] [${connectionId}] Cleaning up`);
       isRunning = false;
+
+      // Cancel the pending StartPty handshake watchdog, if any.
+      if (startPtyWatchdog) {
+        clearTimeout(startPtyWatchdog);
+        startPtyWatchdog = null;
+      }
 
       // Cancel any pending RAF write batch and discard queued data so no
       // stale writes reach a terminal that is about to be disposed.


### PR DESCRIPTION
## Problem

A multi-hour stability soak of the dev app (3 SSH tabs left open idle) showed two backend bugs:

1. **Every idle connection died at the ~60–71 minute mark.** The backend log showed `russh::client: Re-exchanging keys` immediately before each death (channel close + `PTY connection closed` within ~12 ms). `russh::Limits::default()` rekeys every **3600 s** and the app never overrode `limits`. Long-idle sessions die at that rekey; sessions with activity rekey fine (reproduced with `examples/rekey_repro.rs` — 14 successful rekeys with data flowing, 200 s runs).
2. **When a session died, the tab locked into an infinite reconnect loop** (`[会话已恢复 — 已重新连接到原 Shell]` → `[错误：Connection lost: PTY connection closed]` → reconnect → repeat), because the dead PTY session stayed in the detached registry and `StartPty`'s reattach path returned early without checking SSH health — each WS drop re-parked the zombie and refreshed its 5-minute expiry, so it never expired and the frontend never got `ssh_session_dead` to escalate to a full reconnect.

## Fixes

1. **`ssh/mod.rs`**: keep the SSH-spec 1 GiB data rekey but raise the time limit to 7 days so idle terminals never enter the broken rekey path. OpenSSH servers don't time-rekey by default (verified on both test servers: `rekeylimit 0 0` / defaults), so nothing replaces it.
2. **`connection_manager.rs` + `ssh/mod.rs`**: `PtySession` gains a `dead: Arc<AtomicBool>` set when the PTY output channel closes (in `read_from_pty` and the detached drain task). `take_detached_session()` drops dead sessions instead of returning them, `detach_pty_connection()` skips parking them, and `StartPty` then falls through to the SSH session check → returns `ssh_session_dead` → the frontend's existing escalation (`pty-terminal.tsx`, `ssh_session_dead` branch) performs a full reconnect (disconnect + re-authenticate).

## Validation

- 173 Rust tests pass, including 3 new regression tests for the dead-session paths (`test_dead_detached_session_is_dropped_not_reattached`, `test_read_from_pty_marks_session_dead_on_channel_close`, `test_detach_skips_parking_dead_session`).
- Soak on the dev instance: before the fix, connections died at 60–71 min in 3 consecutive rounds; after the fix they survived past 123 minutes in the automated checks and then **ran overnight without a single death**, with tab recovery (evict → full reconnect) verified in the backend logs when connections were killed deliberately.
- `examples/rekey_repro.rs` (+ `env_logger` dev-dependency) documents the rekey reproduction for future russh debugging.