### PR TITLE
fix(settings): start with an empty workspace when startup reconnect is disabled

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -133,10 +133,10 @@ function AppContent() {
   const [isRestoring, setIsRestoring] = useState(false);
   const [restoringProgress, setRestoringProgress] = useState({ current: 0, total: 0 });
   const [currentRestoreTarget, setCurrentRestoreTarget] = useState<{ name: string; host?: string; username?: string } | null>(null);
-  // Tabs restored from the previous session whose automatic reconnect was
-  // skipped because "Reconnect sessions on startup" is disabled. They stay
-  // `pending` and show a Connect action until the user reconnects them.
-  const [deferredRestoreTabIds, setDeferredRestoreTabIds] = useState<ReadonlySet<string>>(() => new Set());
+  // Pending tabs whose latest connect attempt failed. They stay `pending` and
+  // show a Connect action instead of the "waiting" placeholder, because
+  // nothing is actually in flight for them anymore.
+  const [failedPendingTabIds, setFailedPendingTabIds] = useState<ReadonlySet<string>>(() => new Set());
   // The exact tab whose Connect/Reconnect opened the credentials dialog, so
   // handleSaveConnection reconnects that tab. Matching by connection id alone
   // misses primary tabs (no originalConnectionId) and is ambiguous for
@@ -352,25 +352,12 @@ function AppContent() {
 
       if (!isRestoreSessionsOnStartupEnabled()) {
         // The user opted out of automatic reconnect at startup (issue #126).
-        // TerminalGroupProvider already restored the tab layout with every tab
-        // in the `pending` state; leave them there and start no backend
-        // connection. The active-connections list is intentionally kept so
-        // the tabs are persisted again for the next launch.
-        const restoredTabIds = new Set(
-          Object.values(stateRef.current.groups).flatMap(g => g.tabs.map(t => t.id))
-        );
-        const deferred = new Set(
-          activeConnections
-            .map(conn => conn.connectionId)
-            .filter(id => restoredTabIds.has(id))
-        );
-        console.log(`Session restore skipped by setting: ${deferred.size} tab(s) left pending`);
-        if (deferred.size > 0) {
-          setDeferredRestoreTabIds(deferred);
-          toast.info(t('app.restoreDeferred'), {
-            description: t('app.restoreDeferredDesc', { count: deferred.size }),
-          });
-        }
+        // TerminalGroupProvider started from a fresh, empty workspace and
+        // discarded the previous layout, so there is nothing to reconnect
+        // into. This branch is a guard: it keeps a stale active-connections
+        // list (e.g. after an effect-order change) from ever initiating a
+        // connection when the setting is off.
+        console.log('Session restore skipped by setting');
         return;
       }
 
@@ -1026,15 +1013,14 @@ function AppContent() {
     const isDesktop = tabToReconnect.tabType === 'desktop' ||
       connectionData.protocol === 'RDP' || connectionData.protocol === 'VNC';
 
-    // A `pending` tab has no terminal mounted (deferred startup restore, or a
-    // connect still in flight). Keep it pending while the backend session is
-    // established: dispatching `connecting` now would mount PtyTerminal, which
-    // sends StartPty against a session that does not exist yet and can race a
-    // dead-session reconnect with this one. RECONNECT_TAB on success is what
-    // mounts the terminal.
+    // A `pending` tab has no terminal mounted (a connect still in flight).
+    // Keep it pending while the backend session is established: dispatching
+    // `connecting` now would mount PtyTerminal, which sends StartPty against
+    // a session that does not exist yet and can race a dead-session reconnect
+    // with this one. RECONNECT_TAB on success is what mounts the terminal.
     const wasPending = tabToReconnect.connectionStatus === 'pending';
     // Swap the Connect action for the in-flight placeholder while connecting.
-    setDeferredRestoreTabIds(prev => {
+    setFailedPendingTabIds(prev => {
       if (!prev.has(tabId)) return prev;
       const next = new Set(prev);
       next.delete(tabId);
@@ -1046,7 +1032,7 @@ function AppContent() {
      * already cleared), so the final failure never strands the tab.
      */
     const failPending = () => {
-      setDeferredRestoreTabIds(prev => new Set(prev).add(tabId));
+      setFailedPendingTabIds(prev => new Set(prev).add(tabId));
     };
 
     if (!wasPending) {
@@ -1806,8 +1792,8 @@ function AppContent() {
               // the old terminal content showing.)
               dispatch({ type: 'UPDATE_TAB_NAME', tabId: sessionId, name: config.name });
               dispatch({ type: 'RECONNECT_TAB', tabId: sessionId });
-              // A deferred startup-restore tab is connected now.
-              setDeferredRestoreTabIds(prev => {
+              // A pending tab whose connect failed earlier is connected now.
+              setFailedPendingTabIds(prev => {
                 if (!prev.has(sessionId)) return prev;
                 const next = new Set(prev);
                 next.delete(sessionId);
@@ -2151,7 +2137,7 @@ function AppContent() {
                       onCloseTab: handleCloseTab,
                       onCloseAllTabs: handleCloseAllTabs,
                       onDetachTab: handleDetachTab,
-                      deferredRestoreTabIds,
+                      failedPendingTabIds,
                     }}>
                       <ErrorBoundary label={t('app.terminal')}>
                         <GridRenderer node={state.gridLayout} path={[]} />

--- a/src/__tests__/pending-tab-reconnect.test.tsx
+++ b/src/__tests__/pending-tab-reconnect.test.tsx
@@ -1,17 +1,19 @@
 /**
- * Feature test for the "Reconnect Sessions on Startup" setting (issue #126).
+ * On-demand reconnect semantics for `pending` tabs (App.tsx handleReconnect).
  *
- * When the setting is OFF, the tabs from the previous session must still be
- * present in the layout (TerminalGroupProvider restores them as `pending`)
- * but App.tsx must NOT initiate any backend connection at startup. Each
- * deferred tab offers a Connect action that runs the regular full reconnect,
- * and the active-connections list is kept so the tabs persist again for the
- * next launch.
+ * A `pending` tab has no PtyTerminal mounted: mounting one would send StartPty
+ * against a backend session that does not exist yet. While a manual reconnect
+ * is in flight the tab must stay pending (pulsing placeholder); on success the
+ * terminal remounts (RECONNECT_TAB); on a permanent failure the tab is marked
+ * so the explicit Connect action is offered again instead of a dead terminal
+ * or a misleading "waiting" placeholder. A pending tab whose connection has no
+ * stored credentials opens the credentials dialog and reconnects the exact
+ * clicked tab after saving.
  *
- * When the setting is ON (or absent — the default for existing installs),
- * startup behaves as before and every saved connection is reconnected.
- *
- * Same mocked App shell as restore-timeout-cancellation.test.tsx.
+ * The startup layout is mocked with pending tabs (as TerminalGroupProvider
+ * would restore them) and the "Reconnect Sessions on Startup" setting is off,
+ * so startup itself starts no connection and every ssh_connect call below
+ * comes from the manual reconnect under test.
  */
 import React from 'react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -178,17 +180,31 @@ class ResizeObserverMock {
   disconnect() {}
 }
 
-const DEFERRED_HINT = 'Automatic reconnect at startup is disabled';
+const CONNECT_FAILED_HINT = 'The last connection attempt failed';
 
 function sshConnectCalls() {
   return lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect');
 }
 
-describe('"Reconnect Sessions on Startup" setting', () => {
+/** Open the tab context menu on the given tab and trigger its Reconnect item. */
+async function reconnectTabFromContextMenu(name: string): Promise<void> {
+  const groupView = screen.getByTestId('terminal-group-view-group-1');
+  fireEvent.contextMenu(within(groupView).getByText(name));
+  fireEvent.click(await screen.findByText('Reconnect'));
+}
+
+describe('pending tab reconnect', () => {
   beforeEach(() => {
     (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverMock;
     mockState = makeMockState();
     localStorage.clear();
+
+    // The setting is off: startup restores no connections and every
+    // ssh_connect below comes from the manual reconnect under test.
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
 
     const connections = TAB_IDS.map((id, i) => ({
       id,
@@ -227,70 +243,29 @@ describe('"Reconnect Sessions on Startup" setting', () => {
     setRestoreTimingForTests({ connectTimeoutMs: 15_000, overallTimeoutMs: 60_000 });
   });
 
-  it('reconnects every saved connection at startup when the setting is absent (default)', async () => {
+  it('starts no connection at startup and leaves the tabs pending', async () => {
     render(<App />);
-
-    await vi.waitFor(
-      () => {
-        expect(sshConnectCalls()).toHaveLength(TAB_IDS.length);
-      },
-      { timeout: 5000, interval: 50 },
-    );
-    expect(lifecycle.toast.info).not.toHaveBeenCalled();
-    expect(screen.queryByText(DEFERRED_HINT)).toBeNull();
-  });
-
-  it('keeps the tabs pending and starts no connection when the setting is off', async () => {
-    localStorage.setItem(
-      APP_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
-    );
-
-    render(<App />);
-
-    // The deferred-restore notice fires once the restore effect has run.
-    await vi.waitFor(
-      () => {
-        expect(lifecycle.toast.info).toHaveBeenCalledTimes(1);
-      },
-      { timeout: 5000, interval: 50 },
-    );
 
     // Give any (wrongly) scheduled connect a chance to show up before asserting.
-    await new Promise((resolve) => setTimeout(resolve, 100));
+    await new Promise((resolve) => setTimeout(resolve, 150));
     expect(sshConnectCalls()).toHaveLength(0);
+    expect(screen.queryByTestId('pty')).toBeNull();
+    // Every tab shows the pulsing placeholder; the explicit Connect action is
+    // reserved for tabs whose connect actually failed.
+    expect(screen.getAllByText('Waiting for connection...')).toHaveLength(TAB_IDS.length);
+    expect(screen.queryByText(CONNECT_FAILED_HINT)).toBeNull();
+    expect(lifecycle.toast.info).not.toHaveBeenCalled();
     expect(lifecycle.toast.success).not.toHaveBeenCalled();
     expect(lifecycle.toast.error).not.toHaveBeenCalled();
-
-    // The reconnect list must survive so the tabs come back next launch too.
-    expect(lifecycle.clearActiveConnectionsCalls).toBe(0);
-
-    // Every restored tab shows the explicit Connect action instead of the
-    // "waiting" placeholder.
-    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
-    expect(screen.queryByText('Waiting for connection...')).toBeNull();
   });
 
-  it('connects a deferred tab on demand via its Connect button', async () => {
-    localStorage.setItem(
-      APP_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
-    );
-
+  it('reconnects a pending tab on demand via the tab context menu', async () => {
     render(<App />);
 
-    await vi.waitFor(
-      () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
-      },
-      { timeout: 5000, interval: 50 },
-    );
+    await reconnectTabFromContextMenu('Server 1');
 
-    // The Connect button sits next to the hint inside the tab placeholder.
-    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
-    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
-
-    // Exactly one full reconnect for the clicked tab; the other tabs stay deferred.
+    // Exactly one full reconnect for the clicked tab; the other tabs stay
+    // pending with no connection started.
     await vi.waitFor(
       () => {
         expect(sshConnectCalls()).toHaveLength(1);
@@ -302,18 +277,15 @@ describe('"Reconnect Sessions on Startup" setting', () => {
 
     await vi.waitFor(
       () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
+        expect(screen.getByTestId('pty')).toBeTruthy();
       },
       { timeout: 5000, interval: 50 },
     );
     expect(sshConnectCalls()).toHaveLength(1);
+    expect(screen.getAllByText('Waiting for connection...')).toHaveLength(TAB_IDS.length - 1);
   }, 15_000);
 
-  it('keeps a deferred tab pending (no terminal mounted) while its connect is in flight', async () => {
-    localStorage.setItem(
-      APP_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
-    );
+  it('keeps a reconnecting tab pending (no terminal mounted) while its connect is in flight', async () => {
     let settle: ((value: { success: boolean }) => void) | undefined;
     lifecycle.invoke.mockImplementation((command: string) => {
       if (command === 'ssh_connect') {
@@ -326,15 +298,8 @@ describe('"Reconnect Sessions on Startup" setting', () => {
     });
 
     render(<App />);
-    await vi.waitFor(
-      () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
-      },
-      { timeout: 5000, interval: 50 },
-    );
 
-    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
-    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await reconnectTabFromContextMenu('Server 1');
     await vi.waitFor(
       () => {
         expect(sshConnectCalls()).toHaveLength(1);
@@ -342,12 +307,11 @@ describe('"Reconnect Sessions on Startup" setting', () => {
       { timeout: 5000, interval: 50 },
     );
 
-    // In flight: the pulsing placeholder replaces the Connect action and no
-    // PtyTerminal is mounted yet (it would send StartPty to a backend session
-    // that does not exist until ssh_connect succeeds).
-    expect(screen.getByText('Waiting for connection...')).toBeTruthy();
+    // In flight: the pulsing placeholder stays and no PtyTerminal is mounted
+    // (it would send StartPty to a backend session that does not exist until
+    // ssh_connect succeeds).
+    expect(screen.getAllByText('Waiting for connection...')).toHaveLength(TAB_IDS.length);
     expect(screen.queryByTestId('pty')).toBeNull();
-    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
 
     // Success remounts the tab as a terminal (RECONNECT_TAB).
     await act(async () => {
@@ -359,14 +323,10 @@ describe('"Reconnect Sessions on Startup" setting', () => {
       },
       { timeout: 5000, interval: 50 },
     );
-    expect(screen.queryByText('Waiting for connection...')).toBeNull();
+    expect(screen.getAllByText('Waiting for connection...')).toHaveLength(TAB_IDS.length - 1);
   }, 15_000);
 
-  it('offers Connect again when the on-demand connect fails, without mounting a dead terminal', async () => {
-    localStorage.setItem(
-      APP_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
-    );
+  it('offers Connect again when the on-demand reconnect fails, without mounting a dead terminal', async () => {
     lifecycle.invoke.mockImplementation((command: string) => {
       // "Authentication" marks the failure as permanent: no backoff retry.
       if (command === 'ssh_connect') return Promise.resolve({ success: false, error: 'Authentication failed' });
@@ -375,15 +335,8 @@ describe('"Reconnect Sessions on Startup" setting', () => {
     });
 
     render(<App />);
-    await vi.waitFor(
-      () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
-      },
-      { timeout: 5000, interval: 50 },
-    );
 
-    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
-    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await reconnectTabFromContextMenu('Server 1');
     await vi.waitFor(
       () => {
         expect(lifecycle.toast.error).toHaveBeenCalledTimes(1);
@@ -391,11 +344,11 @@ describe('"Reconnect Sessions on Startup" setting', () => {
       { timeout: 5000, interval: 50 },
     );
 
-    // The tab is back to the deferred state: Connect is offered again and no
-    // terminal was mounted for a session that never existed.
+    // The tab is back to pending with the explicit Connect action offered,
+    // and no terminal was mounted for a session that never existed.
     await vi.waitFor(
       () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
+        expect(screen.getAllByText(CONNECT_FAILED_HINT)).toHaveLength(1);
       },
       { timeout: 5000, interval: 50 },
     );
@@ -404,11 +357,7 @@ describe('"Reconnect Sessions on Startup" setting', () => {
   }, 15_000);
 
   it('reconnects the exact clicked tab after credentials are supplied in the dialog', async () => {
-    localStorage.setItem(
-      APP_SETTINGS_STORAGE_KEY,
-      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
-    );
-    // conn-1 is saved without a password: Connect must open the credentials
+    // conn-1 is saved without a password: Reconnect must open the credentials
     // dialog instead of connecting.
     const saved = JSON.parse(localStorage.getItem('r-shell-connections') ?? '[]') as Array<Record<string, unknown>>;
     delete saved[0].password;
@@ -416,15 +365,8 @@ describe('"Reconnect Sessions on Startup" setting', () => {
     lifecycle.dialogProps = null;
 
     render(<App />);
-    await vi.waitFor(
-      () => {
-        expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length);
-      },
-      { timeout: 5000, interval: 50 },
-    );
 
-    const firstPlaceholder = screen.getAllByText(DEFERRED_HINT)[0].parentElement as HTMLElement;
-    fireEvent.click(within(firstPlaceholder).getByRole('button', { name: 'Connect' }));
+    await reconnectTabFromContextMenu('Server 1');
     await vi.waitFor(
       () => {
         expect(lifecycle.dialogProps?.open).toBe(true);
@@ -465,7 +407,7 @@ describe('"Reconnect Sessions on Startup" setting', () => {
       },
       { timeout: 5000, interval: 50 },
     );
-    // Still three tabs: the two untouched ones remain deferred, none was added.
-    expect(screen.getAllByText(DEFERRED_HINT)).toHaveLength(TAB_IDS.length - 1);
+    // Still three tabs: the two untouched ones remain pending, none was added.
+    expect(screen.getAllByText('Waiting for connection...')).toHaveLength(TAB_IDS.length - 1);
   }, 15_000);
 });

--- a/src/__tests__/startup-restore-tabs.test.tsx
+++ b/src/__tests__/startup-restore-tabs.test.tsx
@@ -1,0 +1,246 @@
+/**
+ * Feature tests for the "Reconnect Sessions on Startup" setting (issue #126).
+ *
+ * When the setting is ON (or absent — the default for existing installs),
+ * startup restores the previous session: the saved tab layout is reopened and
+ * every saved connection that has credentials is reconnected.
+ *
+ * When the setting is OFF, the previous session's tabs are NOT reopened: the
+ * app starts with a fresh, empty workspace (TerminalGroupProvider skips the
+ * persisted layout and discards it) and no backend connection is made.
+ *
+ * Uses the real TerminalGroupProvider (seeded through the serializer) so the
+ * layout gating in initializeState is exercised end-to-end. Same mocked App
+ * shell as restore-timeout-cancellation.test.tsx.
+ */
+import React from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import App from '../App';
+import { setRestoreTimingForTests } from '../lib/restore-timing';
+import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
+import { RESTORE_SESSIONS_ON_STARTUP_KEY } from '../lib/startup-restore';
+import { saveState, STORAGE_KEY } from '../lib/terminal-group-serializer';
+import type { TerminalGroupState } from '../lib/terminal-group-types';
+
+const lifecycle = vi.hoisted(() => ({
+  invoke: vi.fn(),
+  activeConnections: [] as Array<{ tabId: string; connectionId: string; order: number; tabType: string; protocol: string }>,
+  toast: { error: vi.fn(), success: vi.fn(), info: vi.fn() },
+  clearActiveConnectionsCalls: 0,
+}));
+
+const TAB_IDS = ['conn-1', 'conn-2', 'conn-3'];
+
+/** Saved layout as the previous session would have persisted it. */
+function makeSavedLayout(): TerminalGroupState {
+  const tabs = TAB_IDS.map((id, i) => ({
+    id,
+    name: `Server ${i + 1}`,
+    tabType: 'terminal' as const,
+    protocol: 'SSH',
+    host: 'example.com',
+    username: 'root',
+    connectionStatus: 'connected' as const,
+    reconnectCount: 0,
+  }));
+  return {
+    groups: { 'group-1': { id: 'group-1', tabs, activeTabId: TAB_IDS[0] } },
+    activeGroupId: 'group-1',
+    gridLayout: { type: 'leaf', groupId: 'group-1' },
+    nextGroupId: 2,
+    tabToGroupMap: Object.fromEntries(TAB_IDS.map((id) => [id, 'group-1'])),
+  };
+}
+
+vi.mock('@/components/pty-terminal', async () => {
+  const ReactModule = await import('react');
+  return {
+    PtyTerminal: () => ReactModule.createElement('div', { 'data-testid': 'pty' }),
+  };
+});
+
+vi.mock('@/lib/connection-storage', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/connection-storage')>();
+  return {
+    ...actual,
+    ActiveConnectionsManager: {
+      getActiveConnections: () => lifecycle.activeConnections,
+      saveActiveConnections: () => {},
+      clearActiveConnections: () => {
+        lifecycle.clearActiveConnectionsCalls++;
+      },
+    },
+  };
+});
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => lifecycle.invoke(...args),
+  isTauri: () => false,
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(async () => vi.fn()),
+}));
+
+vi.mock('@/lib/restoration-manager', () => ({
+  registerRestoration: vi.fn(async () => {}),
+  signalReady: vi.fn(),
+  clearAllRestorations: vi.fn(),
+}));
+
+vi.mock('sonner', () => ({ toast: lifecycle.toast }));
+
+vi.mock('@/components/connection-dialog', async () => {
+  const ReactModule = await import('react');
+  return {
+    ConnectionDialog: () => ReactModule.createElement('div'),
+  };
+});
+vi.mock('@/components/system-monitor', async () => {
+  const ReactModule = await import('react');
+  return { SystemMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/log-monitor', async () => {
+  const ReactModule = await import('react');
+  return { LogMonitor: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/menu-bar', async () => {
+  const ReactModule = await import('react');
+  return { MenuBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/status-bar', async () => {
+  const ReactModule = await import('react');
+  return { StatusBar: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/integrated-file-browser', async () => {
+  const ReactModule = await import('react');
+  return { IntegratedFileBrowser: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/update-checker', async () => {
+  const ReactModule = await import('react');
+  return { UpdateChecker: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/welcome-screen', async () => {
+  const ReactModule = await import('react');
+  return { WelcomeScreen: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/ui/sonner', async () => {
+  const ReactModule = await import('react');
+  return { Toaster: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/desktop-viewer', async () => {
+  const ReactModule = await import('react');
+  return { DesktopViewer: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-browser-view', async () => {
+  const ReactModule = await import('react');
+  return { FileBrowserView: () => ReactModule.createElement('div') };
+});
+vi.mock('@/components/file-editor-view', async () => {
+  const ReactModule = await import('react');
+  return { FileEditorView: () => ReactModule.createElement('div') };
+});
+
+class ResizeObserverMock {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+function sshConnectCalls() {
+  return lifecycle.invoke.mock.calls.filter(([cmd]) => cmd === 'ssh_connect');
+}
+
+/** Persist the layout exactly as TerminalGroupProvider would have saved it. */
+function seedLayout(): void {
+  saveState(makeSavedLayout());
+}
+
+describe('"Reconnect Sessions on Startup" setting', () => {
+  beforeEach(() => {
+    (globalThis as { ResizeObserver?: unknown }).ResizeObserver = ResizeObserverMock;
+    localStorage.clear();
+
+    const connections = TAB_IDS.map((id, i) => ({
+      id,
+      name: `Server ${i + 1}`,
+      host: 'example.com',
+      port: 22,
+      username: 'root',
+      protocol: 'SSH',
+      authMethod: 'password',
+      password: 'secret',
+      createdAt: '2026-01-01T00:00:00.000Z',
+    }));
+    localStorage.setItem('r-shell-connections', JSON.stringify(connections));
+    lifecycle.activeConnections = connections.map((c, i) => ({
+      tabId: c.id,
+      connectionId: c.id,
+      order: i,
+      tabType: 'terminal' as const,
+      protocol: 'SSH' as const,
+    }));
+
+    lifecycle.invoke.mockReset();
+    lifecycle.invoke.mockImplementation((command: string) => {
+      if (command === 'ssh_connect') return Promise.resolve({ success: true });
+      if (command === 'get_system_locale') return Promise.resolve('en-US');
+      return Promise.resolve({});
+    });
+    lifecycle.toast.error.mockReset();
+    lifecycle.toast.success.mockReset();
+    lifecycle.toast.info.mockReset();
+    lifecycle.clearActiveConnectionsCalls = 0;
+  });
+
+  afterEach(() => {
+    cleanup();
+    setRestoreTimingForTests({ connectTimeoutMs: 15_000, overallTimeoutMs: 60_000 });
+  });
+
+  it('reconnects every saved connection at startup when the setting is absent (default)', async () => {
+    seedLayout();
+    render(<App />);
+
+    await vi.waitFor(
+      () => {
+        expect(sshConnectCalls()).toHaveLength(TAB_IDS.length);
+      },
+      { timeout: 5000, interval: 50 },
+    );
+    expect(lifecycle.toast.info).not.toHaveBeenCalled();
+  });
+
+  it('reopens no tabs and starts no connection when the setting is off', async () => {
+    seedLayout();
+    localStorage.setItem(
+      APP_SETTINGS_STORAGE_KEY,
+      JSON.stringify({ [RESTORE_SESSIONS_ON_STARTUP_KEY]: false }),
+    );
+
+    render(<App />);
+
+    // Give any (wrongly) scheduled connect a chance to show up before asserting.
+    await new Promise((resolve) => setTimeout(resolve, 150));
+    expect(sshConnectCalls()).toHaveLength(0);
+    expect(screen.queryByTestId('pty')).toBeNull();
+    expect(screen.queryByText('Waiting for connection...')).toBeNull();
+    expect(lifecycle.toast.info).not.toHaveBeenCalled();
+    expect(lifecycle.toast.success).not.toHaveBeenCalled();
+    expect(lifecycle.toast.error).not.toHaveBeenCalled();
+
+    // No previous-session tab survives: the layout was discarded (or the
+    // fresh empty workspace was saved over it), so re-enabling the setting
+    // later cannot resurrect stale tabs. The stale reconnect list was
+    // cleared along with it.
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const storedTabs = stored
+      ? Object.values((JSON.parse(stored) as { data: TerminalGroupState }).data.groups).flatMap(
+          (group) => (group as { tabs: unknown[] }).tabs,
+        )
+      : [];
+    expect(storedTabs).toHaveLength(0);
+    expect(lifecycle.clearActiveConnectionsCalls).toBeGreaterThan(0);
+  });
+});

--- a/src/components/terminal/terminal-tab-portals.tsx
+++ b/src/components/terminal/terminal-tab-portals.tsx
@@ -53,7 +53,7 @@ function useThemeKey(): number {
 function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: number }) {
   const { t } = useTranslation();
   const { state, dispatch } = useTerminalGroups();
-  const { onReconnectTab, onDetachTab, deferredRestoreTabIds } = useTerminalCallbacks();
+  const { onReconnectTab, onDetachTab, failedPendingTabIds } = useTerminalCallbacks();
   const groupId = state.tabToGroupMap[tab.id];
   const group = groupId ? state.groups[groupId] : undefined;
   const isActive = groupId === state.activeGroupId && group?.activeTabId === tab.id;
@@ -124,16 +124,16 @@ function TerminalTabContent({ tab, themeKey }: { tab: TerminalTab; themeKey: num
       />
     );
   } else if (tab.connectionStatus === 'pending') {
-    // A tab restored from the previous session whose automatic reconnect was
-    // skipped ("Reconnect sessions on startup" off) is not waiting for anything:
-    // offer an explicit Connect action instead of the pulsing placeholder.
-    const isDeferredRestore = deferredRestoreTabIds?.has(tab.id) ?? false;
+    // A `pending` tab whose latest connect attempt failed is not waiting for
+    // anything: offer an explicit Connect action instead of the pulsing
+    // placeholder.
+    const hasFailedConnect = failedPendingTabIds?.has(tab.id) ?? false;
     content = (
       <div className="h-full w-full flex items-center justify-center bg-muted/30">
         <div className="text-center text-muted-foreground space-y-3">
-          {isDeferredRestore ? (
+          {hasFailedConnect ? (
             <>
-              <div>{t('app.restoreDeferredHint')}</div>
+              <div>{t('app.connectFailedHint')}</div>
               <Button size="sm" variant="outline" onClick={handleReconnect}>
                 <RefreshCw className="mr-2 h-4 w-4" />
                 {t('app.connectNow')}

--- a/src/lib/startup-restore.ts
+++ b/src/lib/startup-restore.ts
@@ -2,14 +2,13 @@ import { APP_SETTINGS_STORAGE_KEY } from './keyboard-shortcuts';
 
 /**
  * Settings key (inside the `APP_SETTINGS_STORAGE_KEY` object persisted by
- * SettingsModal) that controls whether App.tsx re-establishes the previous
- * session's connections automatically at startup.
+ * SettingsModal) that controls whether App.tsx restores the previous session
+ * at startup.
  *
- * When disabled, the tabs from the previous session are still restored to the
- * layout but stay in the `pending` state until the user connects them
- * manually (Connect button on the tab, or Reconnect in the tab context menu).
- * This keeps startup fast for users who leave many sessions open but do not
- * need all of them live immediately (see issue #126).
+ * When disabled, the previous session's tabs are not restored at all: the app
+ * starts with a fresh, empty workspace (TerminalGroupProvider skips loading
+ * the persisted layout and discards it) and no connection is made. See
+ * issue #126.
  */
 export const RESTORE_SESSIONS_ON_STARTUP_KEY = 'restoreSessionsOnStartup';
 

--- a/src/lib/terminal-callbacks-context.tsx
+++ b/src/lib/terminal-callbacks-context.tsx
@@ -26,12 +26,11 @@ export interface TerminalCallbacks {
   /** Xshell-style detach (Ctrl+A+D): keep the session alive in the background. */
   onDetachTab?: (tabId: string) => void | Promise<void>;
   /**
-   * Tabs restored from the previous session whose automatic reconnect was
-   * skipped because "Reconnect sessions on startup" is disabled. They stay in
-   * the `pending` state and offer a Connect action until the user connects
-   * them manually.
+   * Pending tabs whose latest connect attempt failed. They stay in the
+   * `pending` state and offer a Connect action instead of the "waiting"
+   * placeholder, because nothing is actually in flight for them anymore.
    */
-  deferredRestoreTabIds?: ReadonlySet<string>;
+  failedPendingTabIds?: ReadonlySet<string>;
 }
 
 const TerminalCallbacksContext = createContext<TerminalCallbacks>({});

--- a/src/lib/terminal-group-context.tsx
+++ b/src/lib/terminal-group-context.tsx
@@ -1,7 +1,8 @@
 import React, { createContext, useContext, useReducer, useEffect, useRef, useMemo } from 'react';
 import type { TerminalGroupState, TerminalGroupAction, TerminalGroup, TerminalTab } from './terminal-group-types';
 import { terminalGroupReducer, createDefaultState } from './terminal-group-reducer';
-import { saveState, loadState, migrateFromLegacy } from './terminal-group-serializer';
+import { saveState, loadState, migrateFromLegacy, STORAGE_KEY } from './terminal-group-serializer';
+import { isRestoreSessionsOnStartupEnabled } from './startup-restore';
 
 interface TerminalGroupContextType {
   state: TerminalGroupState;
@@ -25,6 +26,21 @@ const TerminalGroupContext = createContext<TerminalGroupContextType | null>(null
 
 function initializeState(): TerminalGroupState {
   migrateFromLegacy();
+
+  // The user opted out of session restore ("Reconnect Sessions on Startup"
+  // off, issue #126): start with a fresh, empty workspace instead of reopening
+  // the previous session's tabs. The persisted layout is discarded too, so a
+  // later re-enable of the setting can never resurrect stale tabs saved
+  // before it was switched off.
+  if (!isRestoreSessionsOnStartupEnabled()) {
+    try {
+      localStorage.removeItem(STORAGE_KEY);
+    } catch {
+      // Storage unavailable — starting from the default state is still correct.
+    }
+    return createDefaultState();
+  }
+
   const loaded = loadState();
   if (!loaded) return createDefaultState();
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -51,10 +51,7 @@
     "connectionError": "Connection Error",
     "connectionErrorDesc": "An unexpected error occurred while connecting.",
     "waitingForConnection": "Waiting for connection...",
-    "restoreDeferred": "Sessions Not Reconnected",
-    "restoreDeferredDesc_one": "{{count}} tab from your last session was restored without connecting. Use Connect on the tab to reconnect it, or enable 'Reconnect Sessions on Startup' in Settings.",
-    "restoreDeferredDesc_other": "{{count}} tabs from your last session were restored without connecting. Use Connect on a tab to reconnect it, or enable 'Reconnect Sessions on Startup' in Settings.",
-    "restoreDeferredHint": "Automatic reconnect at startup is disabled",
+    "connectFailedHint": "The last connection attempt failed",
     "connectNow": "Connect",
     "restoreTitle": "Workspace Restore",
     "restoreSubtitle": "Bringing your connections back online",
@@ -331,7 +328,7 @@
       "autoReconnect": "Auto Reconnect",
       "autoReconnectDesc": "Automatically reconnect when connection is lost",
       "restoreSessionsOnStartup": "Reconnect Sessions on Startup",
-      "restoreSessionsOnStartupDesc": "Automatically reconnect the tabs left open in the previous session when the app starts. When off, the tabs are restored but stay disconnected until you connect them manually."
+      "restoreSessionsOnStartupDesc": "Automatically reopen and reconnect the tabs left open in the previous session when the app starts. When off, the app starts with an empty workspace and previous tabs are not reopened."
     },
     "security": {
       "title": "Security Settings",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -51,10 +51,7 @@
     "connectionError": "连接错误",
     "connectionErrorDesc": "连接时发生意外错误。",
     "waitingForConnection": "等待连接...",
-    "restoreDeferred": "会话未重新连接",
-    "restoreDeferredDesc_one": "上次会话的 {{count}} 个标签页已恢复但未连接。点击标签页上的“连接”以重新连接，或在设置中启用“启动时重新连接会话”。",
-    "restoreDeferredDesc_other": "上次会话的 {{count}} 个标签页已恢复但未连接。点击标签页上的“连接”以重新连接，或在设置中启用“启动时重新连接会话”。",
-    "restoreDeferredHint": "启动时自动重新连接已关闭",
+    "connectFailedHint": "上次连接尝试失败",
     "connectNow": "连接",
     "restoreTitle": "工作区恢复",
     "restoreSubtitle": "正在将您的连接恢复上线",
@@ -331,7 +328,7 @@
       "autoReconnect": "自动重新连接",
       "autoReconnectDesc": "连接断开时自动重新连接",
       "restoreSessionsOnStartup": "启动时重新连接会话",
-      "restoreSessionsOnStartupDesc": "应用启动时自动重新连接上次会话中打开的标签页。关闭后标签页仍会恢复，但保持未连接状态，直到您手动连接。"
+      "restoreSessionsOnStartupDesc": "应用启动时自动重新打开并连接上次会话中的标签页。关闭后，应用将以空工作区启动，不会重新打开上次的标签页。"
     },
     "security": {
       "title": "安全设置",


### PR DESCRIPTION
## Summary

Follow-up to #127 / #126: with **Reconnect Sessions on Startup** turned off, the previous session's tabs were still reopened as `pending` placeholders — only the automatic reconnect was skipped. This PR makes the setting behave as expected: **the previous tabs are not reopened at all** and the app starts with a fresh, empty workspace.

## Changes

- `terminal-group-context.tsx` — `initializeState()` now checks the setting before loading the persisted layout. When disabled it skips the load **and discards the stored layout**, so re-enabling the setting later cannot resurrect stale tabs whose reconnect list was already wiped by the empty workspace (the mount-time "save active connections" effect clears the list whenever the workspace is empty).
- `App.tsx` — the restore effect's disabled branch lost the "Sessions Not Reconnected" toast and deferred-marker population (nothing exists to defer anymore); it is now a guard that returns before starting any connection.
- Renamed `deferredRestoreTabIds` → `failedPendingTabIds` (`App.tsx`, `terminal-callbacks-context.tsx`, `terminal-tab-portals.tsx`): the marker now only means "a pending tab whose connect attempt failed — offer Connect again". That UX is preserved (still no `PtyTerminal` mount while a connect is in flight; Connect re-offered after a permanent failure), with the hint reworded to "The last connection attempt failed".
- Locales — setting description updated in `en.json` / `zh-CN.json`; removed the now-unreachable toast strings. `pnpm i18n:check` passes.

## Tests

The old `restore-skipped-when-disabled.test.tsx` (471 lines) was built around the removed "restored but pending" behavior, so it was split into two files:

- **`startup-restore-tabs.test.tsx`** — uses the *real* `TerminalGroupProvider` (seeded via the serializer) to exercise the layout gating end-to-end:
  - default (setting absent) still reconnects every saved connection;
  - setting off → no tabs rendered, no `ssh_connect`, no toasts, layout discarded, reconnect list cleared.
- **`pending-tab-reconnect.test.tsx`** — keeps the on-demand reconnect semantics (entered via the tab context menu, which is the path that still exists): startup starts no connections; pending tab reconnects on demand; no `PtyTerminal` mounted while the connect is in flight; Connect re-offered after a permanent auth failure (no dead terminal, no backoff retry); credentials-dialog flow reconnects the exact clicked tab.

## Verification

- `pnpm test`: 74 files, 742 tests passing
- `tsc --noEmit` clean; `eslint` on touched files: 0 errors (the one repo-wide error in `settings-modal.tsx:425` is pre-existing from #127 and untouched here)

Closes #126 (the remaining UX gap reported there)