### PR TITLE
fix(security): authenticate the local WebSocket PTY bridge

### DIFF
--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -2279,6 +2279,24 @@ pub async fn get_websocket_port() -> Result<u16, String> {
     }
 }
 
+/// What the webview needs to open the PTY bridge: the bound port and the
+/// per-launch token the server demands in the handshake (issue #138).
+#[derive(Debug, Serialize)]
+pub struct WebSocketEndpoint {
+    pub port: u16,
+    pub token: String,
+}
+
+#[tauri::command]
+pub async fn get_websocket_endpoint() -> Result<WebSocketEndpoint, String> {
+    let port = get_websocket_port().await?;
+    let token = crate::WEBSOCKET_TOKEN
+        .get()
+        .cloned()
+        .ok_or_else(|| "WebSocket server not yet started".to_string())?;
+    Ok(WebSocketEndpoint { port, token })
+}
+
 // ========== PTY Connection ==========
 // PTY terminal I/O now uses WebSocket instead of IPC for better performance
 // WebSocket server runs on a dynamically assigned port (9001-9010)

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -16,11 +16,18 @@ mod websocket_server;
 use connection_manager::ConnectionManager;
 use std::sync::atomic::AtomicU16;
 use std::sync::Arc;
+use std::sync::OnceLock;
 use tauri::{Emitter, Manager};
 use websocket_server::WebSocketServer;
 
 // Global atomic to store the WebSocket port (shared between backend and frontend)
 pub static WEBSOCKET_PORT: AtomicU16 = AtomicU16::new(0);
+
+/// Per-launch secret the PTY bridge requires in every WebSocket handshake.
+/// Generated when the server starts; handed to the webview only through the
+/// `get_websocket_endpoint` command, so a foreign local process or a web page
+/// that can reach 127.0.0.1 cannot open or drive sessions (issue #138).
+pub static WEBSOCKET_TOKEN: OnceLock<String> = OnceLock::new();
 
 /// Applies the saved top-left position of the "main" window on startup.
 ///
