### PR TITLE
fix(terminal): keep a hidden pane's WebGL renderer through a grace period

### DIFF
--- a/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
+++ b/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
@@ -295,7 +295,7 @@ describe('PtyTerminal renderer lifecycle (issue #87)', () => {
     expect(mocks.terminals[0].refresh).toHaveBeenCalledWith(0, mocks.terminals[0].rows - 1);
     expect(mocks.terminals[0].focus).toHaveBeenCalled();
 
-    // Hidden again: the GPU context is released.
+    // Hidden again: the GPU context is kept through the grace period …
     view.rerender(
       <PtyTerminal
         connectionId="lazy-1"
@@ -306,7 +306,72 @@ describe('PtyTerminal renderer lifecycle (issue #87)', () => {
       />,
     );
     await flushFrames(1);
+    expect(mocks.webglInstances[0].dispose).not.toHaveBeenCalled();
+
+    // … and released once the pane has stayed hidden long enough (60 s).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
     expect(mocks.webglInstances[0].dispose).toHaveBeenCalled();
+  });
+
+  it('keeps the live WebGL renderer across a quick hide/show (issue #134)', async () => {
+    // Releasing on every hide cost ~1.2 s per tab switch: a dispose on the
+    // outgoing pane and a full renderer rebuild + first paint on the
+    // incoming one. A pane shown again before the grace period must reuse
+    // its renderer — no dispose, no second WebglAddon.
+    const view = render(
+      <PtyTerminal
+        connectionId="quick-1"
+        connectionName="Quick"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+    await flushFrames(2);
+    expect(mocks.webglInstances).toHaveLength(1);
+
+    view.rerender(
+      <PtyTerminal
+        connectionId="quick-1"
+        connectionName="Quick"
+        host="127.0.0.1"
+        username="root"
+        isActive={false}
+      />,
+    );
+    await flushFrames(1);
+    // Well inside the grace period.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5_000);
+    });
+
+    const terminal = mocks.terminals[0];
+    terminal.refresh.mockClear();
+    terminal.focus.mockClear();
+    view.rerender(
+      <PtyTerminal
+        connectionId="quick-1"
+        connectionName="Quick"
+        host="127.0.0.1"
+        username="root"
+        isActive
+      />,
+    );
+    await flushFrames(3);
+
+    expect(mocks.webglInstances[0].dispose).not.toHaveBeenCalled();
+    expect(mocks.webglInstances).toHaveLength(1);
+    // Activation still repaints and focuses the pane.
+    expect(terminal.refresh).toHaveBeenCalledWith(0, terminal.rows - 1);
+    expect(terminal.focus).toHaveBeenCalled();
+
+    // The cancelled release must not fire later either.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(120_000);
+    });
+    expect(mocks.webglInstances[0].dispose).not.toHaveBeenCalled();
   });
 
   it('loads WebGL at mount for a terminal that mounts active', async () => {

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -84,6 +84,17 @@ function claimSshDeadEscalation(connectionId: string): boolean {
  * Communication is done via WebSocket for low-latency bidirectional streaming.
  */
 
+/**
+ * How long a pane stays hidden before its WebGL context is released.
+ *
+ * Releasing on every hide (#105) made each tab switch tear the renderer down
+ * and rebuild it on return — measured at ~1.2 s per switch on a 248×45 grid
+ * (issue #134). The reason to release at all is to stop panes hidden for hours
+ * from holding GPU contexts the browser may evict; a grace period keeps quick
+ * switching free while long-hidden panes still let go of the GPU.
+ */
+const HIDDEN_WEBGL_RELEASE_MS = 60_000;
+
 export function PtyTerminal({
   connectionId,
   connectionName,
@@ -107,6 +118,9 @@ export function PtyTerminal({
   // activation effect can load/release the renderer without re-running the
   // whole session setup.
   const webglControlsRef = React.useRef<{ ensure: () => void; release: () => void } | null>(null);
+  // Pending grace-period release of this pane's WebGL context (see
+  // HIDDEN_WEBGL_RELEASE_MS); cancelled when the pane becomes visible again.
+  const webglReleaseTimerRef = React.useRef<ReturnType<typeof setTimeout> | null>(null);
   // Mirrors the latest `isActive` prop for non-effect code paths (the
   // ResizeObserver completing a pending activation).
   const isActiveStateRef = React.useRef(isActive);
@@ -1251,6 +1265,10 @@ export function PtyTerminal({
       
       // Dispose WebGL addon FIRST so GPU textures are released before the
       // terminal canvas is removed from the DOM.
+      if (webglReleaseTimerRef.current) {
+        clearTimeout(webglReleaseTimerRef.current);
+        webglReleaseTimerRef.current = null;
+      }
       if (webglAddonRef.current) {
         try { webglAddonRef.current.dispose(); } catch (_e) { /* already disposed */ }
         webglAddonRef.current = null;
@@ -1292,11 +1310,24 @@ export function PtyTerminal({
     if (!isActive) {
       wasActiveRef.current = false;
       isActiveStateRef.current = false;
-      // Release this pane's WebGL context while hidden — visible panes get
-      // the GPU; hidden panes keep their text via the DOM renderer (xterm
-      // v6 core's `_createRenderer()` → `DomRenderer`, restored on dispose).
-      webglControlsRef.current?.release();
+      // Release this pane's WebGL context only once it has stayed hidden for
+      // the grace period — visible panes get the GPU; long-hidden panes keep
+      // their text via the DOM renderer (xterm v6 core's `_createRenderer()`
+      // → `DomRenderer`, restored on dispose). Releasing immediately on every
+      // hide was what made tab switching slow (issue #134).
+      if (webglReleaseTimerRef.current) clearTimeout(webglReleaseTimerRef.current);
+      webglReleaseTimerRef.current = setTimeout(() => {
+        webglReleaseTimerRef.current = null;
+        webglControlsRef.current?.release();
+      }, HIDDEN_WEBGL_RELEASE_MS);
       return;
+    }
+
+    // Visible again before the grace period elapsed: keep the live renderer,
+    // so the switch costs neither a dispose nor a rebuild.
+    if (webglReleaseTimerRef.current) {
+      clearTimeout(webglReleaseTimerRef.current);
+      webglReleaseTimerRef.current = null;
     }
 
     if (wasActiveRef.current) {


### PR DESCRIPTION
Fixes #134

## Summary

Since #105 a pane releases its WebGL context the moment it is hidden and rebuilds it on the next activation. On a large grid that makes every tab switch pay for tearing the renderer down and building it back up. This PR keeps the context alive for a grace period (60 s) after a pane is hidden, so quick switching costs nothing, while panes hidden for a long time still let go of the GPU — which is what #105 was for.

## What was measured

Instrumented fork builds (`[DIAG]` console timings on `main`), 248×45 grid, three SSH tabs, Windows 11 / WebView2. The same grid size, DOM size (~1.1k nodes), pane count and frame cadence (~270 fps idle) in every run — so the cost is not the size of the terminal or a throttled compositor.

| per switch | release on hide (current) | context kept |
|---|---|---|
| outgoing pane: `WebglAddon.dispose()` | 279–323 ms | 0.2–0.4 ms |
| incoming pane: activation (`focus()` waiting on the rebuilt renderer) | 300–328 ms | 5–6 ms |
| incoming pane: first completed paint after activation | +954–960 ms | +11–13 ms |
| **click → painted frame** | **~1300 ms** | **49–53 ms** |

Frame gaps around a slow switch were `343/939/9/9/4/…` ms: two discrete stalls (the dispose, then the rebuild + first paint), not a throttle. Creating the context itself is cheap (8–12 ms); it is the dispose/rebuild cycle on an already-used terminal that is expensive. Interestingly the same cycle costs ~5 ms on tabs restored at startup — I could not pin down that asymmetry, but the fix does not depend on it: the cycle is unnecessary work on every switch either way.

## Change

- `pty-terminal.tsx` — hiding a pane now arms a `HIDDEN_WEBGL_RELEASE_MS` (60 s) timer that releases the context; showing the pane again cancels it. Unmount clears a pending timer before disposing. Context loss while hidden is still covered by the existing `onContextLoss` fallback and the `ensure()` on activation, so the overnight-eviction case from #105 keeps working.
- `pty-terminal-renderer-lifecycle.test.tsx` — the existing hide test now expects no release right after hiding and a release once 60 s elapse; a new test covers hide/show inside the grace period (no dispose, no second `WebglAddon`, activation still repaints and focuses, the cancelled release never fires).

## Verification

- `pnpm vitest run` — 79 files, 769 tests passing (1 new).
- `pnpm tsc --noEmit` clean; `pnpm lint` — no errors in the changed file.
- Manual: a fork build of this branch on Windows 11 — tab switching with three freshly opened SSH tabs is immediate; the slow case from #134 no longer reproduces.
