### PR TITLE
fix(transfer-queue): fix bright row dividers and enable list scrolling

### DIFF
--- a/src/__tests__/transfer-queue.test.tsx
+++ b/src/__tests__/transfer-queue.test.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TransferQueue } from '../components/transfer-queue';
+import type { TransferItem } from '../lib/transfer-queue-reducer';
+
+const mocks = vi.hoisted(() => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: mocks.invoke,
+}));
+
+function makeTransfer(id: string): TransferItem {
+  return {
+    id,
+    fileName: 'rule-view.svg',
+    direction: 'download',
+    sourcePath: '/remote/rule-view.svg',
+    destinationPath: '/local/rule-view.svg',
+    status: 'completed',
+    progress: 100,
+    bytesTransferred: 2621,
+    totalBytes: 2621,
+    speed: 0,
+  };
+}
+
+function renderQueue(transfers: TransferItem[], dispatch = vi.fn()) {
+  return render(
+    <TransferQueue
+      transfers={transfers}
+      dispatch={dispatch}
+      expanded
+      onToggleExpanded={() => {}}
+    />,
+  );
+}
+
+describe('TransferQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.invoke.mockResolvedValue(undefined);
+  });
+
+  afterEach(cleanup);
+
+  it('uses the global border color for row dividers', () => {
+    const { container } = renderQueue([
+      makeTransfer('t1'),
+      makeTransfer('t2'),
+      makeTransfer('t3'),
+    ]);
+    const list = container.querySelector('.divide-y');
+    expect(list).not.toBeNull();
+    expect(list!.className).toContain('divide-border');
+    expect(list!.className).not.toContain('/40');
+  });
+
+  it('constrains the scroll viewport to max-h-40', () => {
+    const { container } = renderQueue([makeTransfer('t1')]);
+    const root = container.querySelector('[data-slot="scroll-area"]');
+    const viewport = container.querySelector('[data-slot="scroll-area-viewport"]');
+    expect(root).not.toBeNull();
+    expect(viewport).not.toBeNull();
+    expect(root!.className).toContain('max-h-40');
+    expect(root!.className).toContain('overflow-hidden');
+    expect(root!.className).toContain('[&>[data-slot=scroll-area-viewport]]:max-h-40');
+  });
+
+  it('wires completed-download buttons to open_in_os and CLEAR_COMPLETED', () => {
+    const dispatch = vi.fn();
+    renderQueue([makeTransfer('t1')], dispatch);
+    fireEvent.click(screen.getByTitle('Open file'));
+    expect(mocks.invoke).toHaveBeenCalledWith('open_in_os', { path: '/local/rule-view.svg' });
+    fireEvent.click(screen.getByTitle('Show in folder'));
+    expect(mocks.invoke).toHaveBeenCalledWith('open_in_os', { path: '/local' });
+    fireEvent.click(screen.getByText('Clear'));
+    expect(dispatch).toHaveBeenCalledWith({ type: 'CLEAR_COMPLETED' });
+  });
+});

--- a/src/components/transfer-queue.tsx
+++ b/src/components/transfer-queue.tsx
@@ -156,13 +156,13 @@ export function TransferQueue({
         </button>
       </CollapsibleTrigger>
       <CollapsibleContent>
-        <ScrollArea className="max-h-40">
+        <ScrollArea className="max-h-40 overflow-hidden [&>[data-slot=scroll-area-viewport]]:max-h-40">
           {transfers.length === 0 ? (
             <div className="flex items-center justify-center h-12 text-xs text-muted-foreground">
               {t('transferQueue.noTransfers')}
             </div>
           ) : (
-            <div className="divide-y divide-border/40">
+            <div className="divide-y divide-border">
               {transfers.map((item) => (
                 <div
                   key={item.id}


### PR DESCRIPTION
Fixes #150

## Summary

Two visual defects in the transfer queue panel at the bottom of the file browser: row dividers rendered as a bright line that did not match any other divider in the app, and the list was hard-clipped at 160px with no way to scroll and see the remaining items.

## Root cause

- **Bright dividers**: the rows used `divide-y divide-border/40`. Custom colors in `tailwind.config.js` are defined as bare CSS variables (e.g. `border: 'var(--border)'`) with no `<alpha-value>` placeholder, so Tailwind 3 silently drops the `/40` class entirely. With no border-color rule, dividers fell back to Tailwind preflight's hardcoded `#e5e7eb` — a light-theme gray that stands out harshly in the dark theme.
- **No scrolling**: the list is wrapped in `<ScrollArea className="max-h-40">`. The Radix viewport is sized with `height: 100%`, which cannot resolve against a parent whose height is auto (max-height does not participate in percentage resolution), so the viewport grew to full content height, produced no overflow, and Radix kept `overflowY: hidden`. The root's `max-h-40` only clipped the content visually — every other scrollable ScrollArea in the codebase uses a definite height (`h-[400px]`, `h-32`, `h-full`, `flex-1 min-h-0`); this was the only `max-h-*` usage.

## Changes

- `src/components/transfer-queue.tsx`
  - Row container: `divide-border/40` → `divide-border` (verified with a local tailwindcss compile that the new spelling generates `border-color: var(--border)`, matching every other `border-border` usage).
  - ScrollArea: added `overflow-hidden` on the root plus `[&>[data-slot=scroll-area-viewport]]:max-h-40` so the viewport itself gets the max-height constraint, content overflows the viewport, and Radix enables its custom scrollbar (selector verified against `scroll-area.tsx` slot names; the arbitrary-variant pattern already exists elsewhere in the codebase).
- `src/__tests__/transfer-queue.test.tsx` (new): 3 tests — divider uses the global `divide-border` class, the scroll viewport carries the max-height constraint, and completed-download buttons call `open_in_os` with the file path / parent directory and dispatch `CLEAR_COMPLETED`.

## Testing

- New component tests: 3/3 pass; full suite 772/772 pass (80 files, Node 20); `tsc --noEmit` clean; eslint 0 errors; i18n key parity intact.
- Manual verification in the packaged app: dividers now match the theme border color and lists longer than 160px scroll to reveal all entries.