@@ -448,6 +455,7 @@ pub fn run() {
             commands::detect_gpu,
             commands::get_gpu_stats,
             commands::get_websocket_port,
+            commands::get_websocket_endpoint,
             // Standalone SFTP/FTP commands
             commands::sftp_connect,
             commands::sftp_standalone_disconnect,

--- a/src-tauri/src/websocket_server.rs
+++ b/src-tauri/src/websocket_server.rs
@@ -1,5 +1,5 @@
 use crate::connection_manager::ConnectionManager;
-use crate::WEBSOCKET_PORT;
+use crate::{WEBSOCKET_PORT, WEBSOCKET_TOKEN};
 use anyhow::Result;
 use futures::{SinkExt, StreamExt};
 use serde::{Deserialize, Serialize};
@@ -10,7 +10,9 @@ use std::sync::Arc;
 use std::time::Duration;
 use tokio::net::{TcpListener, TcpStream};
 use tokio::sync::{mpsc, Mutex, Semaphore};
-use tokio_tungstenite::{accept_async, tungstenite::Message};
+use tokio_tungstenite::tungstenite::handshake::server::{ErrorResponse, Request, Response};
+use tokio_tungstenite::tungstenite::http::StatusCode;
+use tokio_tungstenite::{accept_hdr_async, tungstenite::Message};
 use tokio_util::sync::CancellationToken;
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -363,6 +365,8 @@ impl WebSocketServer {
         let listener = listener
             .ok_or_else(|| anyhow::anyhow!("Failed to bind to any port in range 9001-9010"))?;
 
+        // The bridge token must exist before the first client can connect.
+        WEBSOCKET_TOKEN.get_or_init(generate_bridge_token);
         // Store the bound port in the global atomic for frontend to query
         WEBSOCKET_PORT.store(bound_port, Ordering::SeqCst);
         tracing::info!("WebSocket port stored: {}", bound_port);
@@ -387,7 +391,29 @@ impl WebSocketServer {
 
     /// Handle a single WebSocket connection
     async fn handle_connection(&self, stream: TcpStream) -> Result<()> {
-        let ws_stream = accept_async(stream).await?;
+        // Authenticate the handshake before any protocol message is read: the
+        // listener is on loopback, but loopback is reachable by every local
+        // process and, through the browser, by every web page the user has
+        // open. Without this, `StartPty`/`Input` with a known connection id
+        // would hand a foreign client a shell on the user's SSH session.
+        let expected = WEBSOCKET_TOKEN.get().cloned().unwrap_or_default();
+        let ws_stream = accept_hdr_async(stream, |req: &Request, res: Response| {
+            let origin = req.headers().get("origin").and_then(|v| v.to_str().ok());
+            match validate_handshake(origin, req.uri().query(), &expected) {
+                Ok(()) => Ok(res),
+                Err(reason) => {
+                    tracing::warn!(
+                        "Rejected WebSocket handshake: {} (origin={:?})",
+                        reason,
+                        origin
+                    );
+                    let mut response = ErrorResponse::new(Some(reason.to_string()));
+                    *response.status_mut() = StatusCode::FORBIDDEN;
+                    Err(response)
+                }
+            }
+        })
+        .await?;
         let (mut ws_sender, mut ws_receiver) = ws_stream.split();
 
         // Bounded channel: when full the PTY reader blocks, providing backpressure
@@ -1016,5 +1042,137 @@ mod tests {
         let uncoded = WsError::from(PtyStartError::Other(anyhow::anyhow!("misc")));
         assert_eq!(uncoded.code, None);
         assert_eq!(uncoded.message, "misc");
+    }
+}
+
+// ── Handshake authentication (issue #138) ───────────────────────────────────
+
+/// Origins the app's own webview reports, per platform. Anything else is a
+/// foreign page that happens to be able to reach 127.0.0.1.
+const ALLOWED_ORIGINS: &[&str] = &[
+    "tauri://localhost",
+    "http://tauri.localhost",
+    "https://tauri.localhost",
+];
+
+/// The Vite dev server, only in debug builds.
+#[cfg(debug_assertions)]
+const DEV_ORIGINS: &[&str] = &["http://localhost:1420", "http://127.0.0.1:1420"];
+#[cfg(not(debug_assertions))]
+const DEV_ORIGINS: &[&str] = &[];
+
+/// 32 random bytes, base64url without padding — URL-safe, so the frontend can
+/// pass it verbatim as a query parameter.
+fn generate_bridge_token() -> String {
+    use base64::Engine;
+    use rand::RngCore;
+    let mut bytes = [0u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+}
+
+/// Compare without leaking where the first differing byte is.
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    a.iter().zip(b).fold(0u8, |acc, (x, y)| acc | (x ^ y)) == 0
+}
+
+/// Decide whether a WebSocket upgrade request may proceed.
+///
+/// - The `token` query parameter must equal the per-launch token. A missing
+///   or empty expected token (server not initialised) rejects everything.
+/// - If the client sent an `Origin` header it must be one of the app's own
+///   origins. Non-browser clients send none and rely on the token alone.
+pub(crate) fn validate_handshake(
+    origin: Option<&str>,
+    query: Option<&str>,
+    expected_token: &str,
+) -> Result<(), &'static str> {
+    if expected_token.is_empty() {
+        return Err("bridge token not initialised");
+    }
+    if let Some(origin) = origin {
+        let allowed = ALLOWED_ORIGINS
+            .iter()
+            .chain(DEV_ORIGINS.iter())
+            .any(|o| o.eq_ignore_ascii_case(origin));
+        if !allowed {
+            return Err("origin not allowed");
+        }
+    }
+    let presented = query.and_then(|q| q.split('&').find_map(|kv| kv.strip_prefix("token=")));
+    match presented {
+        Some(t) if constant_time_eq(t.as_bytes(), expected_token.as_bytes()) => Ok(()),
+        Some(_) => Err("invalid token"),
+        None => Err("missing token"),
+    }
+}
+
+#[cfg(test)]
+mod handshake_tests {
+    use super::*;
+
+    const TOKEN: &str = "s3cr3t-t0k3n_ABC";
+
+    #[test]
+    fn accepts_app_origin_with_valid_token() {
+        assert_eq!(
+            validate_handshake(Some("tauri://localhost"), Some("token=s3cr3t-t0k3n_ABC"), TOKEN),
+            Ok(())
+        );
+        assert_eq!(
+            validate_handshake(Some("http://tauri.localhost"), Some("token=s3cr3t-t0k3n_ABC"), TOKEN),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn accepts_non_browser_client_with_valid_token() {
+        // No Origin header: a native client, allowed on the strength of the token.
+        assert_eq!(validate_handshake(None, Some("token=s3cr3t-t0k3n_ABC"), TOKEN), Ok(()));
+    }
+
+    #[test]
+    fn rejects_foreign_origin_even_with_valid_token() {
+        assert_eq!(
+            validate_handshake(Some("https://evil.example"), Some("token=s3cr3t-t0k3n_ABC"), TOKEN),
+            Err("origin not allowed")
+        );
+        assert_eq!(
+            validate_handshake(Some("null"), Some("token=s3cr3t-t0k3n_ABC"), TOKEN),
+            Err("origin not allowed")
+        );
+    }
+
+    #[test]
+    fn rejects_missing_wrong_or_empty_token() {
+        assert_eq!(validate_handshake(None, None, TOKEN), Err("missing token"));
+        assert_eq!(validate_handshake(None, Some(""), TOKEN), Err("missing token"));
+        assert_eq!(validate_handshake(None, Some("token="), TOKEN), Err("invalid token"));
+        assert_eq!(validate_handshake(None, Some("token=nope"), TOKEN), Err("invalid token"));
+        // Prefix / superstring must not pass.
+        assert_eq!(validate_handshake(None, Some("token=s3cr3t-t0k3n_AB"), TOKEN), Err("invalid token"));
+        assert_eq!(validate_handshake(None, Some("token=s3cr3t-t0k3n_ABCD"), TOKEN), Err("invalid token"));
+    }
+
+    #[test]
+    fn finds_token_among_other_query_parameters() {
+        assert_eq!(validate_handshake(None, Some("x=1&token=s3cr3t-t0k3n_ABC&y=2"), TOKEN), Ok(()));
+    }
+
+    #[test]
+    fn rejects_everything_when_server_token_is_unset() {
+        assert_eq!(validate_handshake(None, Some("token="), ""), Err("bridge token not initialised"));
+    }
+
+    #[test]
+    fn generated_token_is_long_urlsafe_and_unique() {
+        let a = generate_bridge_token();
+        let b = generate_bridge_token();
+        assert_eq!(a.len(), 43); // 32 bytes → 43 base64url chars without padding
+        assert!(a.chars().all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_'));
+        assert_ne!(a, b);
     }
 }

--- a/src/__tests__/pty-terminal-activation.test.tsx
+++ b/src/__tests__/pty-terminal-activation.test.tsx
@@ -118,7 +118,7 @@ vi.mock('@xterm/addon-search', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
+++ b/src/__tests__/pty-terminal-renderer-lifecycle.test.tsx
@@ -128,7 +128,7 @@ vi.mock('@xterm/addon-clipboard', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
   // App's keyboard-shortcut hook branches on this; these tests run in
   // browser mode where there is no Tauri backend.
   isTauri: () => false,

--- a/src/__tests__/pty-terminal-resize-sync.test.tsx
+++ b/src/__tests__/pty-terminal-resize-sync.test.tsx
@@ -137,7 +137,7 @@ vi.mock('@xterm/addon-clipboard', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/pty-terminal-scrollbar.test.tsx
+++ b/src/__tests__/pty-terminal-scrollbar.test.tsx
@@ -99,7 +99,7 @@ vi.mock('@xterm/addon-search', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/pty-terminal-send-text.test.tsx
+++ b/src/__tests__/pty-terminal-send-text.test.tsx
@@ -118,7 +118,7 @@ vi.mock('@xterm/addon-search', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
+++ b/src/__tests__/pty-terminal-ssh-dead-escalation.test.tsx
@@ -117,7 +117,7 @@ vi.mock('@xterm/addon-clipboard', () => ({
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
-  invoke: vi.fn(async (command: string) => (command === 'get_websocket_port' ? 9001 : undefined)),
+  invoke: vi.fn(async (command: string) => (command === 'get_websocket_endpoint' ? { port: 9001, token: 'test-token' } : undefined)),
 }));
 
 vi.mock('@tauri-apps/plugin-clipboard-manager', () => ({

--- a/src/__tests__/websocket-endpoint.test.ts
+++ b/src/__tests__/websocket-endpoint.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const invoke = vi.hoisted(() => vi.fn());
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => invoke(...args),
+}));
+
+import { DEFAULT_WS_PORT, getWebSocketUrl } from '../lib/websocket-endpoint';
+
+describe('getWebSocketUrl (bridge handshake token, issue #138)', () => {
+  beforeEach(() => {
+    invoke.mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  it('asks the backend for the endpoint and puts the token in the query string', async () => {
+    invoke.mockResolvedValue({ port: 9004, token: 'abc-DEF_123' });
+
+    await expect(getWebSocketUrl()).resolves.toBe('ws://127.0.0.1:9004/?token=abc-DEF_123');
+    expect(invoke).toHaveBeenCalledWith('get_websocket_endpoint');
+  });
+
+  it('percent-encodes a token that is not URL-safe', async () => {
+    invoke.mockResolvedValue({ port: 9001, token: 'a+b/c=' });
+
+    await expect(getWebSocketUrl()).resolves.toBe('ws://127.0.0.1:9001/?token=a%2Bb%2Fc%3D');
+  });
+
+  it('falls back to the default port without a token when the backend is unavailable', async () => {
+    invoke.mockRejectedValue(new Error('no backend'));
+
+    await expect(getWebSocketUrl()).resolves.toBe(`ws://127.0.0.1:${DEFAULT_WS_PORT}`);
+    expect(console.warn).toHaveBeenCalled();
+  });
+});

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -384,7 +384,9 @@ export function ConnectionDialog({
     setIsConnecting(true);
     setIsCancelling(false);
     cancelRequestedRef.current = false;
-    const connectionId = editingConnection?.id || `connection-${Date.now()}`;
+    // A random id, never a timestamp: connection ids address sessions on the
+    // local bridge, so they must not be guessable (issue #138).
+    const connectionId = editingConnection?.id || crypto.randomUUID();
     connectionIdRef.current = connectionId;
 
     // Basic validation — anonymous FTP doesn't require a username

--- a/src/components/desktop-viewer.tsx
+++ b/src/components/desktop-viewer.tsx
@@ -1,6 +1,7 @@
 import React, { useRef, useEffect, useState, useCallback } from 'react';
 import { useTranslation } from 'react-i18next';
 import { invoke } from '@tauri-apps/api/core';
+import { getWebSocketUrl } from '@/lib/websocket-endpoint';
 import { readText as readClipboardText, writeText as writeClipboardText } from '@tauri-apps/plugin-clipboard-manager';
 import { toast } from 'sonner';
 import { DesktopToolbar } from './desktop-toolbar';
@@ -64,16 +65,12 @@ export function DesktopViewer({
     let cancelled = false;
 
     const connect = async () => {
-      let wsPort = 9001;
-      try {
-        wsPort = await invoke<number>('get_websocket_port');
-      } catch {
-        // fallback to default
-      }
+      // Port + per-launch bridge token from the backend (issue #138).
+      const wsUrl = await getWebSocketUrl();
 
       if (cancelled) return;
 
-      ws = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+      ws = new WebSocket(wsUrl);
       wsRef.current = ws;
 
       ws.onopen = () => {

--- a/src/components/pty-terminal.tsx
+++ b/src/components/pty-terminal.tsx
@@ -5,8 +5,8 @@ import { WebLinksAddon } from '@xterm/addon-web-links';
 import { WebglAddon } from '@xterm/addon-webgl';
 import { SearchAddon } from '@xterm/addon-search';
 import { ClipboardAddon } from '@xterm/addon-clipboard';
-import { invoke } from '@tauri-apps/api/core';
 import { readText as readClipboardText, writeText as writeClipboardText } from '@tauri-apps/plugin-clipboard-manager';
+import { getWebSocketUrl } from '@/lib/websocket-endpoint';
 import { loadAppearanceSettings, getThemeAwareTerminalOptions, getThemeAwareTerminalTheme, terminalThemes, defaultTerminalTheme } from '../lib/terminal-config';
 import { TerminalContextMenu } from './terminal/terminal-context-menu';
 import { TerminalSearchBar, type TerminalSearchState } from './terminal/terminal-search-bar';
@@ -655,17 +655,10 @@ export function PtyTerminal({
         onConnectionStatusChange?.(connectionId, 'connecting');
       }
       
-      // Get the dynamically assigned WebSocket port from the backend
-      let wsPort = 9001; // fallback default
-      try {
-        wsPort = await invoke<number>('get_websocket_port');
-        console.log(`[PTY Terminal] [${connectionId}] WebSocket port: ${wsPort}`);
-      } catch (e) {
-        console.warn(`[PTY Terminal] [${connectionId}] Failed to get WebSocket port, using default:`, e);
-      }
-      
+      // Port + per-launch bridge token from the backend (issue #138).
+      const wsUrl = await getWebSocketUrl();
       console.log(`[PTY Terminal] [${connectionId}] Connecting to WebSocket...`);
-      const ws = new WebSocket(`ws://127.0.0.1:${wsPort}`);
+      const ws = new WebSocket(wsUrl);
       // Receive PTY output as ArrayBuffer so we can avoid the JSON overhead of
       // encoding Vec<u8> as integer arrays.  The backend sends binary output
       // frames with the format: [0x01][id_len: u16 BE][connection_id][payload]

--- a/src/lib/websocket-endpoint.ts
+++ b/src/lib/websocket-endpoint.ts
@@ -1,0 +1,32 @@
+import { invoke } from '@tauri-apps/api/core';
+
+/** Port the bridge falls back to when the backend cannot be asked (browser dev mode). */
+export const DEFAULT_WS_PORT = 9001;
+
+/** Shape returned by the `get_websocket_endpoint` Tauri command. */
+export interface WebSocketEndpoint {
+  port: number;
+  token: string;
+}
+
+/**
+ * Build the URL for the local PTY/desktop WebSocket bridge.
+ *
+ * The bridge listens on loopback, which every local process — and, through a
+ * browser, every web page — can reach. Since issue #138 the backend therefore
+ * requires a per-launch token in the handshake; it is only ever handed to this
+ * webview via IPC, so it must travel in the query string of every connection.
+ *
+ * Without a backend (plain `pnpm dev` in a browser) there is no token; the
+ * default port is returned so the failure surfaces as a normal connection
+ * error rather than an exception here.
+ */
+export async function getWebSocketUrl(): Promise<string> {
+  try {
+    const { port, token } = await invoke<WebSocketEndpoint>('get_websocket_endpoint');
+    return `ws://127.0.0.1:${port}/?token=${encodeURIComponent(token)}`;
+  } catch (e) {
+    console.warn('[WebSocket] Failed to get bridge endpoint, using default port without token:', e);
+    return `ws://127.0.0.1:${DEFAULT_WS_PORT}`;
+  }
+}


### PR DESCRIPTION
Fixes #138

## Summary

The PTY/desktop bridge on `127.0.0.1:9001–9010` accepted every connection. Loopback is reachable by every local process and — because WebSocket handshakes to `127.0.0.1` are not subject to CORS — by every web page the user has open. A foreign client that knew or guessed a `connection_id` could send `StartPty` / `Input` and obtain a shell on the user's already-authenticated SSH session. Quick-connect ids were `connection-<ms timestamp>`, which is brute-forceable.

This PR makes the handshake authenticated and the ids unguessable.

## Backend

- **Per-launch token.** `WEBSOCKET_TOKEN` (`lib.rs`) is a `OnceLock<String>` filled with 32 random bytes (base64url, no padding) right before the listener binds, so no client can connect before it exists.
- **Handshake validation** (`websocket_server.rs`). `accept_async` → `accept_hdr_async` with a callback that runs `validate_handshake(origin, query, expected)`:
  - the `token` query parameter must equal the launch token (constant-time compare; prefix/superstring/empty values fail; an uninitialised server token rejects everything);
  - if the client sends an `Origin` header it must be one of the app's own webview origins (`tauri://localhost`, `http(s)://tauri.localhost`); the Vite dev origin is accepted only in debug builds. Non-browser clients send no `Origin` and rely on the token alone.
  - Rejections answer `403` and are logged with the reason and origin.
- **`get_websocket_endpoint` command** returns `{ port, token }`. The token only ever crosses the webview ↔ backend IPC channel. `get_websocket_port` is kept as-is for compatibility.

## Frontend

- New `getWebSocketUrl()` helper (`src/lib/websocket-endpoint.ts`) used by both `PtyTerminal` and `DesktopViewer`; it puts the token in the query string (`ws://127.0.0.1:<port>/?token=<token>`). It falls back to the bare default port only when no backend answers (plain `pnpm dev` in a browser), where a connection cannot succeed anyway.
- `connection-dialog.tsx`: quick-connect ids are now `crypto.randomUUID()` instead of `connection-${Date.now()}` — nothing depended on the prefix.

## Tests

- Rust (`websocket_server.rs`, `handshake_tests`): allowed origins with a valid token; native client without `Origin`; foreign and `null` origins rejected even with a valid token; missing / wrong / prefix / superstring / empty token; token among other query parameters; uninitialised server token; generated token is 43 URL-safe chars and unique.
- Frontend (`websocket-endpoint.test.ts`): URL shape, percent-encoding of a non-URL-safe token, fallback when the backend is unavailable. Existing `PtyTerminal` test mocks switched to the new command.
- `pnpm vitest run` — 80 files, 771 tests passing (3 new). `pnpm tsc --noEmit` clean; `pnpm lint` — no errors in the changed files.
- `cargo test` — run on my fork's CI on macOS, Ubuntu and Windows (see the linked run); a Windows build of this branch connects and works normally.

## Notes for review

- Any one of token or Origin check closes the hole; both are applied as defence in depth.
- No change to the `WsMessage` protocol itself, so the frontend/backend wire format is untouched.
