### PR TITLE
feat(connection-manager): remember collapsed folders across restarts

### DIFF
--- a/src/__tests__/connection-manager-folder-persistence.test.tsx
+++ b/src/__tests__/connection-manager-folder-persistence.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * The connection manager must reopen with the folders in the state the user
+ * left them: collapsing a folder is persisted immediately and honoured by a
+ * fresh mount (which is what an app restart is, as far as the tree knows).
+ */
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ConnectionManager } from '../components/connection-manager';
+import { ConnectionStorageManager } from '../lib/connection-storage';
+import { COLLAPSED_FOLDERS_STORAGE_KEY } from '../lib/folder-expansion';
+
+vi.mock('sonner', () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock('@tauri-apps/api/core', () => ({ invoke: vi.fn() }));
+
+const workId = crypto.randomUUID();
+const prodId = crypto.randomUUID();
+const personalId = crypto.randomUUID();
+
+function seedStorage() {
+  localStorage.clear();
+  const now = new Date().toISOString();
+  localStorage.setItem(
+    'r-shell-connection-folders',
+    JSON.stringify([
+      { id: workId, name: 'Work', path: 'Work', parentPath: undefined, createdAt: now },
+      { id: prodId, name: 'Prod', path: 'Work/Prod', parentPath: 'Work', createdAt: now },
+      { id: personalId, name: 'Personal', path: 'Personal', parentPath: undefined, createdAt: now },
+    ]),
+  );
+  localStorage.setItem(
+    'r-shell-connections',
+    JSON.stringify([
+      { id: crypto.randomUUID(), name: 'Prod box', host: 'p', port: 22, username: 'u', protocol: 'SSH', folder: 'Work/Prod', createdAt: now },
+      { id: crypto.randomUUID(), name: 'Home box', host: 'h', port: 22, username: 'u', protocol: 'SSH', folder: 'Personal', createdAt: now },
+    ]),
+  );
+  ConnectionStorageManager.initialize();
+}
+
+function mount() {
+  return render(
+    <ConnectionManager onConnectionSelect={vi.fn()} selectedConnectionId={null} activeConnections={new Set()} />,
+  );
+}
+
+function chevronOf(container: HTMLElement, folderId: string): HTMLButtonElement {
+  const row = container.querySelector(`[data-conn-node-id="${folderId}"]`);
+  const button = row?.querySelector('button');
+  if (!button) throw new Error(`no chevron for folder ${folderId}`);
+  return button;
+}
+
+describe('ConnectionManager folder expansion persistence', () => {
+  beforeEach(seedStorage);
+  afterEach(cleanup);
+
+  it('starts fully expanded when nothing was stored', () => {
+    mount();
+    expect(screen.getByText('Prod box')).toBeTruthy();
+    expect(screen.getByText('Home box')).toBeTruthy();
+  });
+
+  it('stores a collapse immediately and restores it on a fresh mount', () => {
+    const first = mount();
+    fireEvent.click(chevronOf(first.container, prodId));
+    expect(screen.queryByText('Prod box')).toBeNull();
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_FOLDERS_STORAGE_KEY) ?? '[]')).toEqual([prodId]);
+    first.unmount();
+
+    const second = mount();
+    expect(screen.queryByText('Prod box')).toBeNull(); // Work/Prod still collapsed
+    expect(screen.getByText('Prod')).toBeTruthy(); // ...but its parent is open
+    expect(screen.getByText('Home box')).toBeTruthy(); // Personal untouched
+
+    fireEvent.click(chevronOf(second.container, prodId));
+    expect(screen.getByText('Prod box')).toBeTruthy();
+    expect(JSON.parse(localStorage.getItem(COLLAPSED_FOLDERS_STORAGE_KEY) ?? '[]')).toEqual([]);
+  });
+
+  it('keeps a collapsed parent collapsed across a restart and remembers nested state inside it', () => {
+    const first = mount();
+    fireEvent.click(chevronOf(first.container, prodId));
+    fireEvent.click(chevronOf(first.container, workId));
+    expect(screen.queryByText('Prod')).toBeNull();
+    first.unmount();
+
+    const second = mount();
+    expect(screen.queryByText('Prod')).toBeNull();
+    fireEvent.click(chevronOf(second.container, workId));
+    expect(screen.getByText('Prod')).toBeTruthy();
+    expect(screen.queryByText('Prod box')).toBeNull(); // nested collapse remembered too
+  });
+
+  it('drops ids of folders that no longer exist when the state is next saved', () => {
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, JSON.stringify(['deleted-folder', personalId]));
+    const { container } = mount();
+    expect(screen.queryByText('Home box')).toBeNull();
+
+    fireEvent.click(chevronOf(container, workId));
+    const saved: string[] = JSON.parse(localStorage.getItem(COLLAPSED_FOLDERS_STORAGE_KEY) ?? '[]');
+    expect(saved.sort()).toEqual([personalId, workId].sort()); // 'deleted-folder' is gone
+  });
+
+  it('survives unreadable stored state', () => {
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, '{oops');
+    mount();
+    expect(screen.getByText('Prod box')).toBeTruthy();
+  });
+});

