### PR TITLE
fix(shortcuts): stop hijacking cross-app keys and macOS menu chords (#130 #144)

### DIFF
--- a/src/FileViewerWindow.tsx
+++ b/src/FileViewerWindow.tsx
@@ -91,7 +91,7 @@ export function FileViewerWindow() {
   // On macOS the shared native menu's "Close Tab" key equivalent (Cmd+W)
   // consumes the keystroke before it can reach this webview (menu key
   // equivalents are resolved before the responder chain — the same reason
-  // MACOS_NATIVE_MENU_ACCELERATORS skips them in keyboard-shortcuts.ts). So
+  // MACOS_MENU_OWNED_ACCELERATORS skips them in keyboard-shortcuts.ts). So
   // the menu path must close this window too: it broadcasts `menu-action`,
   // and we act on `close_connection` only while THIS window has focus — the
   // mirror image of the main window's document.hasFocus() guard.

--- a/src/__tests__/keyboard-shortcuts-global.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-global.test.tsx
@@ -64,6 +64,12 @@ function splitCtrlW(handler: () => void): KeyboardShortcut {
   return { key: 'w', ctrlKey: true, handler, description: 'Close active tab' };
 }
 
+function backgroundSummonShortcut(handler: () => void): KeyboardShortcut {
+  // Stands in for a future app-specific background summon key: explicitly
+  // opted in to keep its OS registration while the window is blurred.
+  return { key: 'n', ctrlKey: true, globalInBackground: true, handler, description: 'Summon' };
+}
+
 function focusElement(el: HTMLElement) {
   el.focus();
   document.dispatchEvent(new FocusEvent('focusin', { bubbles: true }));
@@ -76,9 +82,14 @@ function focusBody() {
 }
 
 // Default: no sibling windows exist (single-window app / tests).
+let platformSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
   mockedGetAllWebviewWindows.mockReset();
   mockedGetAllWebviewWindows.mockResolvedValue([]);
+  // Pin a non-macOS host so the macOS menu-ownership paths stay dormant unless
+  // a test explicitly overrides via platformSpy below. (jsdom's own default is
+  // platform-dependent; forcing it removes any ambiguity.)
+  platformSpy = vi.spyOn(navigator, 'platform', 'get').mockReturnValue('Linux x86_64');
 });
 
 afterEach(() => {
@@ -87,6 +98,7 @@ afterEach(() => {
   window.dispatchEvent(new Event('focus'));
   cleanup();
   focusBody();
+  platformSpy.mockRestore();
   vi.clearAllMocks();
 });
 
@@ -177,15 +189,106 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
   });
 
   it('skips the macOS-native menu accelerators on macOS', async () => {
-    const platformSpy = vi.spyOn(navigator, 'platform', 'get').mockReturnValue('MacIntel');
+    platformSpy.mockReturnValue('MacIntel');
+
+    const zenCtrlZ = (): KeyboardShortcut => ({
+      key: 'z',
+      ctrlKey: true,
+      ignoreInTerminal: true,
+      handler: vi.fn(),
+      description: 'Toggle Zen Mode',
+    });
+    const sidebarCtrlM = (): KeyboardShortcut => ({
+      key: 'm',
+      ctrlKey: true,
+      ignoreInTerminal: true,
+      handler: vi.fn(),
+      description: 'Toggle Monitor Panel',
+    });
+    // A user-customized Ctrl+Shift+Z binding would map to the Redo menu chord
+    // (Cmd+Shift+Z) — it too must stay out of OS registration.
+    const redoShiftZ = (): KeyboardShortcut => ({
+      key: 'z',
+      ctrlKey: true,
+      shiftKey: true,
+      handler: vi.fn(),
+      description: 'Custom Ctrl+Shift+Z',
+    });
 
     await act(async () => {
-      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn()), zenCtrlZ(), sidebarCtrlM(), redoShiftZ()]} />);
     });
 
     expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
     expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
-    platformSpy.mockRestore();
+    // All macOS-native menu chords stay exclusive to the menu — nothing with
+    // a menu-owned Cmd form (including the Cmd+Shift+Z Redo chord) is
+    // registered as an OS global hotkey.
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Shift+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+M', expect.any(Function));
+  });
+
+  it('drives menu-conflicting bindings from an in-window keydown on macOS (⌃Z/⌃M)', async () => {
+    platformSpy.mockReturnValue('MacIntel');
+    const onZ = vi.fn();
+    const zenShortcut: KeyboardShortcut = {
+      key: 'z',
+      ctrlKey: true,
+      ignoreInTerminal: true,
+      handler: onZ,
+      description: 'Toggle Zen Mode',
+    };
+    // A menu-conflicting binding WITHOUT ignoreInTerminal (e.g. a user binding
+    // used for a non-terminal-adjacent action) still fires inside the
+    // terminal — only `ignoreInTerminal` bindings yield to the remote shell.
+    const onShiftZ = vi.fn();
+    const redoFallback: KeyboardShortcut = {
+      key: 'z',
+      ctrlKey: true,
+      shiftKey: true,
+      handler: onShiftZ,
+      description: 'Custom Ctrl+Shift+Z',
+    };
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[zenShortcut, redoFallback]} />);
+    });
+
+    // Never registered with the OS — the Cmd chord belongs to the native Undo
+    // menu, and macOS menu items stay exclusive.
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Shift+Z', expect.any(Function));
+
+    // Physical Control (⌃Z) fires the in-window handler.
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
+    expect(onZ).toHaveBeenCalledOnce();
+
+    // Cmd+Z is not the degraded binding — the keystroke must reach the Undo
+    // menu, not toggle Zen mode.
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', ctrlKey: false, metaKey: true, bubbles: true }),
+    );
+    expect(onZ).toHaveBeenCalledOnce();
+
+    // The Cmd+Shift+Z (Redo) fallback fires ⌃⇧Z from the same DOM listener.
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, shiftKey: true, bubbles: true }),
+    );
+    expect(onShiftZ).toHaveBeenCalledOnce();
+
+    // Inside the terminal the binding yields to the remote shell — dispatch
+    // from the focused textarea so the listener sees a real input target.
+    const terminalTextarea = document.querySelector<HTMLElement>('[data-testid="terminal-textarea"]')!;
+    focusElement(terminalTextarea);
+    terminalTextarea.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
+    expect(onZ).toHaveBeenCalledOnce();
+
+    // The non-ignoreInTerminal binding does fire inside the terminal.
+    terminalTextarea.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, shiftKey: true, bubbles: true }),
+    );
+    expect(onShiftZ).toHaveBeenCalledTimes(2);
   });
 
   it('does not register shortcuts without modifiers', async () => {
@@ -211,7 +314,7 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
   });
 
