### PR TITLE
feat(connection): pick the SSH private key with the OS file dialog

### DIFF
--- a/src/__tests__/key-file-picker.test.ts
+++ b/src/__tests__/key-file-picker.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  open: vi.fn(),
+  homeDir: vi.fn(),
+  join: vi.fn(),
+  dirname: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/plugin-dialog', () => ({ open: mocks.open }));
+vi.mock('@tauri-apps/api/path', () => ({
+  homeDir: mocks.homeDir,
+  join: mocks.join,
+  dirname: mocks.dirname,
+}));
+
+import { keyPickerStartDir, pickPrivateKeyFile } from '@/lib/key-file-picker';
+
+const WIN_HOME = 'C:\\Users\\me';
+const WIN_SSH = 'C:\\Users\\me\\.ssh';
+
+/** Minimal stand-ins for the Tauri path API: last separator splits dir/file. */
+function stripLastSegment(p: string): string {
+  const cut = Math.max(p.lastIndexOf('/'), p.lastIndexOf('\\'));
+  return cut > 0 ? p.slice(0, cut) : p;
+}
+
+describe('keyPickerStartDir', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.homeDir.mockResolvedValue(WIN_HOME);
+    mocks.join.mockImplementation(async (...parts: string[]) => parts.join('\\'));
+    mocks.dirname.mockImplementation(async (p: string) => stripLastSegment(p));
+  });
+
+  it('defaults to ~/.ssh when the field is empty', async () => {
+    expect(await keyPickerStartDir('')).toBe(WIN_SSH);
+    expect(await keyPickerStartDir(undefined)).toBe(WIN_SSH);
+  });
+
+  it('defaults to ~/.ssh for a tilde or relative value', async () => {
+    expect(await keyPickerStartDir('~/.ssh/id_ed25519')).toBe(WIN_SSH);
+    expect(await keyPickerStartDir('id_rsa')).toBe(WIN_SSH);
+    expect(mocks.dirname).not.toHaveBeenCalled();
+  });
+
+  it('opens next to an absolute current value (Windows and POSIX)', async () => {
+    expect(await keyPickerStartDir('D:\\keys\\prod.pem')).toBe('D:\\keys');
+    expect(await keyPickerStartDir('/home/me/.ssh/id_ed25519')).toBe('/home/me/.ssh');
+    expect(await keyPickerStartDir('\\\\nas\\keys\\a')).toBe('\\\\nas\\keys');
+  });
+
+  it('gives up quietly when the path API fails', async () => {
+    mocks.homeDir.mockRejectedValue(new Error('no window'));
+    expect(await keyPickerStartDir('')).toBeUndefined();
+  });
+});
+
+describe('pickPrivateKeyFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.homeDir.mockResolvedValue('/home/me');
+    mocks.join.mockImplementation(async (...parts: string[]) => parts.join('/'));
+    mocks.dirname.mockImplementation(async (p: string) => stripLastSegment(p));
+  });
+
+  it('opens a single-file dialog without extension filters and returns the pick', async () => {
+    mocks.open.mockResolvedValue('/home/me/.ssh/id_ed25519');
+    await expect(pickPrivateKeyFile('', 'Select key')).resolves.toBe('/home/me/.ssh/id_ed25519');
+    expect(mocks.open).toHaveBeenCalledWith({
+      multiple: false,
+      directory: false,
+      title: 'Select key',
+      defaultPath: '/home/me/.ssh',
+    });
+    expect(mocks.open.mock.calls[0][0]).not.toHaveProperty('filters');
+  });
+
+  it('returns null when the dialog is dismissed', async () => {
+    mocks.open.mockResolvedValue(null);
+    await expect(pickPrivateKeyFile('/srv/keys/a')).resolves.toBeNull();
+    expect(mocks.open.mock.calls[0][0].defaultPath).toBe('/srv/keys');
+  });
+
+  it('propagates a dialog failure to the caller', async () => {
+    mocks.open.mockRejectedValue(new Error('dialog plugin missing'));
+    await expect(pickPrivateKeyFile('')).rejects.toThrow('dialog plugin missing');
+  });
+});

