### PR TITLE
fix(lint): remove unnecessary type assertion in settings modal

### DIFF
--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -422,7 +422,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
   const scrollToActiveTab = useCallback(() => {
     const el = tabListRef.current;
     if (!el) return;
-    const activeTrigger = el.querySelector('[data-state="active"]') as HTMLElement | null;
+    const activeTrigger = el.querySelector<HTMLElement>('[data-state="active"]');
     if (!activeTrigger) return;
     activeTrigger.scrollIntoView({ inline: 'center', block: 'nearest', behavior: 'smooth' });
   }, []);


### PR DESCRIPTION
## Summary

`pnpm lint` currently exits 1 on `main` with one `@typescript-eslint/no-unnecessary-type-assertion` error at `settings-modal.tsx:425`. This removes the offending assertion so a clean lint run is possible again.

## Root cause

The DOM lib's `querySelector<E extends Element = HTMLElement>` already returns `HTMLElement | null`, so the `as HTMLElement | null` cast in `scrollToActiveTab` changed nothing about the expression's type — it only tripped the rule.

## Changes

- `src/components/settings-modal.tsx`: use the explicit generic form `querySelector<HTMLElement>(...)` instead, matching the existing style in `group-tab-bar.tsx`. No runtime behavior change.

## Testing

- `pnpm lint` → 0 errors (245 pre-existing warnings unchanged)
- `npx tsc --noEmit` → pass
- `pnpm i18n:check` → pass
- `pnpm test` → 769 tests pass

Note: CI currently doesn't run ESLint, which is how this error survived on `main` — worth considering `pnpm lint` as a CI step.