### PR TITLE
fix(terminal): stabilize tab drag; add keyboard reorder, a11y announcements, FLIP animation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -33,6 +33,7 @@ import {
   useKeyboardShortcuts,
 } from './lib/keyboard-shortcuts';
 import type { SplitViewShortcutBindings } from './lib/keyboard-shortcuts';
+import { announce } from './lib/live-announcer';
 import { TerminalGroupProvider, useTerminalGroups } from './lib/terminal-group-context';
 import { TerminalCallbacksProvider } from './lib/terminal-callbacks-context';
 import { GridRenderer } from './components/terminal/grid-renderer';
@@ -265,6 +266,18 @@ function AppContent() {
   // Keyboard shortcuts: layout + split view
   const splitViewShortcuts = useMemo(() => {
     const groupIds = Object.keys(state.groups);
+    // Ctrl+Shift+PageUp/PageDown — move the active tab one slot in its group.
+    const moveActiveTab = (delta: -1 | 1) => {
+      if (!activeGroup?.activeTabId) return;
+      const fromIndex = activeGroup.tabs.findIndex((t) => t.id === activeGroup.activeTabId);
+      const toIndex = fromIndex + delta;
+      if (fromIndex === -1 || toIndex < 0 || toIndex >= activeGroup.tabs.length) return;
+      dispatch({ type: 'REORDER_TAB', groupId: activeGroup.id, fromIndex, toIndex });
+      announce(t('terminal.a11y.tabMovedToPosition', {
+        position: toIndex + 1,
+        total: activeGroup.tabs.length,
+      }));
+    };
     return createSplitViewShortcuts(
       {
         splitRight: () => {
@@ -299,10 +312,12 @@ function AppContent() {
             dispatch({ type: 'ACTIVATE_TAB', groupId: activeGroup.id, tabId: activeGroup.tabs[prevIndex].id });
           }
         },
+        moveTabLeft: () => moveActiveTab(-1),
+        moveTabRight: () => moveActiveTab(1),
       },
       keyboardShortcutSettings,
     );
-  }, [state.activeGroupId, state.groups, activeGroup, dispatch, handleCloseActiveTab, keyboardShortcutSettings]);
+  }, [state.activeGroupId, state.groups, activeGroup, dispatch, handleCloseActiveTab, keyboardShortcutSettings, t]);
 
   const layoutShortcuts = useMemo(() => createLayoutShortcuts({
     toggleLeftSidebar,

--- a/src/__tests__/group-tab-bar-context-menu.test.tsx
+++ b/src/__tests__/group-tab-bar-context-menu.test.tsx
@@ -61,4 +61,32 @@ describe('GroupTabBar context menu', () => {
     expect(onCloseTab).toHaveBeenCalledWith('a');
     expect(dispatch).not.toHaveBeenCalledWith({ type: 'REMOVE_TAB', groupId: '1', tabId: 'a' });
   });
+
+  it('moves a tab left/right from the context menu', async () => {
+    const tabs = [makeTab('a'), makeTab('b'), makeTab('c')];
+    render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+
+    fireEvent.contextMenu(screen.getByText('b'));
+    fireEvent.click(await screen.findByText('Move Tab Left'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REORDER_TAB', groupId: '1', fromIndex: 1, toIndex: 0 });
+
+    dispatch.mockClear();
+    fireEvent.contextMenu(screen.getByText('b'));
+    fireEvent.click(await screen.findByText('Move Tab Right'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REORDER_TAB', groupId: '1', fromIndex: 1, toIndex: 2 });
+  });
+
+  it('disables Move Tab Left on the first tab and Move Tab Right on the last', async () => {
+    const tabs = [makeTab('a'), makeTab('b')];
+    render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+
+    fireEvent.contextMenu(screen.getByText('a'));
+    const moveLeft = (await screen.findByText('Move Tab Left')).closest('[role="menuitem"]');
+    expect(moveLeft?.getAttribute('data-disabled')).not.toBeNull();
+    fireEvent.click(moveLeft as HTMLElement);
+    expect(dispatch).not.toHaveBeenCalled();
+
+    const moveRight = screen.getByText('Move Tab Right').closest('[role="menuitem"]');
+    expect(moveRight?.getAttribute('data-disabled')).toBeNull();
+  });
 });

--- a/src/__tests__/group-tab-bar-drag.test.tsx
+++ b/src/__tests__/group-tab-bar-drag.test.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { GroupTabBar } from '../components/terminal/group-tab-bar';
+import type { TerminalTab } from '../lib/terminal-group-types';
+
+const dispatch = vi.fn();
+
+vi.mock('../lib/terminal-group-context', () => ({
+  useTerminalGroups: () => ({ state: {}, dispatch }),
+}));
+
+beforeEach(() => {
+  dispatch.mockClear();
+});
+
+function makeTab(id: string): TerminalTab {
+  return { id, name: id, connectionStatus: 'connected', reconnectCount: 0 };
+}
+
+/** jsdom lacks elementsFromPoint; stub it so drag hit-testing finds this bar. */
+function stubDropTarget(container: HTMLElement, groupId: string) {
+  const tabBarEl = container.querySelector(`[data-tab-bar-group="${groupId}"]`) as HTMLElement;
+  document.elementsFromPoint = () => [tabBarEl];
+}
+
+function getTabEl(name: string): HTMLElement {
+  return screen.getByText(name).closest('[data-tab-id]') as HTMLElement;
+}
+
+describe('GroupTabBar custom drag', () => {
+  it('ends the drag on a no-button move when pointerup was missed', () => {
+    const tabs = [makeTab('a'), makeTab('b'), makeTab('c')];
+    const { container } = render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+    stubDropTarget(container, '1');
+
+    const tabA = getTabEl('a');
+    fireEvent.pointerDown(tabA, { button: 0, pointerId: 1, clientX: 100, clientY: 10 });
+    // Move past the threshold with the button held — drag is now active
+    fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientX: 130, clientY: 10 });
+    expect(tabA.className).toContain('opacity-40');
+
+    // pointerup was never delivered (e.g. released outside the window): the
+    // next hover move arrives with buttons = 0 and must end the drag
+    fireEvent.pointerMove(document, { pointerId: 1, buttons: 0, clientX: 130, clientY: 10 });
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: 'REORDER_TAB',
+      groupId: '1',
+      fromIndex: 0,
+      toIndex: 2,
+    });
+    expect(tabA.className).not.toContain('opacity-40');
+    expect(document.body.style.userSelect).toBe('');
+
+    // Drag machinery fully torn down — further hover moves do nothing
+    dispatch.mockClear();
+    fireEvent.pointerMove(document, { pointerId: 1, buttons: 0, clientX: 10, clientY: 10 });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('ignores pointer moves from a different pointer', () => {
+    const tabs = [makeTab('a'), makeTab('b'), makeTab('c')];
+    const { container } = render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+    stubDropTarget(container, '1');
+
+    const tabA = getTabEl('a');
+    fireEvent.pointerDown(tabA, { button: 0, pointerId: 1, clientX: 100, clientY: 10 });
+
+    // A second pointer wiggles past the threshold — must not drive this drag
+    fireEvent.pointerMove(document, { pointerId: 2, buttons: 1, clientX: 130, clientY: 10 });
+    expect(tabA.className).not.toContain('opacity-40');
+
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 130, clientY: 10 });
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('does not start a drag from sub-threshold wiggle during a click', () => {
+    const tabs = [makeTab('a'), makeTab('b')];
+    const { container } = render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+    stubDropTarget(container, '1');
+
+    const tabA = getTabEl('a');
+    fireEvent.pointerDown(tabA, { button: 0, pointerId: 1, clientX: 100, clientY: 10 });
+    // 3px diagonal = ~4.2px Euclidean, below the 5px threshold
+    fireEvent.pointerMove(document, { pointerId: 1, buttons: 1, clientX: 103, clientY: 13 });
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 103, clientY: 13 });
+
+    expect(tabA.className).not.toContain('opacity-40');
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  it('FLIP-animates tabs when the order changes', () => {
+    // jsdom rects are all-zero; fake per-tab lefts so the FLIP effect sees the
+    // position change caused by a reorder.
+    const lefts: Record<string, number> = { a: 0, b: 120 };
+    const rectSpy = vi
+      .spyOn(Element.prototype, 'getBoundingClientRect')
+      .mockImplementation(function (this: Element) {
+        const id = this.getAttribute?.('data-tab-id');
+        return { left: id ? lefts[id] ?? 0 : 0 } as DOMRect;
+      });
+
+    try {
+      const { rerender } = render(
+        <GroupTabBar groupId="1" tabs={[makeTab('a'), makeTab('b')]} activeTabId="a" />,
+      );
+
+      // Reorder commit: DOM order and on-screen positions swap
+      lefts.a = 120;
+      lefts.b = 0;
+      rerender(<GroupTabBar groupId="1" tabs={[makeTab('b'), makeTab('a')]} activeTabId="a" />);
+
+      const tabA = getTabEl('a');
+      const tabB = getTabEl('b');
+      // Both tabs are playing from their inverted positions back to zero
+      expect(tabA.style.transition).toContain('transform');
+      expect(tabB.style.transition).toContain('transform');
+      expect(tabA.style.transform).toBe('');
+      expect(tabB.style.transform).toBe('');
+    } finally {
+      rectSpy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -23,6 +23,8 @@ function createMockActions() {
     closeTab: vi.fn(),
     nextTab: vi.fn(),
     prevTab: vi.fn(),
+    moveTabLeft: vi.fn(),
+    moveTabRight: vi.fn(),
   };
 }
 
@@ -42,11 +44,12 @@ function findShortcut(
 describe('createSplitViewShortcuts', () => {
   // Validates: Requirements 5.1, 5.2, 5.3, 5.4, 5.5, 5.6, 5.7
 
-  it('returns 14 shortcuts total', () => {
+  it('returns 16 shortcuts total', () => {
     const actions = createMockActions();
     const shortcuts = createSplitViewShortcuts(actions);
     // 1 splitRight + 1 splitDown + 9 focusGroup + 1 closeTab + 1 nextTab + 1 prevTab
-    expect(shortcuts).toHaveLength(14);
+    // + 1 moveTabLeft + 1 moveTabRight
+    expect(shortcuts).toHaveLength(16);
   });
 
   // Requirement 5.1: Ctrl+\ splits right
@@ -147,6 +150,35 @@ describe('createSplitViewShortcuts', () => {
     expect(shortcut).toBeDefined();
     shortcut!.handler();
     expect(actions.prevTab).toHaveBeenCalledOnce();
+  });
+
+  // Browser convention: Ctrl+Shift+PageUp/PageDown reorder tabs
+  it('Ctrl+Shift+PageUp triggers moveTabLeft', () => {
+    const actions = createMockActions();
+    const shortcuts = createSplitViewShortcuts(actions);
+    const shortcut = findShortcut(shortcuts, 'PageUp', { ctrlKey: true, shiftKey: true });
+
+    expect(shortcut).toBeDefined();
+    shortcut!.handler();
+    expect(actions.moveTabLeft).toHaveBeenCalledOnce();
+  });
+
+  it('Ctrl+Shift+PageDown triggers moveTabRight', () => {
+    const actions = createMockActions();
+    const shortcuts = createSplitViewShortcuts(actions);
+    const shortcut = findShortcut(shortcuts, 'PageDown', { ctrlKey: true, shiftKey: true });
+
+    expect(shortcut).toBeDefined();
+    shortcut!.handler();
+    expect(actions.moveTabRight).toHaveBeenCalledOnce();
+  });
+
+  it('move tab shortcuts fire even while a terminal has focus', () => {
+    const actions = createMockActions();
+    const shortcuts = createSplitViewShortcuts(actions);
+    const shortcut = findShortcut(shortcuts, 'PageUp', { ctrlKey: true, shiftKey: true });
+
+    expect(shortcut!.ignoreInTerminal).toBeFalsy();
   });
 
   // Requirement 5.6: Non-existent group index is a no-op (caller responsibility)

--- a/src/components/terminal/group-tab-bar.tsx
+++ b/src/components/terminal/group-tab-bar.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback, useRef, useEffect } from 'react';
+import React, { useState, useCallback, useLayoutEffect, useRef, useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { X, Plus, Copy, RefreshCw, ArrowLeft, ArrowRight, XCircle, ArrowUp, ArrowDown, MoveRight, FolderSync, Terminal, Monitor, FileCode, MonitorOff } from 'lucide-react';
 import type { TerminalTab, SplitDirection } from '../../lib/terminal-group-types';
@@ -17,6 +17,7 @@ import {
   ContextMenuSubContent,
 } from '../ui/context-menu';
 import { DEFAULT_APP_KEYBOARD_SHORTCUTS, formatKeyboardShortcut } from '@/lib/keyboard-shortcuts';
+import { announce } from '@/lib/live-announcer';
 
 // ── Module-level drag state (shared across all GroupTabBar instances) ──
 
@@ -94,6 +95,14 @@ export function GroupTabBar({
     closeTabShortcut ?? DEFAULT_APP_KEYBOARD_SHORTCUTS.closeSession,
     navigator.platform.toUpperCase().includes('MAC'),
   );
+  const formattedMoveTabLeftShortcut = formatKeyboardShortcut(
+    DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabLeft,
+    navigator.platform.toUpperCase().includes('MAC'),
+  );
+  const formattedMoveTabRightShortcut = formatKeyboardShortcut(
+    DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabRight,
+    navigator.platform.toUpperCase().includes('MAC'),
+  );
   const { dispatch } = useTerminalGroups();
   const [dropIndex, setDropIndex] = useState<number | null>(null);
   const [isDragOver, setIsDragOver] = useState(false);
@@ -129,22 +138,88 @@ export function GroupTabBar({
 
   // ── Pointer-based custom drag ──
 
+  // FLIP: when a commit changes which position each tab occupies (drag drop,
+  // keyboard/context-menu move, tab close), animate tabs from their previous
+  // on-screen position into the new one instead of jumping.
+  const tabOrderRef = useRef<{ order: string; lefts: Map<string, number> } | null>(null);
+
+  useLayoutEffect(() => {
+    const container = tabBarRef.current;
+    if (!container) return;
+
+    const lefts = new Map<string, number>();
+    for (const node of container.querySelectorAll<HTMLElement>('[data-tab-id]')) {
+      lefts.set(node.dataset.tabId ?? '', node.getBoundingClientRect().left);
+    }
+    const order = tabs.map((tab) => tab.id).join('\u0000');
+    const prev = tabOrderRef.current;
+    tabOrderRef.current = { order, lefts };
+
+    // First paint, or a re-render that kept the order (status update, drag
+    // indicator moving, panel resize) — just refresh the snapshot.
+    if (!prev || prev.order === order) return;
+
+    const reducedMotion =
+      typeof window.matchMedia === 'function' &&
+      window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+    if (reducedMotion) return;
+
+    for (const node of container.querySelectorAll<HTMLElement>('[data-tab-id]')) {
+      const id = node.dataset.tabId ?? '';
+      const prevLeft = prev.lefts.get(id);
+      const nextLeft = lefts.get(id);
+      if (prevLeft === undefined || nextLeft === undefined) continue;
+      const delta = prevLeft - nextLeft;
+      if (Math.abs(delta) < 1) continue;
+
+      node.style.transform = `translateX(${delta}px)`;
+      node.style.transition = 'none';
+      // Force a style flush so the inverted position is committed before the
+      // play transition starts in the same frame.
+      void node.offsetWidth;
+      node.style.transition = 'transform 150ms ease';
+      node.style.transform = '';
+      // The inline transition intentionally stays: nothing else transitions
+      // transform on tabs, and the next FLIP resets it to 'none' first.
+    }
+  }, [tabs]);
+
   const handlePointerDown = useCallback(
     (e: React.PointerEvent, tabId: string, tabName: string) => {
       if (e.button !== 0) return; // left click only
       e.preventDefault(); // prevent native drag ghost + text selection
 
+      // Capture the pointer so pointerup is delivered even when the button is
+      // released outside the window — otherwise WebKit drops it and the drag
+      // sticks to the cursor with no button held.
+      try {
+        e.currentTarget.setPointerCapture(e.pointerId);
+      } catch {
+        // Environments without pointer capture (jsdom) — the buttons guard in
+        // onMove below is the fallback.
+      }
+
+      const pointerId = e.pointerId;
       const startX = e.clientX;
       const startY = e.clientY;
       let dragging = false;
       const DRAG_THRESHOLD = 5;
 
       const onMove = (ev: PointerEvent) => {
+        if (ev.pointerId !== pointerId) return; // ignore other pointers
+
+        // Button released without a pointerup reaching us (missed event) —
+        // end the drag instead of following the cursor with no button held.
+        if (ev.buttons === 0) {
+          onUp(ev);
+          return;
+        }
+
         const dx = ev.clientX - startX;
         const dy = ev.clientY - startY;
 
         if (!dragging) {
-          if (Math.abs(dx) + Math.abs(dy) < DRAG_THRESHOLD) return;
+          if (Math.hypot(dx, dy) < DRAG_THRESHOLD) return;
           dragging = true;
           activeDrag = { tabId, sourceGroupId: groupId, tabName };
           document.body.style.userSelect = 'none';
@@ -225,6 +300,10 @@ export function GroupTabBar({
               const adjustedTarget = targetIndex > fromIndex ? targetIndex - 1 : targetIndex;
               if (adjustedTarget !== fromIndex) {
                 dispatch({ type: 'REORDER_TAB', groupId: sourceGroupId, fromIndex, toIndex: adjustedTarget });
+                announce(t('terminal.a11y.tabMovedToPosition', {
+                  position: adjustedTarget + 1,
+                  total: tabs.length,
+                }));
               }
             }
           } else {
@@ -236,7 +315,11 @@ export function GroupTabBar({
               tabId: dragTabId,
               targetIndex,
             });
+            announce(t('terminal.a11y.tabMovedToGroup'));
           }
+        } else {
+          // Released outside every tab bar (or the window blurred mid-drag)
+          announce(t('terminal.a11y.dragCancelled'));
         }
 
         activeDrag = null;
@@ -248,7 +331,7 @@ export function GroupTabBar({
       document.addEventListener('pointercancel', onUp);
       window.addEventListener('blur', onUp);
     },
-    [groupId, tabs, dispatch],
+    [groupId, tabs, dispatch, t],
   );
 
   // Suppress native dragstart in case browser tries to initiate HTML5 DnD
@@ -287,6 +370,18 @@ export function GroupTabBar({
       dispatch({ type: 'MOVE_TAB_TO_NEW_GROUP', groupId, tabId, direction });
     },
     [dispatch, groupId],
+  );
+
+  const handleMoveTabBy = useCallback(
+    (tabId: string, delta: -1 | 1) => {
+      const fromIndex = tabs.findIndex((t) => t.id === tabId);
+      if (fromIndex === -1) return;
+      const toIndex = fromIndex + delta;
+      if (toIndex < 0 || toIndex >= tabs.length) return;
+      dispatch({ type: 'REORDER_TAB', groupId, fromIndex, toIndex });
+      announce(t('terminal.a11y.tabMovedToPosition', { position: toIndex + 1, total: tabs.length }));
+    },
+    [tabs, dispatch, groupId, t],
   );
 
   return (
@@ -418,6 +513,18 @@ export function GroupTabBar({
                       {t('contextMenu.closeAllTabs')}
                     </ContextMenuItem>
                   )}
+                  <ContextMenuSeparator />
+                  {/* Move tab within the group */}
+                  <ContextMenuItem disabled={index === 0} onClick={() => handleMoveTabBy(tab.id, -1)}>
+                    <ArrowLeft className="mr-2 h-4 w-4" />
+                    {t('contextMenu.moveTabLeft')}
+                    <ContextMenuShortcut>{formattedMoveTabLeftShortcut}</ContextMenuShortcut>
+                  </ContextMenuItem>
+                  <ContextMenuItem disabled={index === tabs.length - 1} onClick={() => handleMoveTabBy(tab.id, 1)}>
+                    <ArrowRight className="mr-2 h-4 w-4" />
+                    {t('contextMenu.moveTabRight')}
+                    <ContextMenuShortcut>{formattedMoveTabRightShortcut}</ContextMenuShortcut>
+                  </ContextMenuItem>
                   <ContextMenuSeparator />
                   {/* Move to New Group submenu */}
                   <ContextMenuSub>

--- a/src/lib/__tests__/live-announcer.test.ts
+++ b/src/lib/__tests__/live-announcer.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { announce } from '../live-announcer';
+
+function nextFrame(): Promise<void> {
+  return new Promise((resolve) => requestAnimationFrame(() => resolve()));
+}
+
+describe('live-announcer', () => {
+  afterEach(() => {
+    document.querySelectorAll('[role="status"]').forEach((el) => el.remove());
+  });
+
+  it('creates a visually hidden polite live region and announces into it', async () => {
+    announce('Moved to position 2 of 3');
+    await nextFrame();
+
+    const region = document.querySelector('[role="status"]');
+    expect(region).not.toBeNull();
+    expect(region?.getAttribute('aria-live')).toBe('polite');
+    expect(region?.className).toContain('sr-only');
+    expect(region?.textContent).toBe('Moved to position 2 of 3');
+  });
+
+  it('reuses a single live region across announcements', async () => {
+    announce('first');
+    await nextFrame();
+    announce('second');
+    await nextFrame();
+
+    expect(document.querySelectorAll('[role="status"]')).toHaveLength(1);
+    expect(document.querySelector('[role="status"]')?.textContent).toBe('second');
+  });
+
+  it('clears before re-setting so identical messages re-announce', async () => {
+    announce('same');
+    await nextFrame();
+    expect(document.querySelector('[role="status"]')?.textContent).toBe('same');
+
+    announce('same');
+    // Synchronously cleared — screen readers will see the change once the
+    // next frame sets the text again.
+    expect(document.querySelector('[role="status"]')?.textContent).toBe('');
+    await nextFrame();
+    expect(document.querySelector('[role="status"]')?.textContent).toBe('same');
+  });
+});

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -39,6 +39,9 @@ export const DEFAULT_APP_KEYBOARD_SHORTCUTS = {
   closeSession: 'Ctrl+W',
   nextTab: 'Ctrl+Tab',
   previousTab: 'Ctrl+Shift+Tab',
+  // Browser convention (Chrome/Firefox/GNOME Terminal) for reordering tabs.
+  moveTabLeft: 'Ctrl+Shift+PageUp',
+  moveTabRight: 'Ctrl+Shift+PageDown',
 } as const;
 
 export const DEFAULT_LAYOUT_SHORTCUTS = {
@@ -742,6 +745,8 @@ export const createSplitViewShortcuts = (actions: {
   closeTab: () => void;
   nextTab: () => void;
   prevTab: () => void;
+  moveTabLeft: () => void;
+  moveTabRight: () => void;
 }, bindings: Partial<SplitViewShortcutBindings> = {}): KeyboardShortcut[] => {
   const resolvedBindings: SplitViewShortcutBindings = {
     ...DEFAULT_SPLIT_VIEW_SHORTCUTS,
@@ -788,6 +793,21 @@ export const createSplitViewShortcuts = (actions: {
       DEFAULT_SPLIT_VIEW_SHORTCUTS.prevTab,
       actions.prevTab,
       'Previous tab in group',
+    ),
+    // Like the split shortcuts above, these intentionally keep firing while a
+    // terminal has focus — terminal emulators reserve Ctrl+Shift+PageUp/Down
+    // for tab reordering (the remote shell does not use this chord).
+    createConfiguredShortcut(
+      DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabLeft,
+      DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabLeft,
+      actions.moveTabLeft,
+      'Move tab left within group',
+    ),
+    createConfiguredShortcut(
+      DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabRight,
+      DEFAULT_APP_KEYBOARD_SHORTCUTS.moveTabRight,
+      actions.moveTabRight,
+      'Move tab right within group',
     ),
   ];
 };

--- a/src/lib/live-announcer.ts
+++ b/src/lib/live-announcer.ts
@@ -1,0 +1,30 @@
+/**
+ * Screen-reader announcements for tab drag / keyboard reordering.
+ *
+ * Writes into a persistent visually-hidden `role="status"` live region. The
+ * clear-then-set step is required so repeating the same message (e.g. moving
+ * a tab to the same position twice) still triggers an announcement — screen
+ * readers only speak when the region's text actually changes.
+ */
+
+let region: HTMLElement | null = null;
+
+function ensureRegion(): HTMLElement {
+  if (region?.isConnected) {
+    return region;
+  }
+  region = document.createElement('div');
+  region.setAttribute('role', 'status');
+  region.setAttribute('aria-live', 'polite');
+  region.className = 'sr-only';
+  document.body.appendChild(region);
+  return region;
+}
+
+export function announce(message: string): void {
+  const el = ensureRegion();
+  el.textContent = '';
+  window.requestAnimationFrame(() => {
+    el.textContent = message;
+  });
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -741,6 +741,8 @@
     "splitDown": "Split Down",
     "moveTabToNewGroup": "Move Tab to New Group",
     "moveTabToGroup": "Move Tab to Group",
+    "moveTabLeft": "Move Tab Left",
+    "moveTabRight": "Move Tab Right",
     "search": "Search",
     "findNext": "Find Next",
     "findPrevious": "Find Previous",
@@ -1133,7 +1135,12 @@
   },
   "terminal": {
     "search": "Search...",
-    "groupAriaLabel": "Terminal group {{id}}"
+    "groupAriaLabel": "Terminal group {{id}}",
+    "a11y": {
+      "tabMovedToPosition": "Moved to position {{position}} of {{total}}",
+      "tabMovedToGroup": "Moved to another group",
+      "dragCancelled": "Tab drag cancelled"
+    }
   },
   "terminalSearchBar": {
     "findInTerminal": "Find in terminal...",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -759,6 +759,8 @@
     "splitDown": "Podziel w dół",
     "moveTabToNewGroup": "Przenieś kartę do nowej grupy",
     "moveTabToGroup": "Przenieś kartę do grupy",
+    "moveTabLeft": "Przenieś kartę w lewo",
+    "moveTabRight": "Przenieś kartę w prawo",
     "search": "Szukaj",
     "findNext": "Znajdź następne",
     "findPrevious": "Znajdź poprzednie",
@@ -1181,7 +1183,12 @@
   },
   "terminal": {
     "search": "Szukaj...",
-    "groupAriaLabel": "Grupa terminali {{id}}"
+    "groupAriaLabel": "Grupa terminali {{id}}",
+    "a11y": {
+      "tabMovedToPosition": "Przeniesiono na pozycję {{position}} z {{total}}",
+      "tabMovedToGroup": "Przeniesiono do innej grupy",
+      "dragCancelled": "Anulowano przeciąganie karty"
+    }
   },
   "terminalSearchBar": {
     "findInTerminal": "Znajdź w terminalu...",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -741,6 +741,8 @@
     "splitDown": "向下分屏",
     "moveTabToNewGroup": "移动到新分组",
     "moveTabToGroup": "移动到分组",
+    "moveTabLeft": "左移标签页",
+    "moveTabRight": "右移标签页",
     "search": "搜索",
     "findNext": "查找下一个",
     "findPrevious": "查找上一个",
@@ -1133,7 +1135,12 @@
   },
   "terminal": {
     "search": "搜索...",
-    "groupAriaLabel": "终端组 {{id}}"
+    "groupAriaLabel": "终端组 {{id}}",
+    "a11y": {
+      "tabMovedToPosition": "已移到第 {{position}} 位（共 {{total}} 个标签页）",
+      "tabMovedToGroup": "已移动到另一个分组",
+      "dragCancelled": "已取消标签页拖拽"
+    }
   },
   "terminalSearchBar": {
     "findInTerminal": "在终端中查找...",


### PR DESCRIPTION
## Summary

Hardens the terminal tab bar's custom pointer drag and closes the remaining best-practice gaps for tab reordering. No DnD library introduced — the app has a single drag surface and the custom implementation now matches the Chromium/VS Code pattern (pointer events + explicit capture).

Fixes the reported bug where a tab kept dragging even with no mouse button held.

## Changes

**Drag reliability** — `src/components/terminal/group-tab-bar.tsx`
- `setPointerCapture` on pointerdown so `pointerup` is delivered even when the button is released outside the window; WebKit/WKWebView otherwise drops it, leaving the drag stuck to the cursor (leaked listeners, ghost following hover moves)
- `onMove` safety nets: a move with `buttons === 0` (missed pointerup) ends the drag at the current position instead of ghost-following the cursor; moves from a different `pointerId` are ignored
- Drag threshold switched from Manhattan to Euclidean distance (5px) — diagonal click jitter no longer starts a drag

**Keyboard + menu reorder**
- `Ctrl+Shift+PageUp` / `Ctrl+Shift+PageDown` move the active tab (browser convention; works while a terminal has focus, same as the `Ctrl+\` split shortcuts)
- New context-menu items "Move Tab Left / Move Tab Right" with shortcut hints, disabled at group edges

**Accessibility** — new `src/lib/live-announcer.ts`
- Polite `role="status"` live region with clear-then-set so identical messages re-announce
- Announces same-group reorder (position of total), cross-group move, and cancelled drags
- New i18n keys in all three locales: `terminal.a11y.*`, `contextMenu.moveTabLeft/Right`

**FLIP animation**
- Tabs animate into place after drag drop, keyboard/menu move, and close-shift; only fires when the tab order actually changes (not on status updates, drag indicators, or panel resize); respects `prefers-reduced-motion`

## Testing

- [x] Unit tests: 50 passing across affected files — drag regression (missed pointerup ends drag, foreign pointer ignored, sub-threshold click doesn't drag), FLIP smoke, keyboard shortcut wiring, context-menu move items, live-announcer behavior
- [x] `pnpm i18n:check` — 1169 keys × 3 locales
- [x] `tsc --noEmit` clean; eslint 0 errors on changed files