-  it('registers everything while the window is blurred, then re-applies the element context on focus', async () => {
+  it('unregisters convention-key defaults while the window is blurred, then re-applies the element context on focus', async () => {
     await act(async () => {
       render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
     });
@@ -221,16 +324,68 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
     mockedUnregister.mockClear();
 
-    // App goes to the background → everything stays registered (global
-    // semantics), even with a terminal still focused inside the webview.
+    // App goes to the background → default bindings are convention keys and
+    // must not hijack the foreground app (issues #130/#144): everything gets
+    // unregistered, even with a terminal still focused inside the webview.
+    // (Ctrl+B was already dropped by the terminal context above, so only
+    // Ctrl+W is observed being unregistered here.)
     window.dispatchEvent(new Event('blur'));
-    expect(mockedUnregister).not.toHaveBeenCalled();
-    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
 
     // App returns to the foreground → element context applies again.
     window.dispatchEvent(new Event('focus'));
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+  });
+
+  it('keeps only background-opted shortcuts registered while the window is blurred', async () => {
+    await act(async () => {
+      render(
+        <GlobalShortcutHarness
+          shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn()), backgroundSummonShortcut(vi.fn())]}
+        />,
+      );
+    });
+
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+N', expect.any(Function));
+
+    // App goes to the background → only the shortcut explicitly opted in via
+    // `globalInBackground` keeps its OS registration; convention keys
+    // (Ctrl+B sidebar, Ctrl+W close tab) are released to the foreground app.
+    window.dispatchEvent(new Event('blur'));
     expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
-    expect(mockedUnregister).not.toHaveBeenCalledWith('CommandOrControl+W');
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
+    expect(mockedUnregister).not.toHaveBeenCalledWith('CommandOrControl+N');
+
+    // Focus returns → everything registers again.
+    window.dispatchEvent(new Event('focus'));
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+  });
+
+  it('does not re-register convention keys when the window becomes visible but stays blurred', async () => {
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+    });
+
+    // App goes to the background → everything unregistered (default config).
+    window.dispatchEvent(new Event('blur'));
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
+
+    // An occluding window moves away: visibility flips to visible while the
+    // window is STILL blurred. Treating visible as focused here would
+    // re-register the convention-key defaults and revive the hijack
+    // (#130/#144) until the next real focus event. Drive the hidden=false
+    // branch explicitly (jsdom's document.hidden is otherwise always true,
+    // which would make this test pass under the old `!document.hidden` logic).
+    mockedRegister.mockClear();
+    const hiddenSpy = vi.spyOn(document, 'hidden', 'get').mockReturnValue(false);
+    const hasFocusSpy = vi.spyOn(document, 'hasFocus').mockReturnValue(false);
+    document.dispatchEvent(new Event('visibilitychange'));
+    hiddenSpy.mockRestore();
+    hasFocusSpy.mockRestore();
+
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
   });
 
   it('re-syncs on the Tauri onFocusChanged signal', async () => {
@@ -242,23 +397,27 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
     mockedUnregister.mockClear();
 
-    // Window focus lost (authoritative webview signal) → register everything.
+    // Window focus lost (authoritative webview signal) → unregister the
+    // convention-key default bindings (background hijack fix, #130/#144).
+    // (Ctrl+B was already dropped by the terminal context above.)
     expect(focusChangedCaptured.handler).toBeTypeOf('function');
     act(() => {
       focusChangedCaptured.handler!(false);
     });
-    expect(mockedUnregister).not.toHaveBeenCalled();
-    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
 
-    // Window focused again while the terminal is still focused → drop the
-    // terminal-critical shortcut again.
+    // Window focused again while the terminal is still focused → the
+    // terminal context applies: Ctrl+B stays dropped (must NOT be silently
+    // re-registered), Ctrl+W re-registers.
+    mockedRegister.mockClear();
     act(() => {
       focusChangedCaptured.handler!(true);
     });
-    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
   });
 
