### PR TITLE
feat(settings): option to skip automatic session reconnect at startup…

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -137,6 +137,11 @@ function AppContent() {
   // skipped because "Reconnect sessions on startup" is disabled. They stay
   // `pending` and show a Connect action until the user reconnects them.
   const [deferredRestoreTabIds, setDeferredRestoreTabIds] = useState<ReadonlySet<string>>(() => new Set());
+  // The exact tab whose Connect/Reconnect opened the credentials dialog, so
+  // handleSaveConnection reconnects that tab. Matching by connection id alone
+  // misses primary tabs (no originalConnectionId) and is ambiguous for
+  // duplicates.
+  const [pendingReconnectTabId, setPendingReconnectTabId] = useState<string | null>(null);
 
   // Layout management
   const {
@@ -834,6 +839,7 @@ function AppContent() {
     setConnectionDialogOpen(true);
     setEditingConnection(null);
     setPendingConnectionId(null);
+    setPendingReconnectTabId(null);
   }, []);
 
   const handleDuplicateTab = useCallback(async (tabId: string) => {
@@ -1012,23 +1018,74 @@ function AppContent() {
       });
       setEditingConnection(toConnectionConfig(connectionData));
       setPendingConnectionId(originalConnectionId);
+      setPendingReconnectTabId(tabId);
       setConnectionDialogOpen(true);
       return;
     }
 
-    // A deferred startup-restore tab is now being connected explicitly.
+    const isDesktop = tabToReconnect.tabType === 'desktop' ||
+      connectionData.protocol === 'RDP' || connectionData.protocol === 'VNC';
+
+    // A `pending` tab has no terminal mounted (deferred startup restore, or a
+    // connect still in flight). Keep it pending while the backend session is
+    // established: dispatching `connecting` now would mount PtyTerminal, which
+    // sends StartPty against a session that does not exist yet and can race a
+    // dead-session reconnect with this one. RECONNECT_TAB on success is what
+    // mounts the terminal.
+    const wasPending = tabToReconnect.connectionStatus === 'pending';
+    // Swap the Connect action for the in-flight placeholder while connecting.
     setDeferredRestoreTabIds(prev => {
       if (!prev.has(tabId)) return prev;
       const next = new Set(prev);
       next.delete(tabId);
       return next;
     });
+    /**
+     * Failed while still pending: offer Connect again instead of a dead
+     * terminal. Applies to backoff retries too (they re-enter with the marker
+     * already cleared), so the final failure never strands the tab.
+     */
+    const failPending = () => {
+      setDeferredRestoreTabIds(prev => new Set(prev).add(tabId));
+    };
 
-    // Update tab status to connecting
-    dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'connecting' });
+    if (!wasPending) {
+      dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'connecting' });
+    }
 
     try {
-      if (isFileBrowser) {
+      if (isDesktop) {
+        // RDP/VNC reconnect: same request as the startup restore path.
+        try {
+          await invoke('desktop_disconnect', { connectionId: tabId });
+        } catch {
+          // Ignore errors when disconnecting
+        }
+
+        const proto = connectionData.protocol;
+        await invoke('desktop_connect', {
+          request: {
+            connection_id: tabId,
+            host: connectionData.host,
+            port: connectionData.port || (proto === 'RDP' ? 3389 : 5900),
+            protocol: proto.toLowerCase(),
+            username: connectionData.username || '',
+            password: connectionData.password || '',
+            domain: connectionData.domain || null,
+            resolution: connectionData.rdpResolution || '1920x1080',
+            color_depth: connectionData.vncColorDepth ? parseInt(connectionData.vncColorDepth) : 24,
+          }
+        });
+
+        clearReconnectRetry(tabId);
+        if (!tabToReconnect.originalConnectionId) {
+          ConnectionStorageManager.updateLastConnected(originalConnectionId);
+        }
+        dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'connected' });
+        toast.success(t('app.reconnected'), {
+          description: t('app.reconnectedDesc', { name: tabToReconnect.name }),
+        });
+      } else if (isFileBrowser) {
         // SFTP/FTP reconnect
         try {
           if (isSftp) {
@@ -1109,7 +1166,11 @@ function AppContent() {
             // Stay 'connecting' — the next attempt is already scheduled.
           } else {
             clearReconnectRetry(tabId);
-            dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
+            if (wasPending) {
+              failPending();
+            } else {
+              dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
+            }
             toast.error(t('app.reconnectionFailed'), {
               description: result.error || t('app.reconnectionFailedDesc'),
             });
@@ -1119,7 +1180,11 @@ function AppContent() {
     } catch (error) {
       console.error('Error reconnecting:', error);
       clearReconnectRetry(tabId);
-      dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
+      if (wasPending) {
+        failPending();
+      } else {
+        dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'disconnected' });
+      }
       toast.error(t('app.reconnectionError'), {
         description: error instanceof Error ? error.message : t('app.reconnectionErrorDesc'),
       });
@@ -1594,6 +1659,7 @@ function AppContent() {
         setEditingConnection(toConnectionConfig(connectionData));
         setConnectionDialogOpen(true);
         setPendingConnectionId(null);
+        setPendingReconnectTabId(null);
       } else {
         toast.error(t('app.connectionNotFound'), {
           description: t('app.connectionNotFoundDesc1'),
@@ -1617,14 +1683,20 @@ function AppContent() {
     const wasPendingConnect = pendingConnectionId === config.id;
     if (wasPendingConnect) {
       setPendingConnectionId(null);
+      const targetTabId = pendingReconnectTabId;
+      setPendingReconnectTabId(null);
 
       // Reuse the existing disconnected/pending tab (created by the initial failed
       // connection attempt) instead of creating a new one. This avoids leaving a
-      // dead tab behind after the user saves a fix and auto-connects.
-      const pendingTab = allTabs.find(tab =>
-        tab.originalConnectionId === config.id &&
-        (tab.connectionStatus === 'disconnected' || tab.connectionStatus === 'pending')
-      );
+      // dead tab behind after the user saves a fix and auto-connects. Prefer the
+      // exact tab that opened the dialog: a primary tab has no
+      // originalConnectionId, and several duplicates would be ambiguous.
+      const pendingTab =
+        (targetTabId ? allTabs.find(tab => tab.id === targetTabId) : undefined) ??
+        allTabs.find(tab =>
+          tab.originalConnectionId === config.id &&
+          (tab.connectionStatus === 'disconnected' || tab.connectionStatus === 'pending')
+        );
       const sessionId = pendingTab ? pendingTab.id : `${config.id}-dup-${Date.now()}`;
 
       const isSftp = config.protocol === 'SFTP';
@@ -1734,6 +1806,13 @@ function AppContent() {
               // the old terminal content showing.)
               dispatch({ type: 'UPDATE_TAB_NAME', tabId: sessionId, name: config.name });
               dispatch({ type: 'RECONNECT_TAB', tabId: sessionId });
+              // A deferred startup-restore tab is connected now.
+              setDeferredRestoreTabIds(prev => {
+                if (!prev.has(sessionId)) return prev;
+                const next = new Set(prev);
+                next.delete(sessionId);
+                return next;
+              });
             } else {
               // No existing tab — create a new one
               const newTab: TerminalTab = {
@@ -1764,7 +1843,7 @@ function AppContent() {
         }
       }
     }
-  }, [state.groups, state.activeGroupId, allTabs, dispatch, t, pendingConnectionId]);
+  }, [state.groups, state.activeGroupId, allTabs, dispatch, t, pendingConnectionId, pendingReconnectTabId]);
 
   // Get recent connections for quick connect
   const recentConnections = useMemo(() => {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -49,6 +49,7 @@ import {
 } from './lib/editor-windows-store';
 import { getAllWebviewWindows } from '@tauri-apps/api/webviewWindow';
 import { getRestoreTiming } from './lib/restore-timing';
+import { isRestoreSessionsOnStartupEnabled } from './lib/startup-restore';
 
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from './components/ui/resizable';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from './components/ui/tabs';
@@ -132,6 +133,10 @@ function AppContent() {
   const [isRestoring, setIsRestoring] = useState(false);
   const [restoringProgress, setRestoringProgress] = useState({ current: 0, total: 0 });
   const [currentRestoreTarget, setCurrentRestoreTarget] = useState<{ name: string; host?: string; username?: string } | null>(null);
+  // Tabs restored from the previous session whose automatic reconnect was
+  // skipped because "Reconnect sessions on startup" is disabled. They stay
+  // `pending` and show a Connect action until the user reconnects them.
+  const [deferredRestoreTabIds, setDeferredRestoreTabIds] = useState<ReadonlySet<string>>(() => new Set());
 
   // Layout management
   const {
@@ -337,6 +342,30 @@ function AppContent() {
       const activeConnections = ActiveConnectionsManager.getActiveConnections();
 
       if (activeConnections.length === 0) {
+        return;
+      }
+
+      if (!isRestoreSessionsOnStartupEnabled()) {
+        // The user opted out of automatic reconnect at startup (issue #126).
+        // TerminalGroupProvider already restored the tab layout with every tab
+        // in the `pending` state; leave them there and start no backend
+        // connection. The active-connections list is intentionally kept so
+        // the tabs are persisted again for the next launch.
+        const restoredTabIds = new Set(
+          Object.values(stateRef.current.groups).flatMap(g => g.tabs.map(t => t.id))
+        );
+        const deferred = new Set(
+          activeConnections
+            .map(conn => conn.connectionId)
+            .filter(id => restoredTabIds.has(id))
+        );
+        console.log(`Session restore skipped by setting: ${deferred.size} tab(s) left pending`);
+        if (deferred.size > 0) {
+          setDeferredRestoreTabIds(deferred);
+          toast.info(t('app.restoreDeferred'), {
+            description: t('app.restoreDeferredDesc', { count: deferred.size }),
+          });
+        }
         return;
       }
 
@@ -986,6 +1015,14 @@ function AppContent() {
       setConnectionDialogOpen(true);
       return;
     }
+
+    // A deferred startup-restore tab is now being connected explicitly.
+    setDeferredRestoreTabIds(prev => {
+      if (!prev.has(tabId)) return prev;
+      const next = new Set(prev);
+      next.delete(tabId);
+      return next;
+    });
 
     // Update tab status to connecting
     dispatch({ type: 'UPDATE_TAB_STATUS', tabId, status: 'connecting' });
@@ -2035,6 +2072,7 @@ function AppContent() {
                       onCloseTab: handleCloseTab,
                       onCloseAllTabs: handleCloseAllTabs,
                       onDetachTab: handleDetachTab,
+                      deferredRestoreTabIds,
                     }}>
                       <ErrorBoundary label={t('app.terminal')}>
                         <GridRenderer node={state.gridLayout} path={[]} />

--- a/src/__tests__/restore-skipped-when-disabled.test.tsx
+++ b/src/__tests__/restore-skipped-when-disabled.test.tsx
@@ -1,0 +1,303 @@
+/**
+ * Feature test for the "Reconnect Sessions on Startup" setting (issue #126).
+ *
+ * When the setting is OFF, the tabs from the previous session must still be
+ * present in the layout (TerminalGroupProvider restores them as `pending`)
+ * but App.tsx must NOT initiate any backend connection at startup. Each
+ * deferred tab offers a Connect action that runs the regular full reconnect,
+ * and the active-connections list is kept so the tabs persist again for the
+ * next launch.
+ *
+ * When the setting is ON (or absent — the default for existing installs),
+ * startup behaves as before and every saved connection is reconnected.
+ *
+ * Same mocked App shell as restore-timeout-cancellation.test.tsx.
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import type { TerminalGroupState } from '../lib/terminal-group-types';
+import App from '../App';
+import { setRestoreTimingForTests } from '../lib/restore-timing';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
+import { RESTORE_SESSIONS_ON_STARTUP_KEY } from '../lib/startup-restore';
+
+const lifecycle = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  activeConnections: [] as Array<{ tabId: string; connectionId: string; order: number; tabType: string; protocol: string }>,
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  clearActiveConnectionsCalls: 0,
+}));
+
+let mockState: TerminalGroupState;
+
+const TAB_IDS = ['conn-1', 'conn-2', 'conn-3'];
+
+/** Layout as TerminalGroupProvider restores it at startup: every tab `pending`. */
+function makeMockState(): TerminalGroupState {
+  const tabs = TAB_IDS.map((id, i) => ({
+    id,
+    name: `Server ${i + 1}`,
+    tabType: 'terminal' as const,
+    protocol: 'SSH',
+    host: 'example.com',
+    username: 'root',
+    connectionStatus: 'pending' as const,
+    reconnectCount: 0,
+  }));
+  return {
+    groups: { 'group-1': { id: 'group-1', tabs, activeTabId: TAB_IDS[0] } },
+    activeGroupId: 'group-1',
+    gridLayout: { type: 'leaf', groupId: 'group-1' },
+    nextGroupId: 2,
+    tabToGroupMap: Object.fromEntries(TAB_IDS.map((id) => [id, 'group-1'])),
+  };
+}
+
+vi.mock('@/lib/terminal-group-context', async () => {
+  const ReactModule = await import('react');
+  const { terminalGroupReducer } = await import('@/lib/terminal-group-reducer');
+  const Ctx = ReactModule.createContext<unknown>(null);
+  return {
+    TerminalGroupProvider: ({ children }: { children: React.ReactNode }) => {
+      const [state, dispatch] = ReactModule.useReducer(terminalGroupReducer, mockState);
+      const activeGroup = state.groups[state.activeGroupId] ?? null;
+      const activeTab =
+        activeGroup?.tabs.find((t) => t.id === activeGroup.activeTabId) ?? null;
+      const activeConnection = activeTab
+        ? { connectionId: activeTab.id, name: activeTab.name, protocol: '', host: '', username: '', status: activeTab.connectionStatus }
+        : null;
+      const value = ReactModule.useMemo(
+        () => ({ state, dispatch, activeGroup, activeTab, activeConnection }),
+        [state],
+      );
+      return ReactModule.createElement(Ctx.Provider, { value }, children);
+    },
+    useTerminalGroups: () => ReactModule.useContext(Ctx),
+  };
+});
+
+vi.mock('@/components/pty-terminal', async () => {
+  const ReactModule = await import('react');
+  return {
+    PtyTerminal: () => ReactModule.createElement('div', { 'data-testid': 'pty' }),
+  };
+});
+
+vi.mock('@/lib/connection-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/connection-storage')>();
+  return {
+    ...actual,
+    ActiveConnectionsManager: {
+      getActiveConnections: () => lifecycle.activeConnections,
+      saveActiveConnections: () => {},
+      clearActiveConnections: () => {
+        lifecycle.clearActiveConnectionsCalls++;
+      },
+    },
+  };
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => lifecycle.invoke(...args),
+  isTauri: () => false,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('@/lib/restoration-manager', () => ({
+  registerRestoration: vi.fn(async () => {}),
+  signalReady: vi.fn(),
+  clearAllRestorations: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: lifecycle.toast }));
+
+vi.mock('@/components/connection-dialog', async () => {
+  const ReactModule = await import('react');
+  return { ConnectionDialog: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/system-monitor', async () => {
+  const ReactModule = await import('react');
+  return { SystemMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/log-monitor', async () => {
+  const ReactModule = await import('react');
+  return { LogMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/menu-bar', async () => {
+  const ReactModule = await import('react');
+  return { MenuBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/status-bar', async () => {
+  const ReactModule = await import('react');
+  return { StatusBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/integrated-file-browser', async () => {
+  const ReactModule = await import('react');
+  return { IntegratedFileBrowser: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/update-checker', async () => {
+  const ReactModule = await import('react');
+  return { UpdateChecker: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/welcome-screen', async () => {
+  const ReactModule = await import('react');
+  return { WelcomeScreen: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/ui/sonner', async () => {
+  const ReactModule = await import('react');
+  return { Toaster: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/desktop-viewer', async () => {
+  const ReactModule = await import('react');
+  return { DesktopViewer: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-browser-view', async () => {
+  const ReactModule = await import('react');
+  return { FileBrowserView: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-editor-view', async () => {
+  const ReactModule = await import('react');
+  return { FileEditorView: () => ReactModule.createElement('div') };
+});
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+const DEFERRED_HINT = 'Automatic reconnect at startup is disabled';
+
+function sshConnectCalls() {
+  return lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect');
+}
+
+describe('"Reconnect Sessions on Startup" setting', () => {
+  beforeEach(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverMock;
+    mockState = makeMockState();
+    localStorage.clear();
+
+    const connections = TAB_IDS.map((id, i) => ({
+      id,
+      name: `Server ${i + 1}`,
+      host: 'example.com',
+      port: 22,
+      username: 'root',
+      protocol: 'SSH',
+      authMethod: 'password',
+      password: 'secret',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+    localStorage.setItem('r-shell-connections', JSON.stringify(connections));
+    lifecycle.activeConnections = connections.map((c, i) => ({
+      tabId: c.id,
+      connectionId: c.id,
+      order: i,
+      tabType: 'terminal' as const,
+      protocol: 'SSH' as const,
+    }));
+
+    lifecycle.invoke.mockReset();
+    lifecycle.invoke.mockImplementation((command: string) => {
+      if (command === 'ssh_connect') return Promise.resolve({ success: true });
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+    lifecycle.toast.error.mockReset();
+    lifecycle.toast.success.mockReset();
+    lifecycle.toast.info.mockReset();
+    lifecycle.clearActiveConnectionsCalls = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    setRestoreTimingForTests({ connectTimeoutMs: 15_000, overallTimeoutMs: 60_000 });
+  });
+
+  it('reconnects every saved connection at startup when the setting is absent (default)', async () => {
+    render(<App />);
+
+    await vi.waitFor(
+      () => {
+        expect(sshConnectCalls()).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(lifecycle.toast.info).not.toHaveBeenCalled();
+    expect(screen.queryByText(DEFERRED_HINT)).toBeNull();
+  });
+
+  it('keeps the tabs pending and starts no connection when the setting is off', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+
+    render(<App />);
+
+    // The deferred-restore notice fires once the restore effect has run.
+    await vi.waitFor(
+      () => {
+        expect(lifecycle.toast.info).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // Give any (wrongly) scheduled connect a chance to show up before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    expect(sshConnectCalls()).toHaveLength(0);
+    expect(lifecycle.toast.success).not.toHaveBeenCalled();
+    expect(lifecycle.toast.error).not.toHaveBeenCalled();
+
+    // The reconnect list must survive so the tabs come back next launch too.
+    expect(lifecycle.clearActiveConnectionsCalls).toBe(0);
+
+    // Every restored tab shows the explicit Connect action instead of the
+    // "waiting" placeholder.
+    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+    expect(screen.queryByText('Waiting for connection...')).toBeNull();
+  });
+
+  it('connects a deferred tab on demand via its Connect button', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+
+    render(<App />);
+
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // The Connect button sits next to the hint inside the tab placeholder.
+    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
+    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+
+    // Exactly one full reconnect for the clicked tab; the other tabs stay deferred.
+    await vi.waitFor(
+      () => {
+        expect(sshConnectCalls()).toHaveLength(1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    const [, args] = sshConnectCalls()[0] as [string, { request: { connection_id: string } }];
+    expect(args.request.connection_id).toBe(TAB_IDS[0]);
+
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(sshConnectCalls()).toHaveLength(1);
+  }, 15_000);
+});

--- a/src/__tests__/restore-skipped-when-disabled.test.tsx
+++ b/src/__tests__/restore-skipped-when-disabled.test.tsx
@@ -15,7 +15,7 @@
  */
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen, within } from '@testing-library/react';
 import type { TerminalGroupState } from '../lib/terminal-group-types';
 import App from '../App';
 import { setRestoreTimingForTests } from '../lib/restore-timing';
@@ -27,6 +27,7 @@ const lifecycle = vi.hoisted(() => ({
   activeConnections: [] as Array<{ tabId: string; connectionId: string; order: number; tabType: string; protocol: string }>,
   toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
   clearActiveConnectionsCalls: 0,
+  dialogProps: null as Record<string, unknown> | null,
 }));
 
 let mockState: TerminalGroupState;
@@ -115,9 +116,16 @@ vi.mock('@/lib/restoration-manager', () => ({
 
 vi.mock('sonner', () => ({ toast: lifecycle.toast }));
 
+// Capture the dialog props so a test can drive the "save credentials" path
+// (onSave) exactly as the real dialog would.
 vi.mock('@/components/connection-dialog', async () => {
   const ReactModule = await import('react');
-  return { ConnectionDialog: () => ReactModule.createElement('div') };
+  return {
+    ConnectionDialog: (props: Record<string, unknown>) => {
+      lifecycle.dialogProps = props;
+      return ReactModule.createElement('div');
+    },
+  };
 });
 vi.mock('@/components/system-monitor', async () => {
   const ReactModule = await import('react');
@@ -299,5 +307,165 @@ describe('"Reconnect Sessions on Startup" setting', () => {
       { timeout: 5000, interval: 50 },
     );
     expect(sshConnectCalls()).toHaveLength(1);
+  }, 15_000);
+
+  it('keeps a deferred tab pending (no terminal mounted) while its connect is in flight', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+    let settle: ((value: { success: boolean }) => void) | undefined;
+    lifecycle.invoke.mockImplementation((command: string) => {
+      if (command === 'ssh_connect') {
+        return new Promise<{ success: boolean }>((resolve) => {
+          settle = resolve;
+        });
+      }
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+
+    render(<App />);
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
+    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await vi.waitFor(
+      () => {
+        expect(sshConnectCalls()).toHaveLength(1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // In flight: the pulsing placeholder replaces the Connect action and no
+    // PtyTerminal is mounted yet (it would send StartPty to a backend session
+    // that does not exist until ssh_connect succeeds).
+    expect(screen.getByText('Waiting for connection...')).toBeTruthy();
+    expect(screen.queryByTestId('pty')).toBeNull();
+    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
+
+    // Success remounts the tab as a terminal (RECONNECT_TAB).
+    await act(async () => {
+      settle?.({ success: true });
+    });
+    await vi.waitFor(
+      () => {
+        expect(screen.getByTestId('pty')).toBeTruthy();
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(screen.queryByText('Waiting for connection...')).toBeNull();
+  }, 15_000);
+
+  it('offers Connect again when the on-demand connect fails, without mounting a dead terminal', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+    lifecycle.invoke.mockImplementation((command: string) => {
+      // "Authentication" marks the failure as permanent: no backoff retry.
+      if (command === 'ssh_connect') return Promise.resolve({ success: false, error: 'Authentication failed' });
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+
+    render(<App />);
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
+    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await vi.waitFor(
+      () => {
+        expect(lifecycle.toast.error).toHaveBeenCalledTimes(1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    // The tab is back to the deferred state: Connect is offered again and no
+    // terminal was mounted for a session that never existed.
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(screen.queryByTestId('pty')).toBeNull();
+    expect(sshConnectCalls()).toHaveLength(1);
+  }, 15_000);
+
+  it('reconnects the exact clicked tab after credentials are supplied in the dialog', async () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+    // conn-1 is saved without a password: Connect must open the credentials
+    // dialog instead of connecting.
+    const saved = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]') as Array<Record<string, unknown>>;
+    delete saved[0].password;
+    localStorage.setItem('r-shell-connections', JSON.stringify(saved));
+    lifecycle.dialogProps = null;
+
+    render(<App />);
+    await vi.waitFor(
+      () => {
+        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+
+    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
+    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await vi.waitFor(
+      () => {
+        expect(lifecycle.dialogProps?.open).toBe(true);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(sshConnectCalls()).toHaveLength(0);
+    expect((lifecycle.dialogProps?.editingConnection as { id: string }).id).toBe(TAB_IDS[0]);
+
+    // Saving credentials from the dialog must reconnect the clicked (primary)
+    // tab itself, not spawn a "-dup-" tab or pick another duplicate.
+    const onSave = lifecycle.dialogProps?.onSave as (config: unknown) => Promise<void>;
+    await act(async () => {
+      await onSave({
+        id: TAB_IDS[0],
+        name: 'Server 1',
+        host: 'example.com',
+        port: 22,
+        username: 'root',
+        password: 'secret',
+        protocol: 'SSH',
+        authMethod: 'password',
+      });
+    });
+
+    await vi.waitFor(
+      () => {
+        expect(sshConnectCalls()).toHaveLength(1);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    const [, args] = sshConnectCalls()[0] as [string, { request: { connection_id: string } }];
+    expect(args.request.connection_id).toBe(TAB_IDS[0]);
+
+    await vi.waitFor(
+      () => {
+        expect(screen.getByTestId('pty')).toBeTruthy();
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    // Still three tabs: the two untouched ones remain deferred, none was added.
+    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
   }, 15_000);
 });

--- a/src/__tests__/startup-restore.test.ts
+++ b/src/__tests__/startup-restore.test.ts
@@ -1,0 +1,48 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  isRestoreSessionsOnStartupEnabled,
+  RESTORE_SESSIONS_ON_STARTUP_KEY,
+} from '../lib/startup-restore';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
+
+describe('isRestoreSessionsOnStartupEnabled', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('defaults to enabled when no settings were ever saved', () => {
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(true);
+  });
+
+  it('defaults to enabled when the settings object lacks the key (existing installs)', () => {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ checkUpdates: true }));
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(true);
+  });
+
+  it('is disabled only by an explicit false', () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(false);
+
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: true }),
+    );
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(true);
+  });
+
+  it('falls back to enabled for non-boolean values', () => {
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: 'no' }),
+    );
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(true);
+  });
+
+  it('falls back to enabled when the stored settings are not valid JSON', () => {
+    localStorage.setItem(APP_SETTINGS_STORAGE_KEY, '{not json');
+    expect(isRestoreSessionsOnStartupEnabled()).toBe(true);
+  });
+});

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -1042,12 +1042,13 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
 
                 <div className="flex items-center justify-between">
                   <div className="space-y-0.5">
-                    <Label>{t('settings.connection.restoreSessionsOnStartup')}</Label>
+                    <Label htmlFor="restore-sessions-on-startup">{t('settings.connection.restoreSessionsOnStartup')}</Label>
                     <p className="text-sm text-muted-foreground">
                       {t('settings.connection.restoreSessionsOnStartupDesc')}
                     </p>
                   </div>
                   <Switch
+                    id="restore-sessions-on-startup"
                     checked={settings.restoreSessionsOnStartup}
                     onCheckedChange={(checked) => updateSetting('restoreSessionsOnStartup', checked)}
                   />

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -115,6 +115,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
     connectionTimeout: 30,
     keepAliveInterval: 60,
     autoReconnect: true,
+    restoreSessionsOnStartup: true,
     
     // Security settings
     hostKeyVerification: true,
@@ -363,6 +364,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         connectionTimeout: 30,
         keepAliveInterval: 60,
         autoReconnect: true,
+        restoreSessionsOnStartup: true,
         hostKeyVerification: true,
         savePasswords: false,
         autoLockTimeout: 30,
@@ -1033,6 +1035,21 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
                   <Switch
                     checked={settings.autoReconnect}
                     onCheckedChange={(checked) => updateSetting('autoReconnect', checked)}
+                  />
+                </div>
+
+                <Separator />
+
+                <div className="flex items-center justify-between">
+                  <div className="space-y-0.5">
+                    <Label>{t('settings.connection.restoreSessionsOnStartup')}</Label>
+                    <p className="text-sm text-muted-foreground">
+                      {t('settings.connection.restoreSessionsOnStartupDesc')}
+                    </p>
+                  </div>
+                  <Switch
+                    checked={settings.restoreSessionsOnStartup}
+                    onCheckedChange={(checked) => updateSetting('restoreSessionsOnStartup', checked)}
                   />
                 </div>
               </CardContent>

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -10,6 +10,8 @@ import React, {
 } from 'react';
 import { useTranslation } from 'react-i18next';
 import { createPortal } from 'react-dom';
+import { RefreshCw } from 'lucide-react';
+import { Button } from '../ui/button';
 import { useTerminalGroups } from '../../lib/terminal-group-context';
 import { useTerminalCallbacks } from '../../lib/terminal-callbacks-context';
 import type { TerminalTab } from '../../lib/terminal-group-types';
@@ -51,7 +53,7 @@ function useThemeKey(): number {
 function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: number }) {
   const { t } = useTranslation();
   const { state, dispatch } = useTerminalGroups();
-  const { onReconnectTab, onDetachTab } = useTerminalCallbacks();
+  const { onReconnectTab, onDetachTab, deferredRestoreTabIds } = useTerminalCallbacks();
   const groupId = state.tabToGroupMap[tab.id];
   const group = groupId ? state.groups[groupId] : undefined;
   const isActive = groupId === state.activeGroupId && group?.activeTabId === tab.id;
@@ -122,10 +124,24 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
       />
     );
   } else if (tab.connectionStatus === 'pending') {
+    // A tab restored from the previous session whose automatic reconnect was
+    // skipped ("Reconnect sessions on startup" off) is not waiting for anything:
+    // offer an explicit Connect action instead of the pulsing placeholder.
+    const isDeferredRestore = deferredRestoreTabIds?.has(tab.id) ?? false;
     content = (
       <div className="h-full w-full flex items-center justify-center bg-muted/30">
-        <div className="text-center text-muted-foreground">
-          <div className="animate-pulse">{t('app.waitingForConnection')}</div>
+        <div className="text-center text-muted-foreground space-y-3">
+          {isDeferredRestore ? (
+            <>
+              <div>{t('app.restoreDeferredHint')}</div>
+              <Button size="sm" variant="outline" onClick={handleReconnect}>
+                <RefreshCw className="mr-2 h-4 w-4" />
+                {t('app.connectNow')}
+              </Button>
+            </>
+          ) : (
+            <div className="animate-pulse">{t('app.waitingForConnection')}</div>
+          )}
         </div>
       </div>
     );

--- a/src/lib/startup-restore.ts
+++ b/src/lib/startup-restore.ts
@@ -1,0 +1,37 @@
+import { APP_SETTINGS_STORAGE_KEY } from './keyboard-shortcuts';
+
+/**
+ * Settings key (inside the `APP_SETTINGS_STORAGE_KEY` object persisted by
+ * SettingsModal) that controls whether App.tsx re-establishes the previous
+ * session's connections automatically at startup.
+ *
+ * When disabled, the tabs from the previous session are still restored to the
+ * layout but stay in the `pending` state until the user connects them
+ * manually (Connect button on the tab, or Reconnect in the tab context menu).
+ * This keeps startup fast for users who leave many sessions open but do not
+ * need all of them live immediately (see issue #126).
+ */
+export const RESTORE_SESSIONS_ON_STARTUP_KEY = 'restoreSessionsOnStartup';
+
+/** Default: keep the historical behaviour and reconnect everything at startup. */
+export const RESTORE_SESSIONS_ON_STARTUP_DEFAULT = true;
+
+/**
+ * Read the "reconnect sessions at startup" preference from localStorage.
+ *
+ * Only an explicit `false` disables the automatic restore; a missing key,
+ * unparsable settings, or any non-boolean value fall back to the default so
+ * existing installs keep their current behaviour.
+ */
+export function isRestoreSessionsOnStartupEnabled(): boolean {
+  try {
+    const raw = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (!raw) return RESTORE_SESSIONS_ON_STARTUP_DEFAULT;
+    const parsed: unknown = JSON.parse(raw);
+    if (!parsed || typeof parsed !== 'object') return RESTORE_SESSIONS_ON_STARTUP_DEFAULT;
+    const value = (parsed as Record<string, unknown>)[RESTORE_SESSIONS_ON_STARTUP_KEY];
+    return value !== false;
+  } catch {
+    return RESTORE_SESSIONS_ON_STARTUP_DEFAULT;
+  }
+}

--- a/src/lib/terminal-callbacks-context.tsx
+++ b/src/lib/terminal-callbacks-context.tsx
@@ -25,6 +25,13 @@ export interface TerminalCallbacks {
   onCloseAllTabs?: (groupId: string) => void | Promise<void>;
   /** Xshell-style detach (Ctrl+A+D): keep the session alive in the background. */
   onDetachTab?: (tabId: string) => void | Promise<void>;
+  /**
+   * Tabs restored from the previous session whose automatic reconnect was
+   * skipped because "Reconnect sessions on startup" is disabled. They stay in
+   * the `pending` state and offer a Connect action until the user connects
+   * them manually.
+   */
+  deferredRestoreTabIds?: ReadonlySet<string>;
 }
 
 const TerminalCallbacksContext = createContext<TerminalCallbacks>({});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,6 +51,11 @@
     "connectionError": "Connection Error",
     "connectionErrorDesc": "An unexpected error occurred while connecting.",
     "waitingForConnection": "Waiting for connection...",
+    "restoreDeferred": "Sessions Not Reconnected",
+    "restoreDeferredDesc_one": "{{count}} tab from your last session was restored without connecting. Use Connect on the tab to reconnect it, or enable 'Reconnect Sessions on Startup' in Settings.",
+    "restoreDeferredDesc_other": "{{count}} tabs from your last session were restored without connecting. Use Connect on a tab to reconnect it, or enable 'Reconnect Sessions on Startup' in Settings.",
+    "restoreDeferredHint": "Automatic reconnect at startup is disabled",
+    "connectNow": "Connect",
     "restoreTitle": "Workspace Restore",
     "restoreSubtitle": "Bringing your connections back online",
     "restoreReconnecting": "Reconnecting {{name}}",
@@ -324,7 +329,9 @@
       "connectionTimeout": "Connection Timeout: {{timeout}}s",
       "keepAliveInterval": "Keep Alive Interval: {{interval}}s",
       "autoReconnect": "Auto Reconnect",
-      "autoReconnectDesc": "Automatically reconnect when connection is lost"
+      "autoReconnectDesc": "Automatically reconnect when connection is lost",
+      "restoreSessionsOnStartup": "Reconnect Sessions on Startup",
+      "restoreSessionsOnStartupDesc": "Automatically reconnect the tabs left open in the previous session when the app starts. When off, the tabs are restored but stay disconnected until you connect them manually."
     },
     "security": {
       "title": "Security Settings",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -51,6 +51,11 @@
     "connectionError": "连接错误",
     "connectionErrorDesc": "连接时发生意外错误。",
     "waitingForConnection": "等待连接...",
+    "restoreDeferred": "会话未重新连接",
+    "restoreDeferredDesc_one": "上次会话的 {{count}} 个标签页已恢复但未连接。点击标签页上的“连接”以重新连接，或在设置中启用“启动时重新连接会话”。",
+    "restoreDeferredDesc_other": "上次会话的 {{count}} 个标签页已恢复但未连接。点击标签页上的“连接”以重新连接，或在设置中启用“启动时重新连接会话”。",
+    "restoreDeferredHint": "启动时自动重新连接已关闭",
+    "connectNow": "连接",
     "restoreTitle": "工作区恢复",
     "restoreSubtitle": "正在将您的连接恢复上线",
     "restoreReconnecting": "正在重新连接 {{name}}",
@@ -324,7 +329,9 @@
       "connectionTimeout": "连接超时：{{timeout}}秒",
       "keepAliveInterval": "保持连接间隔：{{interval}}秒",
       "autoReconnect": "自动重新连接",
-      "autoReconnectDesc": "连接断开时自动重新连接"
+      "autoReconnectDesc": "连接断开时自动重新连接",
+      "restoreSessionsOnStartup": "启动时重新连接会话",
+      "restoreSessionsOnStartupDesc": "应用启动时自动重新连接上次会话中打开的标签页。关闭后标签页仍会恢复，但保持未连接状态，直到您手动连接。"
     },
     "security": {
       "title": "安全设置",


### PR DESCRIPTION
… (#126)

Add a "Reconnect Sessions on Startup" switch (Settings > Connection, default on). When it is off, the tabs left open in the previous session are still restored to the layout, but App.tsx starts no backend connection for them: they stay `pending` and show an explicit Connect button (the tab context menu Reconnect works too). An info toast tells the user how many tabs were left disconnected. The active-connections list is kept so the tabs persist again for the next launch.

- src/lib/startup-restore.ts: read the preference from the persisted app settings; only an explicit `false` disables the restore so existing installs keep the current behaviour.
- App.tsx: early return in the restore effect; track deferred tab ids and drop them when the user reconnects a tab.
- terminal-tab-portals.tsx: Connect action in the pending placeholder for deferred tabs; the pulsing "Waiting for connection..." stays for in-flight connects.
- Settings modal + en/zh-CN strings (i18n parity checked).
- Tests: helper unit tests and an App-level test covering default restore, skipped restore, and connect-on-demand.

Closes #126