### PR TITLE
fix(terminal): let the tab close button receive its click under the drag handler

### DIFF
--- a/src/__tests__/group-tab-bar-drag.test.tsx
+++ b/src/__tests__/group-tab-bar-drag.test.tsx
@@ -90,6 +90,35 @@ describe('GroupTabBar custom drag', () => {
     expect(dispatch).not.toHaveBeenCalled();
   });
 
+  it('keeps a press on the close button out of the drag handler so the click closes the tab', () => {
+    // Regression: the tab's pointerdown handler calls setPointerCapture, which
+    // retargets pointerup to the tab; the browser then dispatches the click to
+    // the tab (the common ancestor) instead of the X button, so the close
+    // never fires and the press only selects the tab. jsdom has no pointer
+    // capture, so stub it on the tab and assert the press never reaches it.
+    const tabs = [makeTab('a'), makeTab('b')];
+    const { container } = render(<GroupTabBar groupId="1" tabs={tabs} activeTabId="a" />);
+    stubDropTarget(container, '1');
+
+    const tabA = getTabEl('a');
+    const capture = vi.fn();
+    (tabA as HTMLElement & { setPointerCapture: (id: number) => void }).setPointerCapture = capture;
+    const closeButton = tabA.querySelector('button') as HTMLButtonElement;
+
+    fireEvent.pointerDown(closeButton, { button: 0, pointerId: 1, clientX: 100, clientY: 10 });
+    expect(capture).not.toHaveBeenCalled();
+
+    fireEvent.click(closeButton);
+    expect(dispatch).toHaveBeenCalledWith({ type: 'REMOVE_TAB', groupId: '1', tabId: 'a' });
+    expect(dispatch).not.toHaveBeenCalledWith(expect.objectContaining({ type: 'ACTIVATE_TAB' }));
+
+    // A press on the tab body still arms the drag as before.
+    dispatch.mockClear();
+    fireEvent.pointerDown(tabA, { button: 0, pointerId: 2, clientX: 100, clientY: 10 });
+    expect(capture).toHaveBeenCalledWith(2);
+    fireEvent.pointerUp(document, { pointerId: 2, clientX: 100, clientY: 10 });
+  });
+
   it('FLIP-animates tabs when the order changes', () => {
     // jsdom rects are all-zero; fake per-tab lefts so the FLIP effect sees the
     // position change caused by a reorder.

--- a/src/components/terminal/group-tab-bar.tsx
+++ b/src/components/terminal/group-tab-bar.tsx
@@ -438,6 +438,11 @@ export function GroupTabBar({
                       variant="ghost"
                       size="sm"
                       className="p-0 h-4 w-4 opacity-0 group-hover:opacity-100"
+                      // Keep the press off the tab's drag handler: it calls
+                      // setPointerCapture on the tab, which retargets pointerup
+                      // to the tab, so the browser dispatches the click to the
+                      // tab instead of this button and the close never fires.
+                      onPointerDown={(e) => e.stopPropagation()}
                       onClick={(e) => {
                         e.stopPropagation();
                         handleTabClose(tab.id);


### PR DESCRIPTION
Title: fix(terminal): let the tab close button receive its click under the drag handler

Fixes #135 

## Summary

Since #133 the tab element handles `pointerdown` for custom drag: it calls `preventDefault()` and `setPointerCapture()`. The close (X) button is a descendant, so a press on it bubbles into that handler and captures the pointer on the tab.

Pointer capture retargets `pointerup` to the tab, and the browser then dispatches the resulting `click` to the common ancestor of the pointerdown target (the button) and the pointerup target (the tab) — the tab itself. The button's `onClick` never fires; the press only selects the tab.

## Change

- `group-tab-bar.tsx` — `onPointerDown={(e) => e.stopPropagation()}` on the close button, so the drag handler never sees the press and the click reaches the button. The tab body keeps its drag behaviour; right-click and the context menu were never affected (the handler ignores non-left buttons).
- `group-tab-bar-drag.test.tsx` — regression test: stubs `setPointerCapture` on the tab (jsdom has none) and asserts a press on the X button never reaches it and the click dispatches `REMOVE_TAB`, while a press on the tab body still arms the drag.

## Verification

- Reproduced on `main` (e754358); v2.9.1 (3682bcf), which predates #133, is not affected.
- `pnpm vitest run` — 79 files, 769 tests passing (1 new).
- `pnpm tsc --noEmit` clean; `pnpm lint` — no errors in the changed file.