-  it('keeps shortcuts registered while blurred when no sibling window of the app is focused', async () => {
+  it('unregisters everything while blurred when no sibling window is focused and nothing opted in', async () => {
     mockedGetAllWebviewWindows.mockResolvedValue([
       { label: 'main', isFocused: vi.fn(async () => false) },
     ]);
@@ -273,13 +432,13 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     mockedUnregister.mockClear();
 
     // App goes to the background (another app, not a sibling window) →
-    // everything stays registered so the shortcuts keep firing globally.
+    // default bindings are convention keys: everything gets unregistered so
+    // the foreground app keeps its keys (issues #130/#144).
+    // (Ctrl+B was already dropped by the terminal context above.)
     window.dispatchEvent(new Event('blur'));
     await act(async () => {});
 
-    expect(mockedUnregister).not.toHaveBeenCalled();
-    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
-    expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
   });
 
   it('unregisters every shortcut while a sibling window (e.g. the file-viewer editor) has focus', async () => {
@@ -313,7 +472,7 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     expect(handlerCalls).toHaveLength(2); // mount + refocus; each holds a fresh handler
   });
 
-  it('re-registers shortcuts when a sibling window closes while the app is backgrounded', async () => {
+  it('re-registers only background-opted shortcuts when a sibling window closes while the app is backgrounded', async () => {
     vi.useFakeTimers();
     try {
       mockedGetAllWebviewWindows.mockResolvedValue([
@@ -322,22 +481,31 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
       ]);
 
       await act(async () => {
-        render(<GlobalShortcutHarness shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn())]} />);
+        render(
+          <GlobalShortcutHarness
+            shortcuts={[layoutCtrlB(vi.fn()), splitCtrlW(vi.fn()), backgroundSummonShortcut(vi.fn())]}
+          />,
+        );
       });
 
       window.dispatchEvent(new Event('blur'));
       await act(async () => {});
       expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+W');
+      expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+N');
 
       // The file-viewer window closes while another app stays foreground. The
-      // blur-time polling notices and restores the background semantics.
+      // blur-time polling notices and re-registers only the shortcuts that
+      // opted in via `globalInBackground` — convention keys stay unregistered.
       mockedGetAllWebviewWindows.mockResolvedValue([
         { label: 'main', isFocused: vi.fn(async () => false) },
       ]);
+      mockedRegister.mockClear();
       vi.advanceTimersByTime(2000);
       await act(async () => {});
 
-      expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+      expect(mockedRegister).toHaveBeenCalledWith('CommandOrControl+N', expect.any(Function));
+      expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+W', expect.any(Function));
+      expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+B', expect.any(Function));
     } finally {
       vi.useRealTimers();
     }

--- a/src/__tests__/keyboard-shortcuts-global.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-global.test.tsx
@@ -251,9 +251,6 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     // A menu-conflicting binding WITHOUT ignoreInTerminal (e.g. a user binding
     // used for a non-terminal-adjacent action) still fires inside the
     // terminal — only `ignoreInTerminal` bindings yield to the remote shell.
-    // A menu-conflicting binding WITHOUT ignoreInTerminal (e.g. a user binding
-    // used for a non-terminal-adjacent action) still fires inside the
-    // terminal — only `ignoreInTerminal` bindings yield to the remote shell.
     const onShiftZ = vi.fn();
     const redoFallback: KeyboardShortcut = {
       key: 'z',

--- a/src/__tests__/keyboard-shortcuts-global.test.tsx
+++ b/src/__tests__/keyboard-shortcuts-global.test.tsx
@@ -11,9 +11,15 @@ vi.mock('@tauri-apps/api/core', () => ({
   isTauri: () => true,
 }));
 
+// `getCurrentWindow().isFocused()` probe added with the initial-focus
+// correction; tests that don't care pin it to `true` (the optimistic default)
+// in beforeEach. Resolvable to `false` to exercise the blurred-set correction.
+const isFocusedMock = vi.hoisted(() => vi.fn(async (): Promise<boolean> => true));
+
 vi.mock('@tauri-apps/api/window', () => ({
   getCurrentWindow: () => ({
     label: 'main',
+    isFocused: isFocusedMock,
     onFocusChanged: vi.fn(async (handler: (event: { payload: boolean }) => void) => {
       focusChangedCaptured.handler = (payload: boolean) => handler({ payload });
       return vi.fn();
@@ -84,11 +90,14 @@ function focusBody() {
 // Default: no sibling windows exist (single-window app / tests).
 let platformSpy: ReturnType<typeof vi.spyOn>;
 beforeEach(() => {
+  isFocusedMock.mockReset();
+  isFocusedMock.mockResolvedValue(true);
   mockedGetAllWebviewWindows.mockReset();
   mockedGetAllWebviewWindows.mockResolvedValue([]);
   // Pin a non-macOS host so the macOS menu-ownership paths stay dormant unless
-  // a test explicitly overrides via platformSpy below. (jsdom's own default is
-  // platform-dependent; forcing it removes any ambiguity.)
+  // a test explicitly overrides via platformSpy below. (jsdom always reports
+  // an empty platform string, never the host OS — pinning makes the intent
+  // explicit rather than relying on that accident.)
   platformSpy = vi.spyOn(navigator, 'platform', 'get').mockReturnValue('Linux x86_64');
 });
 
@@ -242,6 +251,9 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
     // A menu-conflicting binding WITHOUT ignoreInTerminal (e.g. a user binding
     // used for a non-terminal-adjacent action) still fires inside the
     // terminal — only `ignoreInTerminal` bindings yield to the remote shell.
+    // A menu-conflicting binding WITHOUT ignoreInTerminal (e.g. a user binding
+    // used for a non-terminal-adjacent action) still fires inside the
+    // terminal — only `ignoreInTerminal` bindings yield to the remote shell.
     const onShiftZ = vi.fn();
     const redoFallback: KeyboardShortcut = {
       key: 'z',
@@ -250,19 +262,33 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
       handler: onShiftZ,
       description: 'Custom Ctrl+Shift+Z',
     };
+    const onM = vi.fn();
+    const sidebarCtrlM: KeyboardShortcut = {
+      key: 'm',
+      ctrlKey: true,
+      ignoreInTerminal: true,
+      handler: onM,
+      description: 'Toggle Monitor Panel',
+    };
 
     await act(async () => {
-      render(<GlobalShortcutHarness shortcuts={[zenShortcut, redoFallback]} />);
+      render(<GlobalShortcutHarness shortcuts={[zenShortcut, redoFallback, sidebarCtrlM]} />);
     });
 
     // Never registered with the OS — the Cmd chord belongs to the native Undo
     // menu, and macOS menu items stay exclusive.
     expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Z', expect.any(Function));
     expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+Shift+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('CommandOrControl+M', expect.any(Function));
 
     // Physical Control (⌃Z) fires the in-window handler.
     window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
     expect(onZ).toHaveBeenCalledOnce();
+
+    // Physical Control (⌃M) fires the in-window handler too — the other
+    // degraded chord (⌘M belongs to the Minimize menu).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'm', ctrlKey: true, bubbles: true }));
+    expect(onM).toHaveBeenCalledOnce();
 
     // Cmd+Z is not the degraded binding — the keystroke must reach the Undo
     // menu, not toggle Zen mode.
@@ -289,6 +315,81 @@ describe('useKeyboardShortcuts in Tauri (global-shortcut plugin path)', () => {
       new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, shiftKey: true, bubbles: true }),
     );
     expect(onShiftZ).toHaveBeenCalledTimes(2);
+  });
+
+  it('keeps explicit-Cmd spellings out of OS registration on macOS', async () => {
+    platformSpy.mockReturnValue('MacIntel');
+    // The shortcut editor accepts explicit Cmd/Command/Meta spellings, which
+    // map to the `Command` accelerator — the same physical chord on macOS as
+    // CommandOrControl. They must hit the same menu-ownership exclusions, or
+    // e.g. a user-configured Cmd+W would still be OS-registered and fire
+    // alongside the native menu's Close action.
+    await act(async () => {
+      render(
+        <GlobalShortcutHarness
+          shortcuts={[
+            { key: 'w', metaKey: true, handler: vi.fn(), description: 'Close (Cmd+W)' },
+            { key: 'z', metaKey: true, ignoreInTerminal: true, handler: vi.fn(), description: 'Zen (Cmd+Z)' },
+            { key: 'z', metaKey: true, shiftKey: true, handler: vi.fn(), description: 'Custom (Cmd+Shift+Z)' },
+            { key: 'n', metaKey: true, globalInBackground: true, handler: vi.fn(), description: 'Summon (Cmd+N)' },
+          ]}
+        />,
+      );
+    });
+
+    expect(mockedRegister).not.toHaveBeenCalledWith('Command+W', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('Command+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('Command+Shift+Z', expect.any(Function));
+    expect(mockedRegister).not.toHaveBeenCalledWith('Command+N', expect.any(Function));
+  });
+
+  it('drives an explicit-Cmd Zen binding from the physical-Control chord on macOS', async () => {
+    platformSpy.mockReturnValue('MacIntel');
+    const onZ = vi.fn();
+    const zenCmdZ: KeyboardShortcut = {
+      key: 'z',
+      metaKey: true,
+      ignoreInTerminal: true,
+      handler: onZ,
+      description: 'Toggle Zen Mode (Cmd+Z)',
+    };
+
+    await act(async () => {
+      render(<GlobalShortcutHarness shortcuts={[zenCmdZ]} />);
+    });
+
+    // Not OS-registered — ⌘Z belongs to the Undo menu.
+    expect(mockedRegister).not.toHaveBeenCalledWith('Command+Z', expect.any(Function));
+
+    // The physical Control variant (⌃Z) fires the handler — the degraded
+    // binding matches the physical key the label advertises (⌃).
+    window.dispatchEvent(new KeyboardEvent('keydown', { key: 'z', ctrlKey: true, bubbles: true }));
+    expect(onZ).toHaveBeenCalledOnce();
+
+    // The actual Cmd chord reaches the Undo menu, not the handler.
+    window.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'z', ctrlKey: false, metaKey: true, bubbles: true }),
+    );
+    expect(onZ).toHaveBeenCalledOnce();
+  });
+
+  it('applies blurred-set semantics when mounted without window focus', async () => {
+    // A webview launched in the background (open -g, autostart) mounts with
+    // the optimistic focused set; the isFocused() probe corrects it to the
+    // blurred set without waiting for the first focus event.
+    isFocusedMock.mockResolvedValue(false);
+    const onB = vi.fn();
+    await act(async () => {
+      render(
+        <GlobalShortcutHarness shortcuts={[layoutCtrlB(onB), backgroundSummonShortcut(vi.fn())]} />,
+      );
+    });
+
+    // The mount-time probe corrected the registrations: Ctrl+B (a default
+    // convention key) unregisters, the explicit background opt-in stays.
+    expect(mockedUnregister).toHaveBeenCalledWith('CommandOrControl+B');
+    expect(mockedUnregister).not.toHaveBeenCalledWith('CommandOrControl+N');
+    expect(mockedRegister).toHaveBeenLastCalledWith('CommandOrControl+N', expect.any(Function));
   });
 
   it('does not register shortcuts without modifiers', async () => {

--- a/src/__tests__/keyboard-shortcuts.test.ts
+++ b/src/__tests__/keyboard-shortcuts.test.ts
@@ -346,6 +346,26 @@ describe('formatKeyboardShortcut', () => {
     expect(formatKeyboardShortcut('Ctrl+Shift+ArrowRight', true)).toBe('⌘+⇧+→');
     expect(formatKeyboardShortcut('Alt+W', true)).toBe('⌥+W');
   });
+
+  it('shows ⌃ for macOS menu-degraded chords (Zen/sidebar and explicit-Cmd spellings)', () => {
+    const platformSpy = vi.spyOn(navigator, 'platform', 'get').mockReturnValue('MacIntel');
+    try {
+      // The degraded branch (new in this PR): ⌘Z/⌘M belong to the native menu,
+      // the binding fires as the physical-Control variant — labels show ⌃.
+      expect(formatKeyboardShortcut('Ctrl+Z', true)).toBe('⌃+Z');
+      expect(formatKeyboardShortcut('Ctrl+Shift+Z', true)).toBe('⌃+⇧+Z');
+      expect(formatKeyboardShortcut('Ctrl+M', true)).toBe('⌃+M');
+      // An explicit-Cmd spelling of the same chords degrades identically.
+      expect(formatKeyboardShortcut('Cmd+Z', true)).toBe('⌃+Z');
+      expect(formatKeyboardShortcut('Cmd+Shift+Z', true)).toBe('⌃+⇧+Z');
+      expect(formatKeyboardShortcut('Super+Z', true)).toBe('⌃+Z');
+      // Non-degraded chords keep their ⌘ labels, explicit-Cmd included.
+      expect(formatKeyboardShortcut('Ctrl+B', true)).toBe('⌘+B');
+      expect(formatKeyboardShortcut('Cmd+W', true)).toBe('⌘+W');
+    } finally {
+      platformSpy.mockRestore();
+    }
+  });
 });
 
 describe('toAccelerator', () => {

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -122,7 +122,11 @@ export function formatKeyboardShortcut(shortcut: string, isMac: boolean): string
         case 'meta':
         case 'cmd':
         case 'command':
-          return isMac ? '⌘' : 'Meta';
+        case 'super':
+          // An explicit-Cmd binding in a degraded chord shows ⌃ too — its Cmd
+          // form belongs to the menu and the physical-Control variant is what
+          // the user actually presses (matches `menuConflictMatchMods`).
+          return isMac ? (macDegraded ? '⌃' : '⌘') : 'Meta';
         case 'arrowup':
           return '↑';
         case 'arrowdown':
@@ -342,6 +346,37 @@ function currentPlatformIsMac(): boolean {
 }
 
 /**
+ * Canonical macOS ⌘ chord of a binding, in the `CommandOrControl+…` spelling
+ * the menu-ownership sets use. On macOS a `CommandOrControl` (Ctrl-based) and
+ * an explicit `Cmd`/`Command` binding resolve to the same physical ⌘ chord,
+ * so both user spellings must hit the same menu-ownership exclusions —
+ * otherwise a user-configured `Cmd+W`/`Cmd+Z` would still be OS-registered
+ * and double-fire alongside the native menu. `null` when the binding has no
+ * ⌘ modifier at all (including modifier-less chords like F5, which the menu
+ * owns for Reconnect and which `desiredAccelerators` matches via `accel`).
+ */
+function macMenuChord(shortcut: {
+  key: string;
+  ctrlKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+  metaKey?: boolean;
+}): string | null {
+  if (!(shortcut.ctrlKey ?? false) && !(shortcut.metaKey ?? false)) {
+    return null;
+  }
+  const parts = ['CommandOrControl'];
+  if (shortcut.shiftKey) {
+    parts.push('Shift');
+  }
+  if (shortcut.altKey) {
+    parts.push('Option');
+  }
+  parts.push(toAcceleratorKey(shortcut.key));
+  return parts.join('+');
+}
+
+/**
  * Accelerator a shortcut would use as an OS global shortcut. On macOS the
  * Cmd chords owned by the native menu (see `MACOS_MENU_OWNED_ACCELERATORS`)
  * are excluded from global registration entirely — the menu processes them
@@ -370,14 +405,8 @@ function isMacMenuConflictingShortcut(shortcut: KeyboardShortcut): boolean {
   if (!currentPlatformIsMac()) {
     return false;
   }
-  const accel = toAcceleratorFromParsed({
-    key: shortcut.key,
-    ctrlKey: shortcut.ctrlKey ?? false,
-    shiftKey: shortcut.shiftKey ?? false,
-    altKey: shortcut.altKey ?? false,
-    metaKey: shortcut.metaKey ?? false,
-  });
-  return accel !== null && MACOS_MENU_CONFLICT_DEGRADE.has(accel);
+  const chord = macMenuChord(shortcut);
+  return chord !== null && MACOS_MENU_CONFLICT_DEGRADE.has(chord);
 }
 
 /**
@@ -389,8 +418,38 @@ function isMacMenuDegradedShortcut(shortcut: string): boolean {
   if (!currentPlatformIsMac()) {
     return false;
   }
-  const accel = toAccelerator(shortcut);
-  return accel !== null && MACOS_MENU_CONFLICT_DEGRADE.has(accel);
+  const parsed = parseKeyboardShortcut(shortcut);
+  const chord = parsed ? macMenuChord(parsed) : null;
+  return chord !== null && MACOS_MENU_CONFLICT_DEGRADE.has(chord);
+}
+
+/**
+ * The modifier expectations the in-window keydown listener matches against for
+ * a menu-conflicting binding. An explicit-Cmd chord (`Cmd+Z`, `Cmd+Shift+Z`)
+ * degrades to the physical-Control variant (⌃Z, ⌃⇧Z) — its Cmd form belongs
+ * to the native menu, the label shows ⌃ (see `formatKeyboardShortcut`), so the
+ * listener matches the physical Control key the label advertises.
+ */
+function menuConflictMatchMods(shortcut: KeyboardShortcut): {
+  ctrlKey: boolean;
+  metaKey: boolean;
+  shiftKey: boolean;
+  altKey: boolean;
+} {
+  if ((shortcut.metaKey ?? false) && !(shortcut.ctrlKey ?? false)) {
+    return {
+      ctrlKey: true,
+      metaKey: false,
+      shiftKey: shortcut.shiftKey ?? false,
+      altKey: shortcut.altKey ?? false,
+    };
+  }
+  return {
+    ctrlKey: shortcut.ctrlKey ?? false,
+    metaKey: shortcut.metaKey ?? false,
+    shiftKey: shortcut.shiftKey ?? false,
+    altKey: shortcut.altKey ?? false,
+  };
 }
 
 /**
@@ -558,8 +617,15 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       // macOS: the native menu owns these Cmd chords (⌘N new connection, ⌘W
       // close, … — and ⌘Z/⌘M whose features degrade to the in-window ⌃
       // listener below). Registering them as OS global hotkeys would
-      // double-fire alongside the menu.
-      if (currentPlatformIsMac() && MACOS_MENU_OWNED_ACCELERATORS.has(accel)) {
+      // double-fire alongside the menu. `macMenuChord` collapses the
+      // `CommandOrControl` and explicit-`Cmd` spellings (the same physical ⌘
+      // chord on macOS, so a user-configured Cmd+W degrades too); F5 is a
+      // modifier-less menu chord matched via its accelerator directly.
+      const menuChord = macMenuChord(shortcut);
+      if (
+        currentPlatformIsMac() &&
+        (accel === 'F5' || (menuChord !== null && MACOS_MENU_OWNED_ACCELERATORS.has(menuChord)))
+      ) {
         continue;
       }
       if (!byAccelerator.has(accel)) {
@@ -670,11 +736,12 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
         continue;
       }
       const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
+      const mods = menuConflictMatchMods(shortcut);
       const modsMatch =
-        event.ctrlKey === (shortcut.ctrlKey ?? false) &&
-        event.metaKey === (shortcut.metaKey ?? false) &&
-        event.shiftKey === (shortcut.shiftKey ?? false) &&
-        event.altKey === (shortcut.altKey ?? false);
+        event.ctrlKey === mods.ctrlKey &&
+        event.metaKey === mods.metaKey &&
+        event.shiftKey === mods.shiftKey &&
+        event.altKey === mods.altKey;
       if (keyMatch && modsMatch) {
         event.preventDefault();
         event.stopPropagation();

--- a/src/lib/keyboard-shortcuts.ts
+++ b/src/lib/keyboard-shortcuts.ts
@@ -13,6 +13,15 @@ export interface KeyboardShortcut {
   altKey?: boolean;
   metaKey?: boolean;
   ignoreInTerminal?: boolean;
+  /**
+   * Keep this shortcut registered as an OS global shortcut while the app
+   * window is in the background. Opt-in: default bindings are cross-app
+   * convention keys (Ctrl+W, Ctrl+Z, Ctrl+Tab, ...), and registering those
+   * system-wide hijacks them from whichever app is actually focused
+   * (issues #130/#144). Only opt in for keys that summon this app without
+   * colliding with other applications' muscle memory.
+   */
+  globalInBackground?: boolean;
   handler: () => void;
   description: string;
 }
@@ -92,6 +101,11 @@ function normalizeShortcutKey(key: string): string {
 }
 
 export function formatKeyboardShortcut(shortcut: string, isMac: boolean): string {
+  // macOS: bindings whose Cmd form collides with a different menu feature
+  // (⌘Z is Undo, ⌘M is Minimize) fire as the physical-Control variant — show
+  // ⌃ so the label matches what the user actually presses. All other bindings
+  // keep showing their ⌘/Ctrl chord as configured.
+  const macDegraded = isMac && isMacMenuDegradedShortcut(shortcut);
   return shortcut
     .split('+')
     .map(part => {
@@ -99,7 +113,7 @@ export function formatKeyboardShortcut(shortcut: string, isMac: boolean): string
         case 'ctrl':
         case 'control':
         case 'cmdorctrl':
-          return isMac ? '⌘' : 'Ctrl';
+          return isMac ? (macDegraded ? '⌃' : '⌘') : 'Ctrl';
         case 'shift':
           return isMac ? '⇧' : 'Shift';
         case 'alt':
@@ -323,6 +337,18 @@ export function toAccelerator(shortcut: string): string | null {
   return parsed ? toAcceleratorFromParsed(parsed) : null;
 }
 
+function currentPlatformIsMac(): boolean {
+  return navigator.platform.toUpperCase().includes('MAC');
+}
+
+/**
+ * Accelerator a shortcut would use as an OS global shortcut. On macOS the
+ * Cmd chords owned by the native menu (see `MACOS_MENU_OWNED_ACCELERATORS`)
+ * are excluded from global registration entirely — the menu processes them
+ * (the exclusion itself happens in `desiredAccelerators`). This function only
+ * stringifies a binding; register here is the "live" accelerator solely for
+ * non-menu-owned bindings.
+ */
 function acceleratorForShortcut(shortcut: KeyboardShortcut): string | null {
   const parsed: ParsedKeyboardShortcut = {
     key: shortcut.key,
@@ -335,12 +361,47 @@ function acceleratorForShortcut(shortcut: KeyboardShortcut): string | null {
 }
 
 /**
- * Native macOS menu key equivalents (defined in `src-tauri/src/lib.rs`
- * `build_app_menu`). macOS processes those through its menu system whenever
- * the app is focused, so also registering them as global shortcuts would
- * trigger both the menu item action and the shortcut handler.
+ * True when this shortcut's Cmd form collides with a native macOS menu key
+ * (Cmd+Z Undo, Cmd+M Minimize) and the binding is therefore handled IN-WINDOW
+ * via a DOM keydown listener matching the physical Control key. The OS never
+ * registers it and the menu keeps the Cmd chord. Non-macOS: never.
  */
-const MACOS_NATIVE_MENU_ACCELERATORS = new Set([
+function isMacMenuConflictingShortcut(shortcut: KeyboardShortcut): boolean {
+  if (!currentPlatformIsMac()) {
+    return false;
+  }
+  const accel = toAcceleratorFromParsed({
+    key: shortcut.key,
+    ctrlKey: shortcut.ctrlKey ?? false,
+    shiftKey: shortcut.shiftKey ?? false,
+    altKey: shortcut.altKey ?? false,
+    metaKey: shortcut.metaKey ?? false,
+  });
+  return accel !== null && MACOS_MENU_CONFLICT_DEGRADE.has(accel);
+}
+
+/**
+ * String-binding flavor of {@link isMacMenuConflictingShortcut} — used by
+ * `formatKeyboardShortcut` so labels show the physical-Control variant the
+ * user actually presses (⌃Z, ⌃M).
+ */
+function isMacMenuDegradedShortcut(shortcut: string): boolean {
+  if (!currentPlatformIsMac()) {
+    return false;
+  }
+  const accel = toAccelerator(shortcut);
+  return accel !== null && MACOS_MENU_CONFLICT_DEGRADE.has(accel);
+}
+
+/**
+ * Accelerators owned by the native macOS menus (defined in
+ * `src-tauri/src/lib.rs` `build_app_menu`). macOS processes these through its
+ * menu system whenever the app is focused, so they are never registered as OS
+ * global hotkeys — registering them would double-fire alongside the menu.
+ * Shift variants are included where the menu owns them too (Cmd+Shift+Z is
+ * Redo), and F5 for the menu's Reconnect item.
+ */
+const MACOS_MENU_OWNED_ACCELERATORS = new Set([
   'CommandOrControl+N',
   'CommandOrControl+S',
   'CommandOrControl+W',
@@ -348,7 +409,26 @@ const MACOS_NATIVE_MENU_ACCELERATORS = new Set([
   'CommandOrControl+D',
   'CommandOrControl+F',
   'CommandOrControl+L',
+  'CommandOrControl+Z',
+  'CommandOrControl+Shift+Z',
+  'CommandOrControl+M',
   'F5',
+]);
+
+/**
+ * The menu-owned chords whose Cmd form belongs to a DIFFERENT feature in the
+ * menu than the r-shell binding's action: Zen mode (⌘Z vs Undo) and right
+ * sidebar (⌘M vs Minimize). Their Cmd form is left to the menu, and on macOS
+ * they are handled in-window as the physical-Control variants ⌃Z / ⌃M via a
+ * DOM keydown listener (reliable for Control-characters, and inherently
+ * window-scoped so other apps are never affected). Cmd+Shift+Z (Redo) is
+ * included so a user who customizes a binding to Ctrl+Shift+Z gets the same
+ * in-window fallback instead of double-firing with the Redo menu item.
+ */
+const MACOS_MENU_CONFLICT_DEGRADE = new Set([
+  'CommandOrControl+Z',
+  'CommandOrControl+Shift+Z',
+  'CommandOrControl+M',
 ]);
 
 /**
@@ -379,13 +459,15 @@ function currentFocusContext(): FocusContext {
  * semantics) and so editable fields (settings inputs, dialogs) keep receiving
  * their keystrokes: while such an element has focus no shortcut is
  * registered, and while a terminal has focus only shortcuts without
- * `ignoreInTerminal` are. Element focus only applies while the app window is
- * focused — when the app is in the background everything is registered so
- * the shortcuts keep firing globally. The one exception is another window of
- * this same app (e.g. the file-viewer editor window): when such a sibling
- * window has focus the keyboard belongs to that window, so nothing is
- * registered here and OS-level shortcuts can't steal keystrokes from it
- * (Ctrl+W while typing in the editor must not close a terminal tab).
+ * `ignoreInTerminal` are. While the app window is in the background only
+ * shortcuts explicitly opted in via `globalInBackground` stay registered —
+ * default bindings are cross-app convention keys (Ctrl+W, Ctrl+Z, Ctrl+Tab,
+ * Ctrl+1..9) and would hijack them from whatever app is focused
+ * (issues #130/#144). The one exception is another window of this same app
+ * (e.g. the file-viewer editor window): when such a sibling window has focus
+ * the keyboard belongs to that window, so nothing is registered here and
+ * OS-level shortcuts can't steal keystrokes from it (Ctrl+W while typing in
+ * the editor must not close a terminal tab).
  * Accelerator duplicates are resolved in array order — the first shortcut
  * wins, on both registration and `ignoreInTerminal` exclusion — which
  * reproduces the DOM handler's first-match-wins behavior.
@@ -393,10 +475,9 @@ function currentFocusContext(): FocusContext {
 function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
   const registered = new Map<string, KeyboardShortcut>();
   const failed = new Set<string>();
-  const isMac = navigator.platform.toUpperCase().includes('MAC');
   // Element focus (terminal/editable) only matters while the app window is
-  // focused; when another app is in the foreground the shortcuts must stay
-  // registered so they keep firing globally.
+  // focused; when another app is in the foreground only shortcuts explicitly
+  // opted in via `globalInBackground` stay registered.
   let appFocused = true;
   // True while another window of this app (e.g. the file-viewer editor
   // window) has focus. The keyboard then belongs to that window — acting on
@@ -459,9 +540,10 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       return;
     }
     // This window lost focus: element focus no longer applies, so apply the
-    // "blurred" semantics (full registration — background operation) right
-    // away, then refine with an async sibling check. If a sibling window of
-    // this app owns the keyboard, everything gets unregistered on that check.
+    // "blurred" semantics (only `globalInBackground` shortcuts stay
+    // registered) right away, then refine with an async sibling check. If a
+    // sibling window of this app owns the keyboard, everything gets
+    // unregistered on that check.
     sync();
     void refreshSiblingFocus();
   };
@@ -473,7 +555,11 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       if (!accel) {
         continue;
       }
-      if (isMac && MACOS_NATIVE_MENU_ACCELERATORS.has(accel)) {
+      // macOS: the native menu owns these Cmd chords (⌘N new connection, ⌘W
+      // close, … — and ⌘Z/⌘M whose features degrade to the in-window ⌃
+      // listener below). Registering them as OS global hotkeys would
+      // double-fire alongside the menu.
+      if (currentPlatformIsMac() && MACOS_MENU_OWNED_ACCELERATORS.has(accel)) {
         continue;
       }
       if (!byAccelerator.has(accel)) {
@@ -488,7 +574,22 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       return new Map();
     }
 
-    const focus = appFocused ? currentFocusContext() : 'app';
+    if (!appFocused) {
+      // The app is in the background: default bindings are cross-app
+      // convention keys (Ctrl+W closes browser tabs, Ctrl+Z undoes,
+      // Ctrl+Tab/1..9 switch browser tabs) — registering them OS-wide would
+      // hijack them from whatever app is actually focused (issues #130/#144).
+      // Keep only shortcuts explicitly opted in as background-safe.
+      const background = new Map<string, KeyboardShortcut>();
+      for (const [accel, shortcut] of byAccelerator) {
+        if (shortcut.globalInBackground) {
+          background.set(accel, shortcut);
+        }
+      }
+      return background;
+    }
+
+    const focus = currentFocusContext();
     if (focus === 'editable') {
       return new Map();
     }
@@ -539,11 +640,54 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
 
   const handleWindowBlur = () => applyWindowFocus(false);
   const handleWindowFocus = () => applyWindowFocus(true);
-  const handleVisibilityChange = () => applyWindowFocus(!document.hidden);
+  // "Visible" is not "focused": a fully occluded window reports hidden=true
+  // while another app is foreground, and un-hiding it fires hidden=false while
+  // the window may STILL be blurred — assuming focus there would re-register
+  // the convention-key defaults and revive the background hijack (#130/#144).
+  // Only document.hidden=false consults the real focus state.
+  const handleVisibilityChange = () => applyWindowFocus(document.hidden ? false : document.hasFocus());
+
+  // macOS menu-conflicting bindings (Zen mode ⌃Z, right sidebar ⌃M): their
+  // Cmd chord belongs to a native menu command (Undo / Minimize), so the OS
+  // never registers them globally (see `desiredAccelerators`). They fire from
+  // this in-window keydown listener, matching the PHYSICAL Control key — a DOM
+  // listener runs only while this window is focused, so it can never hijack
+  // keys from another application.
+  const handleMenuConflictKeyDown = (event: KeyboardEvent) => {
+    const target = event.target;
+    // Editable fields always keep their keystrokes. A terminal keeps the
+    // keystroke for `ignoreInTerminal` bindings (matching the OS-registration
+    // semantics); other bindings fire here.
+    const inTerminal = isTerminalInputTarget(target);
+    if (isEditableTarget(target) && !inTerminal) {
+      return;
+    }
+    for (const shortcut of shortcutsRef.current) {
+      if (!isMacMenuConflictingShortcut(shortcut)) {
+        continue;
+      }
+      if (inTerminal && shortcut.ignoreInTerminal) {
+        continue;
+      }
+      const keyMatch = event.key.toLowerCase() === shortcut.key.toLowerCase();
+      const modsMatch =
+        event.ctrlKey === (shortcut.ctrlKey ?? false) &&
+        event.metaKey === (shortcut.metaKey ?? false) &&
+        event.shiftKey === (shortcut.shiftKey ?? false) &&
+        event.altKey === (shortcut.altKey ?? false);
+      if (keyMatch && modsMatch) {
+        event.preventDefault();
+        event.stopPropagation();
+        shortcut.handler();
+        return;
+      }
+    }
+  };
 
   window.addEventListener('blur', handleWindowBlur);
   window.addEventListener('focus', handleWindowFocus);
   document.addEventListener('visibilitychange', handleVisibilityChange);
+  window.addEventListener('keydown', handleMenuConflictKeyDown, { capture: true });
 
   // Authoritative focus signal for the webview window: some webview
   // runtimes do not translate OS window focus changes into DOM
@@ -553,8 +697,22 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
       .onFocusChanged(({ payload }) => {
         applyWindowFocus(payload);
       })
-      .then((unlisten) => {
+      .then(async (unlisten) => {
         unlistenFocusChanged = unlisten;
+        // The listener above only fires on CHANGES. The initial mount sync()
+        // registers the full focused set optimistically; probe the real focus
+        // state once so a webview launched in the background (open -g,
+        // autostart) corrects itself to the blurred set without waiting for
+        // its first focus event.
+        try {
+          const focused = await getCurrentWindow().isFocused();
+          if (focused === false) {
+            applyWindowFocus(false);
+          }
+        } catch {
+          // isFocused unavailable (older runtimes / tests): keep the
+          // optimistic default.
+        }
       })
       .catch(() => {});
   } catch {
@@ -574,6 +732,7 @@ function registerGlobalShortcuts(shortcutsRef: RefObject<KeyboardShortcut[]>) {
     window.removeEventListener('blur', handleWindowBlur);
     window.removeEventListener('focus', handleWindowFocus);
     document.removeEventListener('visibilitychange', handleVisibilityChange);
+    window.removeEventListener('keydown', handleMenuConflictKeyDown, { capture: true });
     unlistenFocusChanged?.();
     void unregisterAll().catch(() => {});
   };
@@ -635,10 +794,11 @@ function registerDomKeydown(shortcutsRef: RefObject<KeyboardShortcut[]>) {
  * Similar to VS Code's keyboard shortcuts system
  *
  * In the Tauri app shortcuts are registered with the OS through
- * tauri-plugin-global-shortcut, so they fire even while the app is in the
- * background (except when a terminal or an editable field has focus, see
- * `registerGlobalShortcuts`). In browser dev mode (no Tauri backend) a window
- * keydown listener keeps shortcuts working.
+ * tauri-plugin-global-shortcut and fire while the app is focused (with the
+ * terminal/editable-field caveats of `registerGlobalShortcuts`); while the
+ * app is in the background only shortcuts explicitly opted in via
+ * `globalInBackground` stay registered. In browser dev mode (no Tauri
+ * backend) a window keydown listener keeps shortcuts working.
  */
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boolean = true) {
   const shortcutsRef = useRef(shortcuts);
@@ -664,6 +824,7 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[], enabled: boo
     }
     return accelerators.join('|');
   }, [shortcuts]);
+
 
   useEffect(() => {
     if (!enabled) {


### PR DESCRIPTION
## Summary

Fixes #130 and #144. When r-shell is in the background, its OS-registered global shortcuts hijacked keys from whatever app is actually focused — Ctrl+W closed the user's browser tab (#130), Ctrl/Cmd+Z broke undo in other apps (#144). On macOS, the Cmd forms of Zen mode (⌘Z) and the right sidebar (⌘M) also collided with the native Undo / Minimize menu commands.

## Root cause

PR #110 registered every default binding as an OS global shortcut and kept them all registered while the app was blurred ("background operation"). But the default bindings are cross-app convention keys (Ctrl+W, Ctrl+Z, Ctrl+Tab, Ctrl+1..9), so registering them system-wide steals them from the focused app.

## Changes

- **Blur unregisters convention-key defaults.** While the app window is blurred, only shortcuts explicitly opted in via the new `globalInBackground` flag stay registered (default: none). Other apps keep their keys; #130/#144 fixed.
- **macOS menu-owned chords are never OS-registered.** ⌘N/S/W/T/D/F/L, F5, and ⌘Z/⌘Shift+Z/⌘M (native menu commands incl. Undo / Redo / Minimize) are left to the menu, avoiding double-fire.
- **Explicit-Cmd spellings hit the same exclusions.** `macMenuChord()` normalizes explicit `Cmd`/`Command`/`Meta`/`Super` spellings into the canonical `CommandOrControl` chord, so a user-configured `Cmd+W`/`Cmd+Z` is excluded from OS registration just like the `Ctrl` spelling (review follow-up).
- **Zen / right sidebar degrade to in-window ⌃Z / ⌃M.** Their Cmd form belongs to Undo/Minimize, so on macOS they fire from a DOM keydown listener matching the physical Control key — reliable for control-characters and inherently window-scoped (never affects other apps). The listener yields to editable fields and, for `ignoreInTerminal` bindings, to the terminal. Degraded bindings match the physical Control chord regardless of spelling.
- **`formatKeyboardShortcut` shows ⌃** for degraded chords — Ctrl and explicit-Cmd/Super spellings alike — so labels match what the user actually presses.

## Behavior matrix

| State | Registered |
|---|---|
| Focused, no terminal/editable focus | all (minus macOS menu-owned) |
| Terminal focused | all minus `ignoreInTerminal` |
| Editable focused | none |
| **Blurred** | **only `globalInBackground`** |
| Blurred + sibling window focused | none |

## Testing

- 21 keyboard-shortcut tests (blur semantics, macOS menu ownership, explicit-Cmd degradation, in-window ⌃Z/⌃M fallback, background-launch `isFocused()` correction), 776 total pass
- `tsc --noEmit`, `eslint`, `pnpm i18n:check` clean
- Manual: ⌃Z/⌃M toggle Zen/right sidebar in-app; Cmd+Z/Cmd+M go to Undo/Minimize; other apps' Cmd+Z/Cmd+W/Ctrl+Tab unaffected

## Known limitations

- A mixed `Ctrl+Cmd+Z` spelling (accepted by the parser) shows a doubled ⌃+⌃+Z label; the binding requires both physical keys as configured. Degenerate input, left as-is.
- In bare `pnpm dev` (no Tauri backend) on macOS, degraded chords display ⌃ though no native menu exists in that mode. Production builds are correct.

## Note

r-shell's own in-app Cmd+Z undo in React-controlled inputs is a separate, pre-existing limitation (native undo stack doesn't reach React state) — out of scope here; this PR fixes key ownership, not input-field undo.