--- a/src/__tests__/folder-expansion.test.ts
+++ b/src/__tests__/folder-expansion.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  COLLAPSED_FOLDERS_STORAGE_KEY,
+  applyCollapsedState,
+  collectCollapsedFolderIds,
+  loadCollapsedFolderIds,
+  saveCollapsedFolderIds,
+  type ExpandableNode,
+} from '@/lib/folder-expansion';
+
+const tree = (): ExpandableNode[] => [
+  {
+    id: 'work',
+    type: 'folder',
+    isExpanded: true,
+    children: [
+      { id: 'prod', type: 'folder', isExpanded: true, children: [{ id: 'c1', type: 'connection' }] },
+      { id: 'c2', type: 'connection' },
+    ],
+  },
+  { id: 'personal', type: 'folder', isExpanded: true, children: [] },
+  { id: 'c3', type: 'connection' },
+];
+
+describe('collapsed folder storage', () => {
+  beforeEach(() => localStorage.clear());
+
+  it('round-trips a set of ids', () => {
+    saveCollapsedFolderIds(['work', 'prod']);
+    expect(loadCollapsedFolderIds()).toEqual(new Set(['work', 'prod']));
+  });
+
+  it('is empty when nothing was stored', () => {
+    expect(loadCollapsedFolderIds().size).toBe(0);
+  });
+
+  it('ignores malformed or non-string content', () => {
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, '{not json');
+    expect(loadCollapsedFolderIds().size).toBe(0);
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, JSON.stringify({ work: true }));
+    expect(loadCollapsedFolderIds().size).toBe(0);
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, JSON.stringify(['work', 7, null]));
+    expect(loadCollapsedFolderIds()).toEqual(new Set(['work']));
+  });
+});
+
+describe('applyCollapsedState', () => {
+  it('collapses exactly the stored folders at any depth and leaves the rest expanded', () => {
+    const result = applyCollapsedState(tree(), new Set(['prod', 'stale-id']));
+    expect(result[0].isExpanded).toBe(true);
+    expect(result[0].children?.[0].isExpanded).toBe(false);
+    expect(result[1].isExpanded).toBe(true);
+  });
+
+  it('does not touch connection nodes and does not mutate the input', () => {
+    const input = tree();
+    const result = applyCollapsedState(input, new Set(['work']));
+    expect(result[2]).toBe(input[2]);
+    expect(result[0].children?.[1]).toEqual({ id: 'c2', type: 'connection' });
+    expect(input[0].isExpanded).toBe(true);
+  });
+});
+
+describe('collectCollapsedFolderIds', () => {
+  it('lists collapsed folders only, including nested ones', () => {
+    const t = tree();
+    t[0].children![0].isExpanded = false;
+    t[1].isExpanded = false;
+    expect(collectCollapsedFolderIds(t)).toEqual(['prod', 'personal']);
+  });
+
+  it('treats a missing flag as expanded', () => {
+    expect(collectCollapsedFolderIds([{ id: 'x', type: 'folder' }])).toEqual([]);
+  });
+});