--- a/src/__tests__/key-path-input.test.tsx
+++ b/src/__tests__/key-path-input.test.tsx
@@ -1,0 +1,62 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mocks = vi.hoisted(() => ({
+  pick: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock('@/lib/key-file-picker', () => ({ pickPrivateKeyFile: mocks.pick }));
+vi.mock('sonner', () => ({ toast: { error: mocks.toastError } }));
+
+import { KeyPathInput } from '@/components/key-path-input';
+
+const browseButton = () => screen.getByRole('button', { name: 'Browse for key file' }) as HTMLButtonElement;
+const textbox = () => screen.getByRole('textbox') as HTMLInputElement;
+
+describe('KeyPathInput', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('fills the field with the picked file, starting from the current value', async () => {
+    mocks.pick.mockResolvedValue('/home/me/.ssh/id_ed25519');
+    const onChange = vi.fn();
+    render(<KeyPathInput id="k" value="/old/key" onChange={onChange} />);
+
+    fireEvent.click(browseButton());
+
+    await waitFor(() => expect(onChange).toHaveBeenCalledWith('/home/me/.ssh/id_ed25519'));
+    expect(mocks.pick).toHaveBeenCalledWith('/old/key', 'Select private key');
+  });
+
+  it('leaves the field alone when the dialog is dismissed', async () => {
+    mocks.pick.mockResolvedValue(null);
+    const onChange = vi.fn();
+    render(<KeyPathInput id="k" value="~/.ssh/id_rsa" onChange={onChange} />);
+
+    fireEvent.click(browseButton());
+
+    await waitFor(() => expect(mocks.pick).toHaveBeenCalled());
+    expect(onChange).not.toHaveBeenCalled();
+    expect(textbox().value).toBe('~/.ssh/id_rsa');
+  });
+
+  it('still accepts typed input', () => {
+    const onChange = vi.fn();
+    render(<KeyPathInput id="k" value="" onChange={onChange} />);
+    fireEvent.change(textbox(), { target: { value: '~/.ssh/work' } });
+    expect(onChange).toHaveBeenCalledWith('~/.ssh/work');
+  });
+
+  it('reports a picker failure with a toast instead of throwing', async () => {
+    mocks.pick.mockRejectedValue(new Error('boom'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+    render(<KeyPathInput id="k" value="" onChange={vi.fn()} />);
+
+    fireEvent.click(browseButton());
+
+    await waitFor(() => expect(mocks.toastError).toHaveBeenCalled());
+    expect(mocks.toastError.mock.calls[0][0]).toBe('Could not open the file picker');
+    await waitFor(() => expect(browseButton().disabled).toBe(false));
+    consoleError.mockRestore();
+  });
+});

--- a/src/components/connection-dialog.tsx
+++ b/src/components/connection-dialog.tsx
@@ -4,6 +4,7 @@ import { invoke } from '@tauri-apps/api/core';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogFooter } from './ui/dialog';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
+import { KeyPathInput } from './key-path-input';
 import { PasswordInput } from './ui/password-input';
 import { Label } from './ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
@@ -1029,11 +1030,11 @@ const handleCancelConnectionAttempt = async () => {
                   <div className="space-y-4">
                     <div className="space-y-2">
                       <Label htmlFor="private-key">{t('connectionDialog.label.privateKey')}</Label>
-                      <Input
+                      <KeyPathInput
                         id="private-key"
                         placeholder={t('connectionDialog.placeholder.privateKey')}
-                        value={config.privateKeyPath}
-                        onChange={(e) => updateConfig({ privateKeyPath: e.target.value })}
+                        value={config.privateKeyPath ?? ''}
+                        onChange={(privateKeyPath) => updateConfig({ privateKeyPath })}
                       />
                       <p className="text-xs text-muted-foreground">
                         {t('connectionDialog.placeholder.privateKey')}
@@ -1291,11 +1292,11 @@ const handleCancelConnectionAttempt = async () => {
                           <>
                             <div className="space-y-2">
                               <Label htmlFor="tunnel-key">{t('connectionDialog.label.tunnelKeyPath')}</Label>
-                              <Input
+                              <KeyPathInput
                                 id="tunnel-key"
                                 placeholder={t('connectionDialog.placeholder.tunnelKeyPath')}
-                                value={config.tunnelKeyPath}
-                                onChange={(e) => updateConfig({ tunnelKeyPath: e.target.value })}
+                                value={config.tunnelKeyPath ?? ''}
+                                onChange={(tunnelKeyPath) => updateConfig({ tunnelKeyPath })}
                               />
                             </div>
                             <div className="space-y-2">

--- a/src/components/key-path-input.tsx
+++ b/src/components/key-path-input.tsx
@@ -1,0 +1,59 @@
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { FolderOpen } from 'lucide-react';
+import { toast } from 'sonner';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { pickPrivateKeyFile } from '@/lib/key-file-picker';
+
+interface KeyPathInputProps {
+  id: string;
+  value: string;
+  placeholder?: string;
+  onChange: (value: string) => void;
+}
+
+/**
+ * Text field for a private-key path with a button that opens the OS file
+ * picker. Typing stays possible; the picker just fills the field.
+ */
+export function KeyPathInput({ id, value, placeholder, onChange }: KeyPathInputProps) {
+  const { t } = useTranslation();
+  const [picking, setPicking] = useState(false);
+
+  const browse = async () => {
+    setPicking(true);
+    try {
+      const picked = await pickPrivateKeyFile(value, t('connectionDialog.button.browseKeyTitle'));
+      if (picked) onChange(picked);
+    } catch (error) {
+      console.error('Key file picker failed:', error);
+      toast.error(t('connectionDialog.toast.keyPickerFailed'), { description: String(error) });
+    } finally {
+      setPicking(false);
+    }
+  };
+
+  return (
+    <div className="flex gap-2">
+      <Input
+        id={id}
+        className="flex-1"
+        placeholder={placeholder}
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+      />
+      <Button
+        type="button"
+        variant="outline"
+        size="icon"
+        aria-label={t('connectionDialog.button.browseKey')}
+        title={t('connectionDialog.button.browseKey')}
+        disabled={picking}
+        onClick={browse}
+      >
+        <FolderOpen className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/lib/key-file-picker.ts
+++ b/src/lib/key-file-picker.ts
@@ -1,0 +1,40 @@
+import { open } from '@tauri-apps/plugin-dialog';
+import { dirname, homeDir, join } from '@tauri-apps/api/path';
+
+/** True for `/x`, `\\server\x` and `C:\x` / `C:/x`; false for `~/x` or a bare name. */
+function isAbsoluteLike(path: string): boolean {
+  if (path.startsWith('/') || path.startsWith('\\\\')) return true;
+  return /^[A-Za-z]:[\\/]/.test(path);
+}
+
+/**
+ * Directory the key picker opens in: the folder of the current value when it
+ * is an absolute path, otherwise `~/.ssh`. Returns undefined when neither can
+ * be resolved so the dialog falls back to the OS default.
+ */
+export async function keyPickerStartDir(currentPath?: string): Promise<string | undefined> {
+  const trimmed = currentPath?.trim() ?? '';
+  try {
+    if (trimmed && isAbsoluteLike(trimmed)) {
+      return await dirname(trimmed);
+    }
+    return await join(await homeDir(), '.ssh');
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Open the OS file dialog for a private key. Keys have no conventional
+ * extension, so no filter is applied. Resolves to the chosen path, or null
+ * when the dialog was dismissed.
+ */
+export async function pickPrivateKeyFile(currentPath?: string, title?: string): Promise<string | null> {
+  const selected = await open({
+    multiple: false,
+    directory: false,
+    title,
+    defaultPath: await keyPickerStartDir(currentPath),
+  });
+  return typeof selected === 'string' && selected.length > 0 ? selected : null;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -238,7 +238,9 @@
       "cancelling": "Cancelling...",
       "connecting": "Connecting...",
       "connect": "Connect",
-      "updateAndConnect": "Update & Connect"
+      "updateAndConnect": "Update & Connect",
+      "browseKey": "Browse for key file",
+      "browseKeyTitle": "Select private key"
     },
     "toast": {
       "missingFields": "Missing Required Fields",
@@ -258,7 +260,8 @@
       "connectionFailedDesc": "Unable to connect to the server. Please check your credentials and try again.",
       "connectionError": "Connection Error",
       "connectionErrorDesc": "An unexpected error occurred while connecting.",
-      "credentialSyncFailed": "Failed to encrypt and save the credentials"
+      "credentialSyncFailed": "Failed to encrypt and save the credentials",
+      "keyPickerFailed": "Could not open the file picker"
     },
     "tunnel": {
       "enable": "Enable SSH Tunnel",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -240,7 +240,9 @@
       "cancelling": "Anulowanie...",
       "connecting": "Łączenie...",
       "connect": "Połącz",
-      "updateAndConnect": "Zapisz i połącz"
+      "updateAndConnect": "Zapisz i połącz",
+      "browseKey": "Wybierz plik klucza",
+      "browseKeyTitle": "Wybierz klucz prywatny"
     },
     "toast": {
       "missingFields": "Brak wymaganych pól",
@@ -260,7 +262,8 @@
       "connectionFailedDesc": "Nie udało się połączyć z serwerem. Sprawdź dane logowania i spróbuj ponownie.",
       "connectionError": "Błąd połączenia",
       "connectionErrorDesc": "Podczas łączenia wystąpił nieoczekiwany błąd.",
-      "credentialSyncFailed": "Nie udało się zaszyfrować i zapisać danych logowania"
+      "credentialSyncFailed": "Nie udało się zaszyfrować i zapisać danych logowania",
+      "keyPickerFailed": "Nie udało się otworzyć okna wyboru pliku"
     },
     "tunnel": {
       "enable": "Włącz tunel SSH",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -238,7 +238,9 @@
       "cancelling": "取消中...",
       "connecting": "连接中...",
       "connect": "连接",
-      "updateAndConnect": "更新并连接"
+      "updateAndConnect": "更新并连接",
+      "browseKey": "浏览密钥文件",
+      "browseKeyTitle": "选择私钥"
     },
     "toast": {
       "missingFields": "缺少必填字段",
@@ -258,7 +260,8 @@
       "connectionFailedDesc": "无法连接到服务器，请检查您的凭据并重试。",
       "connectionError": "连接错误",
       "connectionErrorDesc": "连接时发生意外错误。",
-      "credentialSyncFailed": "加密并保存凭据失败"
+      "credentialSyncFailed": "加密并保存凭据失败",
+      "keyPickerFailed": "无法打开文件选择器"
     },
     "tunnel": {
       "enable": "启用 SSH 隧道",


### PR DESCRIPTION
## Summary

The private-key fields in the connection dialog (target host and jump host) only accept a typed path. This adds a browse button next to each of them that opens the system file picker and fills the field with the chosen file. Typing a path still works exactly as before.

## Behaviour

- The picker starts in `~/.ssh`; when the field already holds an absolute path it starts in that file's folder instead. A `~/…` or relative value keeps `~/.ssh` as the start folder.
- No extension filter: private keys have no conventional extension, so the dialog shows all files.
- Dismissing the dialog leaves the field untouched. A picker failure (plugin missing, OS error) shows a toast and keeps the field editable.
- The button is disabled while the dialog is open, so a double click cannot open two dialogs.

## Implementation

- `src/lib/key-file-picker.ts`: `keyPickerStartDir()` and `pickPrivateKeyFile()` on top of `@tauri-apps/plugin-dialog` (already a dependency, `dialog:default` already granted) and `@tauri-apps/api/path`.
- `src/components/key-path-input.tsx`: `KeyPathInput` = `Input` + icon `Button`, used for `private-key` and `tunnel-key` in `connection-dialog.tsx`. The element ids are unchanged, so existing tests and labels keep working.
- Strings added to `en`, `zh-CN` and `pl` (`connectionDialog.button.browseKey`, `browseKeyTitle`, `connectionDialog.toast.keyPickerFailed`); `pnpm i18n:check` passes.

## Tests

- `key-file-picker.test.ts`: start folder for empty / tilde / relative / absolute (Windows, POSIX, UNC) values, quiet fallback when the path API fails, dialog options (single file, no filters, title, start folder), dismissal returns null, failure propagates.
- `key-path-input.test.tsx`: picked file fills the field (starting from the current value), dismissal leaves it alone, typing still works, failure shows a toast and re-enables the button.

`pnpm vitest run`: 81 files, 779 tests passing. `tsc --noEmit` clean, no lint errors in the changed files. [[DO POTWIERDZENIA PO TWOIM TEŚCIE, inaczej usuń]] Verified on a Windows build from my fork: the dialog opens in `~/.ssh`, the chosen file lands in the field and the connection uses it.