--- a/src/components/connection-manager.tsx
+++ b/src/components/connection-manager.tsx
@@ -35,6 +35,12 @@ import {
 } from './ui/alert-dialog';
 import { ConnectionStorageManager } from '../lib/connection-storage';
 import {
+  applyCollapsedState,
+  collectCollapsedFolderIds,
+  loadCollapsedFolderIds,
+  saveCollapsedFolderIds,
+} from '../lib/folder-expansion';
+import {
   ContextMenu,
   ContextMenuContent,
   ContextMenuItem,
@@ -113,9 +119,11 @@ export function ConnectionManager({
     navigator.platform.toUpperCase().includes('MAC'),
   );
   // Load connections from storage
+  // The storage backend returns every folder expanded; reapply the folders
+  // the user collapsed so the tree survives rebuilds and app restarts.
   const loadConnections = (): ConnectionNode[] => {
     const tree = ConnectionStorageManager.buildConnectionTree(activeConnections);
-    return tree.length > 0 ? tree : [];
+    return tree.length > 0 ? applyCollapsedState(tree, loadCollapsedFolderIds()) : [];
   };
 
   // Relative "n min/hours ago" (shared with the welcome screen) for recent
@@ -638,7 +646,10 @@ export function ConnectionManager({
         return node;
       });
     };
-    setConnections(updateNode(connections));
+    const next = updateNode(connections);
+    // Persist on every change (folders that no longer exist drop out here).
+    saveCollapsedFolderIds(collectCollapsedFolderIds(next));
+    setConnections(next);
   };
 
   const getIcon = (node: ConnectionNode) => {

--- a/src/lib/folder-expansion.ts
+++ b/src/lib/folder-expansion.ts
@@ -1,0 +1,63 @@
+/**
+ * Remembers which connection-manager folders the user collapsed, so the tree
+ * reopens in the same shape after a restart.
+ *
+ * Only collapsed folder ids are stored: a folder that is missing from the set
+ * (including one created later) stays expanded, which is the behaviour the
+ * tree always had.
+ */
+
+export const COLLAPSED_FOLDERS_STORAGE_KEY = 'r-shell-collapsed-folders';
+
+export interface ExpandableNode {
+  id: string;
+  type: 'folder' | 'connection';
+  isExpanded?: boolean;
+  children?: ExpandableNode[];
+}
+
+export function loadCollapsedFolderIds(): Set<string> {
+  try {
+    const raw = localStorage.getItem(COLLAPSED_FOLDERS_STORAGE_KEY);
+    if (!raw) return new Set();
+    const parsed: unknown = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return new Set();
+    return new Set(parsed.filter((id): id is string => typeof id === 'string'));
+  } catch {
+    return new Set();
+  }
+}
+
+export function saveCollapsedFolderIds(ids: Iterable<string>): void {
+  try {
+    localStorage.setItem(COLLAPSED_FOLDERS_STORAGE_KEY, JSON.stringify([...ids]));
+  } catch (error) {
+    console.warn('Could not persist folder expansion state:', error);
+  }
+}
+
+/** Return a copy of the tree with every folder's `isExpanded` set from `collapsed`. */
+export function applyCollapsedState<T extends ExpandableNode>(nodes: T[], collapsed: Set<string>): T[] {
+  return nodes.map(node => {
+    if (node.type !== 'folder') return node;
+    const next: T = { ...node, isExpanded: !collapsed.has(node.id) };
+    if (node.children) {
+      next.children = applyCollapsedState(node.children, collapsed);
+    }
+    return next;
+  });
+}
+
+/** Ids of the folders currently collapsed, at any depth. */
+export function collectCollapsedFolderIds(nodes: ExpandableNode[]): string[] {
+  const ids: string[] = [];
+  const walk = (list: ExpandableNode[]) => {
+    for (const node of list) {
+      if (node.type !== 'folder') continue;
+      if (node.isExpanded === false) ids.push(node.id);
+      if (node.children) walk(node.children);
+    }
+  };
+  walk(nodes);
+  return ids;
+}


### PR DESCRIPTION
Title: feat(connection-manager): remember collapsed folders across restarts

## Summary

The connection manager always reopens with every folder and subfolder expanded, whatever the user left behind. The storage backend builds the tree with `isExpanded: true`, and the collapse state lived only in component state, so any restart (and any remount) reset it.

This PR persists the collapse state on every change and reapplies it whenever the tree is rebuilt, so the manager comes back exactly as it was when the app was closed.

## Behaviour

- Collapsing or expanding a folder is saved immediately (no flush on exit, so a crash or force-quit keeps the last state too).
- Restart, reload, and every tree rebuild (new/edited/deleted/moved connection, folder rename, active-connection changes) honour the saved state, at any nesting depth.
- Only **collapsed** folder ids are stored. Anything not stored stays expanded, so existing users see no change until they collapse something, and new folders start expanded as before.
- Ids of folders that no longer exist drop out at the next save; unreadable stored data is ignored and the tree opens fully expanded.

## Implementation

- `src/lib/folder-expansion.ts`: `loadCollapsedFolderIds()` / `saveCollapsedFolderIds()` on `localStorage` key `r-shell-collapsed-folders`, `applyCollapsedState()` (pure, returns a copy) and `collectCollapsedFolderIds()`.
- `connection-manager.tsx`: `loadConnections()` applies the stored state, so every existing `setConnections(loadConnections())` site and the rebuild effect pick it up without further changes; `toggleExpanded()` saves the new state before committing it.

No new strings, no backend changes.

## Tests

- `folder-expansion.test.ts`: storage round-trip, empty and malformed content, applying state at depth without touching connection nodes or mutating the input, collecting nested collapsed ids.
- `connection-manager-folder-persistence.test.tsx`: fully expanded by default; a collapse is stored at once and survives a fresh mount while siblings stay open; a collapsed parent with a collapsed child restores both; stale ids are pruned on the next save; corrupt stored state is tolerated.

`pnpm vitest run`: 81 files, 780 tests passing. `tsc --noEmit` clean, no lint errors in the changed files.
