### PR TITLE
feat(release): Homebrew dual-baseline updates (P0+P1)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,40 @@ jobs:
   release:
     permissions:
       contents: write
+    # Dual baseline: tags without a `-current.` suffix (and workflow_dispatch)
+    # build the compat line; `v*-current.*` tags build only the evolution line
+    # (macOS 26+ arm64, no Intel) which is published as a prerelease so it can
+    # never hijack `releases/latest` from the stable channel.
+    if: >
+      (matrix.baseline == 'compat' && !contains(github.ref, '-current.')) ||
+      (matrix.baseline == 'current' && contains(github.ref, '-current.'))
     strategy:
       fail-fast: false
       matrix:
         include:
+          # ── Stable / compat line (minimumSystemVersion stays at the Tauri default) ──
           - platform: macos-latest
             args: '--target aarch64-apple-darwin'
+            baseline: 'compat'
           - platform: macos-latest
             args: '--target x86_64-apple-darwin'
+            baseline: 'compat'
           - platform: ubuntu-latest
             args: ''
+            baseline: 'compat'
           - platform: windows-latest
             args: ''
+            baseline: 'compat'
+          # ── Evolution / current line (macOS 26+ baseline, arm64 only) ──
+          - platform: macos-latest
+            args: '--target aarch64-apple-darwin --config ''{"bundle":{"macOS":{"minimumSystemVersion":"26.0"}}}'''
+            baseline: 'current'
+          - platform: ubuntu-latest
+            args: ''
+            baseline: 'current'
+          - platform: windows-latest
+            args: ''
+            baseline: 'current'
 
     runs-on: ${{ matrix.platform }}
 
@@ -80,17 +102,20 @@ jobs:
           releaseName: 'r-shell ${{ github.ref_name }}'
           releaseBody: 'See the assets to download this version and install.'
           releaseDraft: false
-          prerelease: false
-          includeUpdaterJson: true
+          prerelease: ${{ matrix.baseline == 'current' }}
+          # The complete manifest is assembled by upload-updater-json /
+          # upload-current-json; a per-job latest.json would be partial, so
+          # only the stable line lets tauri-action emit one at all.
+          includeUpdaterJson: ${{ matrix.baseline == 'compat' }}
           args: ${{ matrix.args }}
 
   # Generate and upload latest.json for the in-app updater.
-  # Skips pre-release tags so a beta/alpha never becomes the `latest` release
-  # and hijack the updater manifest for stable users.
+  # Skips pre-release tags so a beta/alpha/current tag never becomes the
+  # `latest` release and hijacks the updater manifest for stable users.
   upload-updater-json:
     needs: release
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta')
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, '-current.')
     permissions:
       contents: write
     steps:
@@ -211,7 +236,133 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Generate SHA256 checksums for Homebrew
+  # Generate current.json for the evolution line (`v*-current.*` tags) and
+  # attach it to the rolling lightweight `current` tag, so the in-app updater
+  # endpoint stays fixed at releases/download/current/current.json (GitHub has
+  # no "latest prerelease" URL; the rolling tag is the standard workaround).
+  upload-current-json:
+    needs: release
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/') && contains(github.ref_name, '-current.')
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+
+      - name: Poll for release assets to become available
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          TAG: ${{ github.ref_name }}
+        run: |
+          # The current line ships 3 platforms (mac arm64 + linux + windows),
+          # so wait (up to ~5 min) until all updater artifacts are visible.
+          for i in $(seq 1 30); do
+            COUNT=$(curl -sL -H "Authorization: token $GITHUB_TOKEN" \
+              "https://api.github.com/repos/$REPO/releases/tags/$TAG" \
+              | jq '[.assets[]? | select(.name | endswith(".sig") or endswith(".app.tar.gz") or endswith(".AppImage") or endswith("-setup.exe"))] | length')
+            echo "attempt $i: $COUNT updater-related assets visible"
+            if [ "${COUNT:-0}" -ge 3 ]; then
+              break
+            fi
+            sleep 10
+          done
+
+      - name: Generate current.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Same shape as latest.json, but only the platforms the current
+          # line builds (no Intel macOS), and version keeps the full
+          # `-current.N` suffix so semver comparison keeps counting up.
+          VERSION="${GITHUB_REF_NAME#v}"
+          REPO="${{ github.repository }}"
+          TAG="$GITHUB_REF_NAME"
+
+          RELEASE_JSON=$(curl -sL \
+            -H "Authorization: token $GITHUB_TOKEN" \
+            "https://api.github.com/repos/$REPO/releases/tags/$TAG")
+
+          get_signature() {
+            local sig_asset_name="$1"
+            local sig_url sig_body
+            sig_url=$(echo "$RELEASE_JSON" | jq -r --arg name "$sig_asset_name" '.assets[] | select(.name == $name) | .browser_download_url')
+            if [ -z "$sig_url" ] || [ "$sig_url" = "null" ]; then
+              echo ""
+              return
+            fi
+            sig_body=$(curl -sL "$sig_url" | tr -d '\n' | tr -d '[:space:]')
+            if printf '%s' "$sig_body" | grep -Eq '^[A-Za-z0-9+/=]{32,}$'; then
+              printf '%s' "$sig_body"
+            else
+              echo ""
+            fi
+          }
+
+          pick_asset() {
+            local pattern="$1"
+            echo "$RELEASE_JSON" | jq -r --arg p "$pattern" \
+              'first(.assets[] | select(.name | test($p))) | "\(.browser_download_url)\t\(.name)" // empty'
+          }
+
+          add_platform() {
+            local key="$1" pattern="$2"
+            local picked asset_name url sig
+            picked=$(pick_asset "$pattern")
+            if [ -z "$picked" ]; then
+              return
+            fi
+            url="${picked%%$'\t'*}"
+            asset_name="${picked##*$'\t'}"
+            sig=$(get_signature "${asset_name}.sig")
+            if [ -z "$sig" ]; then
+              echo "::warning::No valid signature for $asset_name; $key will be skipped."
+              return
+            fi
+            PLATFORMS=$(echo "$PLATFORMS" | jq --arg k "$key" --arg url "$url" --arg sig "$sig" \
+              '. + {($k): {"url": $url, "signature": $sig}}')
+          }
+
+          PLATFORMS='{}'
+
+          # Evolution-line asset naming: mac arm64 (min macOS 26), linux, windows.
+          add_platform "darwin-aarch64"  'aarch64\.app\.tar\.gz$'
+          add_platform "linux-x86_64"    'amd64\.AppImage$'
+          add_platform "windows-x86_64"  'x64-setup\.exe$'
+
+          PLATFORM_COUNT=$(echo "$PLATFORMS" | jq 'length')
+          if [ "${PLATFORM_COUNT:-0}" -eq 0 ]; then
+            echo "::error::No updater assets were resolved from the release. Aborting current.json upload."
+            exit 1
+          fi
+
+          jq -n --arg version "$VERSION" --arg notes "See release page for details." --arg pub_date "$(date -u +%Y-%m-%dT%H:%M:%SZ)" --argjson platforms "$PLATFORMS" \
+            '{version: $version, notes: $notes, pub_date: $pub_date, platforms: $platforms}' > current.json
+
+          cat current.json
+
+      - name: Upload current.json under the rolling current tag
+        uses: softprops/action-gh-release@v3
+        with:
+          tag_name: current
+          name: 'r-shell current channel'
+          prerelease: true
+          files: current.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Move the rolling current tag to this release
+        run: |
+          # The `current` release above keeps its tag_name, but the tag REF
+          # must follow the newest `-current.N` commit. Force-move it; this
+          # is a mutable reference by design — nothing may assume `current`
+          # points at an immutable commit.
+          git tag -f current "$GITHUB_REF_NAME"
+          git push -f origin current
+
+  # Generate SHA256 checksums (both baselines — whichever .dmg assets the
+  # tag's release carries: 2 dmg on compat tags, 1 arm64 dmg on current tags)
   generate-checksums:
     needs: release
     runs-on: ubuntu-latest
@@ -247,11 +398,13 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-  # Update Homebrew tap (requires HOMEBREW_TAP_TOKEN secret)
+  # Update Homebrew tap (requires HOMEBREW_TAP_TOKEN secret).
+  # The tap's `r-shell` cask tracks the stable line only — current-line tags
+  # must not bump it to a prerelease version.
   update-homebrew:
     needs: generate-checksums
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta')
+    if: startsWith(github.ref, 'refs/tags/') && !contains(github.ref_name, 'alpha') && !contains(github.ref_name, 'beta') && !contains(github.ref_name, '-current.')
     steps:
       - name: Update Homebrew Cask
         uses: peter-evans/repository-dispatch@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,43 +7,50 @@ on:
   workflow_dispatch:
 
 jobs:
+  # A job-level `if` cannot reference the `matrix` context (GitHub only
+  # allows github/needs/vars/inputs there), so the baseline selection for
+  # the tag happens here: this job picks the matrix entries matching the
+  # tag and hands them to `release` as JSON.
+  resolve-matrix:
+    runs-on: ubuntu-latest
+    outputs:
+      entries: ${{ steps.resolve.outputs.entries }}
+    steps:
+      - name: Select matrix entries for this tag
+        id: resolve
+        run: |
+          # Dual baseline: tags without a `-current.` suffix (and
+          # workflow_dispatch) build the compat line; `v*-current.*` tags
+          # build only the evolution line (macOS 26+ arm64, no Intel) which
+          # is published as a prerelease so it can never hijack
+          # `releases/latest` from the stable channel.
+          if [[ "$GITHUB_REF_NAME" == *-current.* ]]; then
+            ENTRIES=$(jq -cn \
+              --arg macArgs '--target aarch64-apple-darwin --config '\''{"bundle":{"macOS":{"minimumSystemVersion":"26.0"}}}'\''' \
+              '{include: [
+                 {platform: "macos-latest",  args: $macArgs, baseline: "current"},
+                 {platform: "ubuntu-latest",  args: "",       baseline: "current"},
+                 {platform: "windows-latest", args: "",       baseline: "current"}
+               ]}')
+          else
+            ENTRIES=$(jq -cn \
+              '{include: [
+                 # Stable / compat line (minimumSystemVersion stays at the Tauri default)
+                 {platform: "macos-latest",  args: "--target aarch64-apple-darwin", baseline: "compat"},
+                 {platform: "macos-latest",  args: "--target x86_64-apple-darwin",  baseline: "compat"},
+                 {platform: "ubuntu-latest",  args: "",                              baseline: "compat"},
+                 {platform: "windows-latest", args: "",                              baseline: "compat"}
+               ]}')
+          fi
+          echo "entries=$ENTRIES" >> "$GITHUB_OUTPUT"
+
   release:
+    needs: resolve-matrix
     permissions:
       contents: write
-    # Dual baseline: tags without a `-current.` suffix (and workflow_dispatch)
-    # build the compat line; `v*-current.*` tags build only the evolution line
-    # (macOS 26+ arm64, no Intel) which is published as a prerelease so it can
-    # never hijack `releases/latest` from the stable channel.
-    if: >
-      (matrix.baseline == 'compat' && !contains(github.ref, '-current.')) ||
-      (matrix.baseline == 'current' && contains(github.ref, '-current.'))
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          # ── Stable / compat line (minimumSystemVersion stays at the Tauri default) ──
-          - platform: macos-latest
-            args: '--target aarch64-apple-darwin'
-            baseline: 'compat'
-          - platform: macos-latest
-            args: '--target x86_64-apple-darwin'
-            baseline: 'compat'
-          - platform: ubuntu-latest
-            args: ''
-            baseline: 'compat'
-          - platform: windows-latest
-            args: ''
-            baseline: 'compat'
-          # ── Evolution / current line (macOS 26+ baseline, arm64 only) ──
-          - platform: macos-latest
-            args: '--target aarch64-apple-darwin --config ''{"bundle":{"macOS":{"minimumSystemVersion":"26.0"}}}'''
-            baseline: 'current'
-          - platform: ubuntu-latest
-            args: ''
-            baseline: 'current'
-          - platform: windows-latest
-            args: ''
-            baseline: 'current'
+      matrix: ${{ fromJSON(needs.resolve-matrix.outputs.entries) }}
 
     runs-on: ${{ matrix.platform }}
 
@@ -215,11 +222,18 @@ jobs:
           add_platform "linux-x86_64"    'amd64\.AppImage$'
           add_platform "windows-x86_64"  'x64-setup\.exe$'
 
-          # Fail loudly rather than shipping an empty/partial manifest that
-          # would silently break updates for every platform.
-          PLATFORM_COUNT=$(echo "$PLATFORMS" | jq 'length')
-          if [ "${PLATFORM_COUNT:-0}" -eq 0 ]; then
-            echo "::error::No updater assets were resolved from the release. Aborting latest.json upload."
+          # Fail loudly rather than shipping a partial manifest: a missing
+          # platform entry silently strands that platform's updater (it sees
+          # "no update" forever), so all four entries are required before
+          # latest.json is uploaded.
+          MISSING_KEYS=""
+          for key in darwin-aarch64 darwin-x86_64 linux-x86_64 windows-x86_64; do
+            if [ "$(echo "$PLATFORMS" | jq --arg k "$key" 'has($k)')" != "true" ]; then
+              MISSING_KEYS="$MISSING_KEYS $key"
+            fi
+          done
+          if [ -n "$MISSING_KEYS" ]; then
+            echo "::error::latest.json is missing required platform entries:$MISSING_KEYS. Aborting upload so a partial manifest can never strand a platform's updater."
             exit 1
           fi
 
@@ -331,9 +345,17 @@ jobs:
           add_platform "linux-x86_64"    'amd64\.AppImage$'
           add_platform "windows-x86_64"  'x64-setup\.exe$'
 
-          PLATFORM_COUNT=$(echo "$PLATFORMS" | jq 'length')
-          if [ "${PLATFORM_COUNT:-0}" -eq 0 ]; then
-            echo "::error::No updater assets were resolved from the release. Aborting current.json upload."
+          # Same completeness requirement as latest.json: the current line
+          # always builds all three platforms, and a partial manifest would
+          # strand the missing platform's updater.
+          MISSING_KEYS=""
+          for key in darwin-aarch64 linux-x86_64 windows-x86_64; do
+            if [ "$(echo "$PLATFORMS" | jq --arg k "$key" 'has($k)')" != "true" ]; then
+              MISSING_KEYS="$MISSING_KEYS $key"
+            fi
+          done
+          if [ -n "$MISSING_KEYS" ]; then
+            echo "::error::current.json is missing required platform entries:$MISSING_KEYS. Aborting upload so a partial manifest can never strand a platform's updater."
             exit 1
           fi
 

--- a/docs/superpowers/specs/2026-09-12-homebrew-official-dual-baseline-design.md
+++ b/docs/superpowers/specs/2026-09-12-homebrew-official-dual-baseline-design.md
@@ -75,7 +75,7 @@ Cask Cookbook：仅当应用自带更新（菜单里有真正执行下载安装�
 而 brew 侧语义：声明了 `auto_updates` 的 cask **默认不被 `brew upgrade` 升级**（需 `--greedy`）。我们希望 brew 用户走 `brew upgrade --cask r-shell`，因此：
 
 - 官方 cask **不含 `auto_updates`**；
-- 应用内更新器检测到自身运行于 `/opt/homebrew/Caskroom/` 或 `/usr/local/Caskroom/`（可判定"自更新可被禁用"）时，禁用自动检查与下载安装，UI 引导用户执行 `brew upgrade`（§4）。
+- 应用内更新器检测到 Homebrew cask receipt 时（`<prefix>/Caskroom/r-shell{,@current}/.metadata/INSTALL_RECEIPT.json`，prefix 覆盖 `/opt/homebrew`、`/usr/local` 与 `HOMEBREW_PREFIX`），禁用自动检查与下载安装，UI 引导用户执行 `brew upgrade`（§4）。注意 **不能靠可执行文件路径包含 `Caskroom` 判定**：`brew install --cask` 会把 .app 移出到 /Applications，Caskroom 里只剩符号链接与 receipt，运行路径不含 "Caskroom"（2026-09-13 在本机 `/opt/homebrew/Caskroom/r-shell/2.9.2/` 实测确认）。
 
 这同时**取代了此前"给私有 tap 加 `auto_updates true`"的方案**：既然 Caskroom 安装一律停用应用内更新，两条 tap 都应省略该 stanza，冲突从根上消失，且 `brew upgrade` 对两个 cask 都直接生效。
 
@@ -148,7 +148,7 @@ release:
         - { platform: windows-latest, args: '', baseline: current }
 ```
 
-每个 entry 顶部 `if: tagMatchesBaseline`（用一步 `jq`/`grep` 判定 tag 是否含 `-current.`，与 matrix 条目匹配；演进线新增的 mac 构建沿用 `macos-latest` runner）。
+基线过滤**不能**写成 job 级 `if: matrix.baseline == ...`——GitHub 的 job 级 `if` 只允许 `github/needs/vars/inputs` 上下文（matrix 仅在 step 级可用），直接引用会在触发时整个 workflow 校验失败。正确做法：前置一个 `resolve-matrix` job 用 `jq` 按 tag 生成过滤后的 entries JSON，`release` job 以 `strategy.matrix: ${{ fromJSON(needs.resolve-matrix.outputs.entries) }}` 消费（演进线新增的 mac 构建沿用 `macos-latest` runner）。
 
 ### 3.2 演进线的最低系统注入
 
@@ -248,7 +248,10 @@ bump-official-cask:
 ```rust
 #[tauri::command] fn get_update_context() -> UpdateContext
 // { homebrewManaged: bool, platform: String, arch: String, macosMajor: Option<u32> }
-// homebrewManaged = std::env::current_exe() 路径包含 "/Caskroom/"
+// homebrewManaged = 可执行文件路径含 "/Caskroom/"（staging 直跑）
+//   或（receipt 存在 且当前运行副本是 /Applications|~/Applications 下的 .app）：
+//   receipt = {/opt/homebrew, /usr/local, $HOMEBREW_PREFIX}/Caskroom/r-shell{,@current}/.metadata/INSTALL_RECEIPT.json
+//   （/Applications 限定用于排除同机上的 tauri-dev 构建——receipt 是机器级标记）
 // macosMajor 用 sysinfo/os_info 或简单解析 `sw_vers`（已有系统信息采集代码可复用）
 
 #[tauri::command] async fn updater_check(channel: String, proxy: Option<String>) -> Result<Option<UpdateMeta>, String>

--- a/docs/superpowers/specs/2026-09-12-homebrew-official-dual-baseline-design.md
+++ b/docs/superpowers/specs/2026-09-12-homebrew-official-dual-baseline-design.md
@@ -1,0 +1,364 @@
+# 进入 Homebrew 官方源（homebrew/cask）：双版本基线发布体系设计
+
+- 日期：2026-09-12
+- 状态：设计稿 v2（已吸收 owner 当日三项决策：①暂不申请 Apple 开发者账号 → 官方 cask 收录搁置，私有 tap 长期为 brew 唯一通道；②演进线自下一个版本首发（`v3.0.0-current.1`）；③官方 cask 由 owner 本人提交，条件成熟后启动——注意 notability 与公证是两个独立门槛，缺一不可，见 §1.5/§7）
+- 范围：发布策略、CI（`.github/workflows/release.yml`）、应用内更新设置（Rust + React）、官方 cask 提交与维护
+- 不在范围：私有 tap `GOODBOY008/homebrew-tap` 内部实现（另仓库，仅约束其接口）
+
+---
+
+## 1. 官方要求核实（已逐条对照 Homebrew 文档）
+
+结论先行——**双基线并存是官方明确允许的**，真正的硬门槛是：公证签名、notability 自投门槛、以及「推荐通道」的界定。
+
+### 1.1 收录通道：homebrew/cask（不是 core）
+
+R-Shell 是开源 GUI 应用且有编译好的 dmg 分发 → 进 `homebrew/cask`（随 brew 内置，用户无需加 tap）。文档明确：开源 CLI / 无编译产物的 GUI 才归 homebrew/core；被 core 拒收也不自动获得 cask 资格。
+
+### 1.2 版本与通道规则（双基线的合法性依据）
+
+> "The unversioned cask normally tracks the upstream release channel recommended for most users. That channel is not necessarily the newest available release."
+
+即：**官方 `r-shell` cask 跟踪"推荐给大多数用户"的通道，不必是最新版本**。其它通道可用 `@beta` / `@nightly` 等 token 单独立 cask；版本钉死的发布线只要上游仍在积极维护就有效。
+
+对我们的含义：
+- 稳定线（兼容基线）= 推荐通道 → 官方 cask 只跟踪它；
+- 演进线（新基线）= 另一通道，可以留在私有 tap（`r-shell@current`）或仅走应用内更新 + 直接下载；
+- **两条线必须同时维护**——官方 cask 一旦收录，稳定线停更超过合理周期会被社区质疑（"actively maintains" 是资格前提）。
+
+### 1.3 系统与架构（Support Tiers，2026-09 现状）
+
+| 架构 | Tier 1（受支持） | Tier 3（尽力而为） |
+|---|---|---|
+| Apple Silicon | macOS 27 / 26 / 15 | 11–14 |
+| Intel | macOS 26 / 15 / 14 | 10.15–13（≤10.14 不支持） |
+
+硬性要求：
+- "A cask must work on every operating system and architecture it declares"——cask 声明双架构就必须双架构都能跑；
+- "A cask that supports macOS must work on the latest major version of macOS"——**必须在 macOS 27 上可运行**（每个稳定版发布前要验证，见 §3.7）；
+- macOS 27 起 Intel 不再有任何受支持系统；GitHub Intel runner 2027 年退役 → x86_64 构建保留在稳定线（Intel 用户 Tier 1 上限是 macOS 26），演进线不做 Intel。
+
+基线取舍：稳定线**沿用 Tauri 默认最低系统（10.13），不设 `depends_on macos`**——不缩小现有用户面，cask 全系统可装；演进线最低 macOS 26（Tahoe）、仅 aarch64。"基线"的差别只体现在演进线的构建参数与测试范围上，稳定线零行为变化。
+
+### 1.4 Gatekeeper / 公证（当前最大缺口）
+
+> "Executable artefacts must pass Homebrew's Gatekeeper checks" 且不得要求关闭/绕过 Gatekeeper。
+
+现状：`release.yml` 只有 updater 的 minisign 密钥（`TAURI_SIGNING_PRIVATE_KEY`，release.yml:76–77），**没有任何 Apple 签名/公证配置**。未公证的 dmg 在新 macOS 上会被 Gatekeeper 拦截 → 官方 cask 的前置阻塞项。
+
+前置条件：Apple Developer Program（Developer ID Application 证书 + App Store Connect API key 或 Apple ID app-specific password）。tauri-action 原生支持，只需注入 secrets（见 §3.3）。
+
+**决策（2026-09-12）：暂不申请 Apple Developer Program。** 后果：签名公证缺失 → 官方 cask 的 Gatekeeper 硬性要求无法满足 → **官方收录整条线搁置**（重启条件见 §7 P4）；私有 tap 继续作为 brew 渠道（现状不变）。§3.3 / §3.5 / §5 保留为条件重启时的实施说明。
+
+### 1.5 Notability（决定性发现：owner 目前不能自投）
+
+Package-Acceptance-Policy 的量化门槛（满足任一即可）：
+
+| 路径 | forks | watchers | stars | r-shell 现状（2026-09-12） |
+|---|---|---|---|---|
+| 社区标准提交 | ≥30 | ≥30 | ≥75 | 33 ✓ / 2 ✗ / 142 ✓ → **达标** |
+| **仓库 owner 自投** | ≥90 | ≥90 | ≥225 | 33 ✗ / 2 ✗ / 142 ✗ → **不达标** |
+
+另：仓库须满 30 天（已满足）；数字以 canonical 仓库为准；达标只是最低线，维护者保留裁量权。
+
+**决策（2026-09-12）：owner 选择自投路径，条件成熟再提交。** 自投的"条件合适"是两个**独立**门槛，缺一不可：
+
+1. notability：225⭐ / 90 forks / 90 watchers 任一达标（现 142⭐ / 33 forks / 2 watchers，均未达）；
+2. 签名公证：需要 Apple Developer Program（§1.4，owner 已决定暂不申请）。
+
+即：**star 涨到 225 而账号未办，提交仍会被拒**——Gatekeeper 检查是收录审核的硬条件，与 star 数无关。§5 的 cask 草案保留，两个条件都齐备后直接可用。
+
+### 1.6 `auto_updates`  stanza 的决策：不加，改为"应用内更新器对 Caskroom 安装自动禁用"
+
+Cask Cookbook：仅当应用自带更新（菜单里有真正执行下载安装的 "Check for Updates…"）时声明 `auto_updates true`；若只是跳转网页则不声明。
+
+而 brew 侧语义：声明了 `auto_updates` 的 cask **默认不被 `brew upgrade` 升级**（需 `--greedy`）。我们希望 brew 用户走 `brew upgrade --cask r-shell`，因此：
+
+- 官方 cask **不含 `auto_updates`**；
+- 应用内更新器检测到自身运行于 `/opt/homebrew/Caskroom/` 或 `/usr/local/Caskroom/`（可判定"自更新可被禁用"）时，禁用自动检查与下载安装，UI 引导用户执行 `brew upgrade`（§4）。
+
+这同时**取代了此前"给私有 tap 加 `auto_updates true`"的方案**：既然 Caskroom 安装一律停用应用内更新，两条 tap 都应省略该 stanza，冲突从根上消失，且 `brew upgrade` 对两个 cask 都直接生效。
+
+> 注意方向：不要反过来（声明 auto_updates + 让更新器在 Caskroom 内就地替换 .app）——Tauri 更新器整包替换 app bundle 会破坏 brew 的 receipt/sha256 追踪，是已知的"更新器 vs brew"冲突根因。
+
+### 1.7 其他条款核对
+
+- 可验证分发：官方 GitHub Releases ✓（要求"开发者发布或公开背书的下载源"）；
+- 重复 cask："同一软件 + 同一发布 + 同一通道"才算重复——私有 tap 若继续存在必须换成不同通道（`r-shell@current`），同名同通道的 `r-shell` 需迁移退役（§3.6）；
+- 试用/激活、fork 命名、多语言 cask 等条款不适用。
+
+### 1.8 差距清单（现状 → 要求）
+
+| # | 差距 | 影响 | 对应方案 |
+|---|---|---|---|
+| 1 | dmg 未签名公证 | cask 硬阻塞 | §3.3 |
+| 2 | 更新器与 brew 安装互相不知情 | 冲突/版本错乱 | §4 |
+| 3 | 单通道 `latest.json`，无基线/通道概念 | 无法双基线 | §3.4、§4 |
+| 4 | owner 自投 notability 不达标（142/225⭐） | 提交人受限 | §7 阶段 2 |
+| 5 | 私有 tap 存在同名 `r-shell` cask | 官方合并时的用户混淆（搁置期间不构成问题：私有 tap 是唯一 brew 通道） | §3.6 |
+| 6 | 未在 macOS 27 上验证 | "must work on latest macOS" | §3.7 |
+| 7 | CI 无按 tag 区分发布线的机制 | 双基线无法落地 | §3.1 |
+
+---
+
+## 2. 双基线模型
+
+| | 稳定线（兼容基线） | 演进线（新基线） |
+|---|---|---|
+| 通道语义 | "推荐给大多数用户"（官方 cask 跟踪） | 尝鲜通道 |
+| 版本示例 | `2.9.3`、`2.9.4`…（晋升后跳 `3.1.x`） | `3.0.0-current.1`、`3.0.0-current.2`… |
+| Git tag | `v2.9.3` | `v3.0.0-current.3` |
+| GitHub Release | 正式版（非 prerelease）→ `releases/latest` 永远指向本线 | **标记为 prerelease** → 不污染 `releases/latest` |
+| 最低 macOS | 10.13（Tauri 默认，不变） | 26.0（Tahoe） |
+| macOS 架构 | aarch64 + x86_64（两个 dmg，与现状一致） | 仅 aarch64 |
+| Windows / Linux | 每个稳定版全平台出包 | 同样出包（跟演进线版本号） |
+| 内容 | bugfix / 安全修复 / 无风险回移（cherry-pick） | 全部新功能 |
+| 更新 manifest | `latest.json`（**URL 与现状完全不变**） | `current.json`（滚动 tag `current` 的 release 资产，§3.4） |
+| Homebrew | 官方 `homebrew/cask/r-shell` + bump 自动化 | （可选）私有 tap `r-shell@current`，或仅应用内更新 |
+
+**首发定档（2026-09-12 决策）：演进线自下一个版本启动，即 `v3.0.0-current.1`**（版本基数取 3.0.0，与稳定线 2.9.x 形成清晰分界）。stable 用户完全无感：`releases/latest` 仍指向 2.9.2，`latest.json` 不变，自动更新不受任何影响。演进线首批用户来自直接下载（GitHub prerelease 页面）；应用内通道切换随本版合入，此后 current 线更新走应用内。
+
+关键机制：
+
+1. **tag 后缀即通道**：`-current.N` 是合法 semver prerelease（`3.0.0-current.3 < 3.0.0`），GitHub 会把标记 prerelease 的演进版排除在 `releases/latest` 之外——所以现有的 `releases/latest/download/latest.json` 稳定通道 URL **零改动**继续可用。
+2. **晋升（promotion）**：演进线每 4–6 周左右冻结一次，从该提交打稳定 tag（如 `v3.1.0`，去掉后缀、非 prerelease）全平台重新出包；稳定线版本号随之跳到 `3.1.x`。同一份代码、两个 tag，与 Chrome stable/beta 模型一致。
+3. **双线同时存续是承诺不是过渡**：官方 cask 收录后，稳定线的维护节奏（安全修复回移时限，目标 ≤7 天）要写进发布流程文档。
+
+---
+
+## 3. CI 设计（`.github/workflows/release.yml` 改造）
+
+### 3.1 触发与矩阵
+
+tag 过滤改为 `v*`（含 `v*-current.*`），在 job 内按 tag 判定发布线：
+
+```yaml
+release:
+  strategy:
+    matrix:
+      include:
+        # —— 稳定线（tag 不含 -current.）——
+        - { platform: macos-latest, args: --target aarch64-apple-darwin, baseline: compat }
+        - { platform: macos-latest, args: --target x86_64-apple-darwin, baseline: compat }
+        - { platform: ubuntu-latest, args: '', baseline: compat }
+        - { platform: windows-latest, args: '', baseline: compat }
+        # —— 演进线（tag 匹配 v*-current.*）——
+        - { platform: macos-latest, args: --target aarch64-apple-darwin, baseline: current }
+        - { platform: ubuntu-latest, args: '', baseline: current }
+        - { platform: windows-latest, args: '', baseline: current }
+```
+
+每个 entry 顶部 `if: tagMatchesBaseline`（用一步 `jq`/`grep` 判定 tag 是否含 `-current.`，与 matrix 条目匹配；演进线新增的 mac 构建沿用 `macos-latest` runner）。
+
+### 3.2 演进线的最低系统注入
+
+tauri-action 的 `args` 里追加内联 config 覆盖（Tauri 2 支持 `--config <json>` 合并）：
+
+```yaml
+args: --target aarch64-apple-darwin --config '{"bundle":{"macOS":{"minimumSystemVersion":"26.0"}}}'
+```
+
+稳定线不传 → 保持默认 10.13。稳定线资产名（`r-shell_<v>_aarch64.dmg` / `_x64.dmg`）不变，保证官方 cask 的 URL 模板稳定。
+
+### 3.3 签名与公证（已搁置——重启官方收录时实施）
+
+> 状态：owner 2026-09-12 决定暂不申请 Apple Developer Program，本节整段挂起；内容保留，作为日后重启时的实施清单。演进线同样跳过签名公证，与稳定线产物形态保持一致。
+
+新增 secrets（前置：Apple Developer Program），tauri-action 检测到以下 env 即自动签名 + 公证：
+
+```
+APPLE_CERTIFICATE            # p12（含 Developer ID Application）
+APPLE_CERTIFICATE_PASSWORD
+APPLE_SIGNING_IDENTITY       # "Developer ID Application: <Name> (TEAMID)"
+APPLE_API_KEY / APPLE_API_ISSUER / APPLE_API_KEY_KEY   # App Store Connect API（推荐）或 APPLE_ID+APPLE_PASSWORD
+```
+
+同时保留现有 `TAURI_SIGNING_PRIVATE_KEY*`（updater 签名与 Gatekeeper 公证是两回事，互不替代）。演进线同样要公证（cask 之外，直接下载用户也受益）。
+
+### 3.4 双 manifest
+
+- **`latest.json`（稳定线，逻辑不变）**：现 job（release.yml:90–212）已在 alpha/beta tag 上跳过，把跳过条件扩展为「凡 `-current.` tag 跳过」即可，选取平台 `darwin-aarch64` / `darwin-x86_64` / `linux-x86_64` / `windows-x86_64`。
+- **`current.json`（演进线，新 job `upload-current-json`）**：结构与 latest.json 相同，但：
+  - `darwin-aarch64` 指向演进线 arm 构建（macOS 26+）；
+  - 附着方式：**移动轻量 tag `current` 到本次 release**（`git tag -f current <tag> && git push -f origin current`），endpoint 固定为
+    `https://github.com/GOODBOY008/r-shell/releases/download/current/current.json`
+    ——GitHub 没有 "latest prerelease" URL，滚动 tag 是业界常用替代（neovim nightly 同款做法）；缺点是该 tag 永远是"可变引用"，文档中注明不应对 `v-current` 语义做任何假设。
+  - `version` 字段写完整 `3.0.0-current.3`；tauri updater 的 semver 比较天然满足 `current.N` 递增可更新。
+
+### 3.5 官方 cask 的 bump 自动化（随官方收录一并搁置）
+
+> 状态：`OFFICIAL_CASK_MERGED` 长期保持 `false`（或干脆不创建该 job）；本节内容在 §7 P4 重启时实施。
+
+仅在稳定线 tag、且仓库变量 `OFFICIAL_CASK_MERGED == 'true'` 时运行（cask 合并前置空跑会报错）：
+
+```yaml
+bump-official-cask:
+  needs: generate-checksums
+  if: startsWith(github.ref, 'refs/tags/v') && !contains(github.ref, '-current.')
+        && vars.OFFICIAL_CASK_MERGED == 'true'
+  runs-on: macos-latest
+  steps:
+    - run: brew install bumpctl   # 或使用 brew 内置 brew bump-cask-pr
+    - run: brew bump-cask-pr --cask r-shell --version ${GITHUB_REF_NAME#v}
+      env:
+        HOMEBREW_GITHUB_API_TOKEN: ${{ secrets.HOMEBREW_CASK_PR_TOKEN }}  # PAT, 含 homebrew/cask fork 权限
+```
+
+`bump-cask-pr` 会自动 fork homebrew/cask、更新 version/sha256（从 checksums 或 Livecheck 抓取）、按模板开 PR。sha256 建议在 cask 中直接写死（见 §5），bump 工具会替换。
+
+### 3.6 私有 tap（`GOODBOY008/homebrew-tap`）：长期作为 brew 唯一通道
+
+官方收录搁置后，私有 tap 不再是过渡方案，而是 brew 用户的正式渠道，按以下规则运行：
+
+1. **`r-shell` cask 只跟踪稳定线，且这是双基线改造中 tap 侧唯一必须的变更**：现有 dispatch 机制（release.yml:251–262）在全部 `v*` tag 上触发，必须给 `update-homebrew` job 加过滤 `!contains(github.ref, '-current.')`，否则演进线 tag 会把 tap 上的 `r-shell` 更新到 prerelease 版本。
+2. tap cask 维持无 `auto_updates` stanza（§1.6），配合应用内 Caskroom 检测。
+3. **演进线不进 tap（首期决策）**：`r-shell@current` cask 暂缓——solo 维护成本考量，演进线用户走直接下载 + 应用内通道切换即可；日后 brew 侧尝鲜需求真实出现再补。
+4. 官方收录重启（§7 P4）时，再执行"私有 tap `r-shell` 弃用迁移 + 可选转 `r-shell@current`"的原方案。
+
+### 3.6-旧稿（官方合并后迁移方案，搁置备查）
+
+1. **现在（阶段 0 即做）**：tap 内 cask 去掉/不添加 `auto_updates`；新版本继续 dispatch 更新（现 release.yml:251–262 机制不动），但 README 安装指引加一段"官方源上线后请迁移"。
+2. **官方 cask 合并后**：私有 tap 的 `r-shell` cask 停止更新并加 `deprecation` 块（deprecate_date + reason 指向官方 cask）；同时新增 `r-shell@current` cask 跟踪演进线（channel 不同，不违反 duplicate 条款），继续由 dispatch 事件驱动，只消费 `-current.*` tag 的产物。
+3. **迁移命令写进 README 与 release notes**：
+   `brew uninstall --cask GOODBOY008/tap/r-shell && brew install --cask r-shell`
+   （应用内更新器检测到 Caskroom 安装会自动让位，见 §4，用户无感知冲突。）
+
+### 3.7 checksums 与测试
+
+- `generate-checksums`（release.yml:215–248）扩展覆盖演进线资产；演进线 dmg 同样需要 sha256 供 tap 的 `r-shell@current` 使用。
+- `test.yml` 矩阵在 GitHub 提供 `macos-15` / `macos-26` runner 后加入双系统冒烟（`pnpm build` + `cargo test` 足够）；**macOS 27 验证**在 runner 可用前作为发版检查清单项（QA 手动过一遍启动 + 连接 + 终端 + SFTP），满足 "must work on latest macOS"。
+
+---
+
+## 4. 应用内设置与更新器改造
+
+### 4.1 设置 UI（`src/components/settings-modal.tsx`）
+
+现有 "Check for Updates" / "Update Proxy" 所在的 Advanced 区（settings-modal.tsx:1339–1376）改造为一个明确的 **"更新" 组**：
+
+1. **更新通道**（新增，key `updateChannel`，默认 `'stable'`，与 `checkUpdates` 同一 localStorage 容器 `sshClientSettings`、同一读写模式）：
+   - `stable`：稳定版（推荐）；
+   - `current`：最新版（仅 macOS 26+ Apple Silicon）——**不满足条件时选项禁用 + tooltip 说明**（门控数据来自 §4.2 的 `get_update_context`）。
+2. **Homebrew 托管横幅**：当 `homebrewManaged == true` 时，隐藏"更新通道/自动检查/代理"三个控件，替换为说明文案 + 命令提示：
+   `此副本由 Homebrew 管理，请运行 brew upgrade --cask r-shell 获取更新`。
+3. `checkUpdates`、`updateProxy` 两个现有 key 与行为保留（非托管安装下）。
+
+### 4.2 Rust 侧新增（`src-tauri/src/commands.rs` + `lib.rs` 注册）
+
+```rust
+#[tauri::command] fn get_update_context() -> UpdateContext
+// { homebrewManaged: bool, platform: String, arch: String, macosMajor: Option<u32> }
+// homebrewManaged = std::env::current_exe() 路径包含 "/Caskroom/"
+// macosMajor 用 sysinfo/os_info 或简单解析 `sw_vers`（已有系统信息采集代码可复用）
+
+#[tauri::command] async fn updater_check(channel: String, proxy: Option<String>) -> Result<Option<UpdateMeta>, String>
+// UpdaterExt::updater_builder(app) → .endpoints(vec![按 channel 选 URL]) → .proxy(...) → .check()
+// 托管安装直接返回特殊错误码/标志，前端据此弹引导
+
+#[tauri::command] async fn updater_download_and_install(app: AppHandle) -> Result<(), String>
+// 持有 updater_check 返回的 Update（进程内缓存于 State），download_and_install 回调里
+// app.emit("updater://progress", { downloaded, total }) 供前端进度条
+```
+
+**为什么必须走 Rust 命令而不是现有 JS `check()`**：JS 端 `CheckOptions` 只有 `headers/timeout/proxy/target/version`，**没有 endpoint 覆盖**；endpoints 覆盖只存在于 Rust `UpdaterBuilder::endpoints()`（docs.rs 已确认）。通道选择在 JS 层无法表达，故把 check/download/install 三步迁到 Rust，前端只保留 UI 与状态机。
+
+前端 `src/components/update-checker.tsx`：`check(proxy)` → `invoke('updater_check', {...})`；进度事件监听 `updater://progress`；安装后仍走 `relaunch()`（quit_guard.rs:15 已放行更新器重启，无需改）。菜单 "check_updates" 事件链路（App.tsx:1766, 2124）不变，托管安装下改为 toast 引导 `brew upgrade`。
+
+### 4.3 门控规则汇总
+
+| 状态 | 自动检查 | 手动检查 | 通道选择 |
+|---|---|---|---|
+| 直接下载安装 | 按 `checkUpdates` | ✓ | stable/current 任选（current 需 macOS≥26 且 arm64） |
+| Caskroom 安装（官方或 tap） | 强制关 | 改为 brew 引导 toast | 隐藏 |
+| 非 macOS 且选 current | — | — | 选项禁用（win/linux 跟随 stable 通道的版本演进，current.json 含 win/linux 条目时不特殊处理，默认 stable） |
+
+补充：**通道只升不降**——已装 `3.0.0-current.x` 的用户把通道切回 stable 后，更新器不会自动降级到 `2.9.x`（tauri updater 默认不安装低版本），需手动下载稳定版覆盖安装；`current` 选项的说明文案应提示这一点。
+
+### 4.4 i18n 与测试
+
+- 新增 key（示例）：`settings.updates.channel.label`、`settings.updates.channel.stable`、`settings.updates.channel.current`、`settings.updates.channel.currentUnavailable`、`settings.updates.homebrewManaged.title/.desc/.command` —— 同步 **en / zh-CN / pl** 三份 locale，`pnpm i18n:check` 过 parity。
+- 扩展 `src/__tests__/update-checker.test.tsx`：通道 → endpoint 断言（mock invoke）、托管安装禁用自动检查、macOS<26 时 current 不可选。
+
+---
+
+## 5. 官方 cask 草案与提交
+
+```ruby
+cask "r-shell" do
+  version "2.9.3"
+  sha256 arm:   "ARM_SHA256",
+         intel: "X64_SHA256"
+  arch arm: "aarch64", intel: "x64"
+
+  url "https://github.com/GOODBOY008/r-shell/releases/download/v#{version}/r-shell_#{version}_#{arch}.dmg",
+      verified: "github.com/GOODBOY008/r-shell/"
+  name "R-Shell"
+  desc "Modern desktop SSH client with terminal, SFTP and monitoring"
+  homepage "https://github.com/GOODBOY008/r-shell"
+
+  # 不设 depends_on macos（稳定线按 Tauri 默认 10.13 兼容）
+  # 不设 auto_updates：Caskroom 安装下应用内更新器自动禁用，更新交由 brew 管理
+
+  app "R-Shell.app"
+  zap trash: [
+    "~/Library/Application Support/com.aiden.r-shell",
+    "~/Library/Caches/com.aiden.r-shell",
+    "~/Library/Preferences/com.aiden.r-shell.plist",
+    "~/Library/WebKit/com.aiden.r-shell",
+    "~/Library/Saved Application State/com.aiden.r-shell.savedState",
+  ]
+end
+```
+
+注意：`app "R-Shell.app"` 的确切 bundle 名以产物为准（`productName` 决定）；sha256 来自 `checksums.txt`；`arch` 映射与现有资产名 `r-shell_<v>_aarch64.dmg` / `r-shell_<v>_x64.dmg` 精确对应。
+
+提交流程（由社区成员署名，见 §1.5）：
+
+1. fork `Homebrew/homebrew-cask` → `brew create --cask <url>` 生成初版；
+2. `brew audit --cask r-shell --online`、`brew style --fix` 全绿；
+3. PR 模板附：项目主页、截图、notability 依据（142⭐/33 forks，标准门槛 75⭐/30 forks 已过）；
+4. 合并后把仓库变量 `OFFICIAL_CASK_MERGED` 置 `true`，激活 §3.5 的 bump 自动化；日常版本仍可能被社区先 bump（cask 有 autobump 机制），与 `bump-cask-pr` 重复时该 job 允许失败（`continue-on-error: true`，冲突即无操作）。
+
+---
+
+## 6. 版本工具与流程文档
+
+- `scripts/bump-version.mjs` 增加 `--channel current`：版本写 `<semver>-current.<N>`（N = 该 minor 在 `git tag` 上的计数 +1）；晋升时正常 `version:patch/minor` 打稳定 tag 即可。CHANGELOG 按发布线分节（`## [3.0.0-current.3] - ...`）。
+- 顺带修复已知问题：脚本向 CHANGELOG 插入时依赖 `## [Unreleased]` 标题，而当前 CHANGELOG 没有该标题（插入会 no-op）——发版流程实际靠 release-version skill 手写。要么补标题，要么把脚本改为"在文件头版本区顶部插入"。
+- `.github/skills/release-version/SKILL.md` 增补：双 tag 约定、晋升流程、cask bump 检查、macOS 27 验证清单项。
+- README 安装段：官方 `brew install --cask r-shell` 置顶；私有 tap 段改为"早期用户 / current 通道"并附迁移命令。
+
+---
+
+## 7. 分阶段落地（2026-09-12 按 owner 三项决策修订）
+
+| 阶段 | 内容 | 状态 |
+|---|---|---|
+| **P0 更新器与 brew 和解 + 通道设置** | Caskroom 检测、设置改造（§4，含 `updateChannel`）、Rust updater 命令、i18n/测试 | 待实施——**下个版本前必须合入** |
+| **P1 双基线 CI** | 矩阵分线（§3.1/3.2）、`current.json` 滚动 tag（§3.4）、`update-homebrew` 加 `-current.` 过滤（§3.6）、bump-version `--channel`（§6） | 待实施——**下个版本前必须合入** |
+| **P2 演进线首发** | 下一个版本 = `v3.0.0-current.1`（mac arm64 min26 + linux + windows，GitHub prerelease），此后演进线 4–6 周一个 current 版、定期晋升 | 依赖 P0+P1 |
+| **P3 签名公证** | Apple Developer Program + CI secrets（§3.3） | **搁置**——owner 决定暂不申请；改变主意即可独立启动，直接下载用户即刻受益 |
+| **P4 官方收录** | owner 自投 cask PR（§5）+ 合并后 bump 自动化（§3.5）+ 私有 tap 迁移 | **搁置**——重启条件：notability 任一达标（225⭐/90 forks/90 watchers）**且** P3 完成；两个门槛独立，只等 star 不够 |
+| **P5 文档收尾** | README 安装段补"两条发布线 / 通道说明 / 手动切换指引"、release-version skill 更新、macOS 27 验证清单 | 随 P2 落地 |
+
+## 8. 风险与开放问题
+
+1. **notability 裁量**：数字达标不保证收录；新提交通常审得更严，PR 描述要备齐截图与定位说明。
+2. **稳定线回移成本**：双线 = 每个安全修复要 cherry-pick；晋升周期建议 4–6 周，过长则稳定线与演进线差距难以收敛。
+3. **滚动 tag `current`**：force-push 可变引用，个别工具（依赖 tag 不可变性的镜像）可能不适；可接受，文档注明。
+4. **更新器迁 Rust**：JS→Rust 的行为等价性靠现有测试兜底（update-checker.test.tsx 全量 mock invoke 重写）；`UpdaterBuilder::endpoints` 为公开 API，版本跟随 plugins-workspace 小版本演进，锁好 Cargo.lock。
+5. **`brew bump-cask-pr` 与社区 autobump 撞车**：job 容忍失败即可，冲突无副作用。
+6. **macOS 27 验证空窗**：runner 未就绪前依赖手动 QA，存在漏检风险（Tahoe→Golden Gate 的 WebKit 行为变化）。
+7. ~~开放问题（需 owner 决策）~~ **已决策（2026-09-12）**：a) 暂不申请 Apple Developer 账号 → P3/P4 搁置；b) 演进线下个版本首发（`v3.0.0-current.1`）；c) 官方 cask 由 owner 自投，条件 = notability 达标 **且** 公证就绪（§1.5）。
+
+---
+
+## 参考来源
+
+- Acceptable Casks：https://docs.brew.sh/Acceptable-Casks
+- Package Acceptance Policy（notability 门槛）：https://docs.brew.sh/Package-Acceptance-Policy
+- Cask Cookbook（auto_updates / arch DSL / depends_on）：https://docs.brew.sh/Cask-Cookbook
+- Support Tiers（2026-09 系统支持矩阵）：https://docs.brew.sh/Support-Tiers
+- Tauri Updater 插件文档：https://v2.tauri.app/plugin/updater/
+- UpdaterBuilder Rust API：https://docs.rs/tauri-plugin-updater/latest/tauri_plugin_updater/struct.UpdaterBuilder.html
+- plugin-updater JS API（CheckOptions 无 endpoint 字段）：https://v2.tauri.app/reference/javascript/updater/

--- a/scripts/bump-version.mjs
+++ b/scripts/bump-version.mjs
@@ -31,6 +31,19 @@ const bumpType = args[0] || 'patch';
 const noCommit = args.includes('--no-commit');
 const skipChangelog = args.includes('--skip-changelog');
 
+// Release channel: 'stable' (default) or 'current' (evolution line,
+// versions like 3.0.0-current.<N>).
+const channelFlagIndex = args.indexOf('--channel');
+const channel =
+  channelFlagIndex !== -1 && args[channelFlagIndex + 1]
+    ? args[channelFlagIndex + 1]
+    : args.find((a) => a.startsWith('--channel='))?.split('=')[1] || 'stable';
+
+if (!['stable', 'current'].includes(channel)) {
+  log.error(`Error: Invalid channel '${channel}'. Use: stable or current`);
+  process.exit(1);
+}
+
 // Validate bump type
 if (!['major', 'minor', 'patch'].includes(bumpType)) {
   log.error(`Error: Invalid bump type '${bumpType}'. Use: major, minor, or patch`);
@@ -48,10 +61,28 @@ const changelogPath = path.join(rootDir, 'CHANGELOG.md');
 const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf8'));
 const currentVersion = packageJson.version;
 
-log.info(`Current version: ${currentVersion}`);
+// Strip an evolution-line suffix (3.0.0-current.2 → 3.0.0) so both channels
+// can bump from either line.
+const currentSuffixMatch = currentVersion.match(/-current\.\d+$/);
+const baseVersion = currentSuffixMatch ? currentVersion.slice(0, currentSuffixMatch.index) : currentVersion;
+
+log.info(`Current version: ${currentVersion} (channel: ${channel})`);
+
+// Count existing evolution-line tags for a base version (v3.0.0-current.*)
+function currentTagCount(base) {
+  try {
+    const tags = execSync('git tag --list', { encoding: 'utf8' })
+      .trim()
+      .split('\n')
+      .filter(Boolean);
+    return tags.filter((tag) => tag.startsWith(`v${base}-current.`)).length;
+  } catch {
+    return 0;
+  }
+}
 
 // Calculate new version
-const [major, minor, patch] = currentVersion.split('.').map(Number);
+const [major, minor, patch] = baseVersion.split('.').map(Number);
 let newVersion;
 
 switch (bumpType) {
@@ -64,6 +95,18 @@ switch (bumpType) {
   case 'patch':
     newVersion = `${major}.${minor}.${patch + 1}`;
     break;
+}
+
+if (channel === 'current') {
+  if (currentSuffixMatch) {
+    // Already on the evolution line: the base stays fixed for the whole
+    // line and only the -current.N counter moves (bumpType is ignored —
+    // promotion to a new base happens on the stable channel).
+    newVersion = baseVersion;
+    log.warn(`Already on the current line — keeping base ${baseVersion} (${bumpType} ignored)`);
+  }
+  const n = currentTagCount(newVersion) + 1;
+  newVersion = `${newVersion}-current.${n}`;
 }
 
 log.success(`New version: ${newVersion}`);
@@ -140,11 +183,25 @@ function performBump() {
 - _Add bug fixes here_
 `;
 
-      // Insert after the Unreleased section
-      changelog = changelog.replace(
-        /(## \[Unreleased\][^\n]*\n\n[^\n]*\n\n)/,
-        `$1${newSection}\n`
-      );
+      // Insert after the Unreleased section when that heading exists. The
+      // repo's CHANGELOG has no `## [Unreleased]` heading (the historical
+      // regex then silently no-opped), so fall back to inserting at the top
+      // of the versioned region, right before the first `## [` heading.
+      const unreleased = changelog.match(/(## \[Unreleased\][^\n]*\n\n[^\n]*\n\n)/);
+      if (unreleased) {
+        changelog = changelog.replace(unreleased[1], `${unreleased[1]}${newSection}\n`);
+      } else {
+        const firstVersionHeading = /^## \[/m.exec(changelog);
+        if (firstVersionHeading) {
+          const insertAt = firstVersionHeading.index;
+          changelog =
+            changelog.slice(0, insertAt) +
+            newSection.trim() + '\n\n' +
+            changelog.slice(insertAt);
+        } else {
+          changelog = changelog.trimEnd() + '\n\n' + newSection.trim() + '\n';
+        }
+      }
 
       fs.writeFileSync(changelogPath, changelog);
       log.warn('⚠️  Please update CHANGELOG.md with actual changes before committing');

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -3682,11 +3682,16 @@ pub fn credential_open(sealed: String) -> Result<String, String> {
 
 // ========== In-App Updater (channel selection + Homebrew detection) ==========
 
-/// Error marker returned by `updater_check` when the running app lives in a
-/// Homebrew Caskroom. The frontend recognizes it and shows `brew upgrade`
-/// guidance instead of an error — the in-app updater must never replace a
+/// Error marker returned by `updater_check` when this install is managed by
+/// Homebrew. The frontend recognizes it and shows `brew upgrade` guidance
+/// instead of an error — the in-app updater must never replace a
 /// brew-managed .app (it would break the receipt/sha256 tracking).
 pub const HOMEBREW_MANAGED_MARKER: &str = "HOMEBREW_MANAGED_INSTALL";
+
+/// Cask tokens that install this app: the stable-line `r-shell` cask and the
+/// evolution-line `r-shell@current` cask. A receipt for either marks the
+/// install as brew-managed.
+const HOMEBREW_CASK_TOKENS: [&str; 2] = ["r-shell", "r-shell@current"];
 
 /// Stable channel manifest. `releases/latest` never points at a prerelease,
 /// so evolution-line tags (`v*-current.N`) cannot hijack this URL.
@@ -3725,14 +3730,83 @@ fn macos_major_version() -> Option<u32> {
     None
 }
 
+/// True when this install is managed by Homebrew. `brew install --cask`
+/// moves the .app out to /Applications and leaves only a symlink plus a
+/// receipt in the Caskroom, so the executable path normally contains no
+/// "Caskroom" — the receipt (`<prefix>/Caskroom/<token>/.metadata/
+/// INSTALL_RECEIPT.json`, present for every cask install) is the reliable
+/// marker. Requiring the receipt file (not just the Caskroom dir) keeps a
+/// stale uninstalled-cask directory from counting.
+fn cask_receipt_exists(prefixes: &[std::path::PathBuf]) -> bool {
+    prefixes.iter().any(|prefix| {
+        HOMEBREW_CASK_TOKENS.iter().any(|token| {
+            prefix
+                .join("Caskroom")
+                .join(token)
+                .join(".metadata")
+                .join("INSTALL_RECEIPT.json")
+                .exists()
+        })
+    })
+}
+
+fn homebrew_prefixes() -> Vec<std::path::PathBuf> {
+    // Both default prefixes (Apple Silicon / Intel) plus custom installs via
+    // HOMEBREW_PREFIX (unset for GUI apps launched from Finder/Dock).
+    let mut prefixes: Vec<std::path::PathBuf> = vec!["/opt/homebrew".into(), "/usr/local".into()];
+    if let Ok(custom) = std::env::var("HOMEBREW_PREFIX") {
+        if !custom.is_empty() {
+            prefixes.push(custom.into());
+        }
+    }
+    prefixes
+}
+
+/// The innermost `.app` bundle containing `exe`, if any (a dev build's
+/// `target/debug/r-shell` binary has none).
+fn app_bundle_dir(exe: &std::path::Path) -> Option<&std::path::Path> {
+    exe.ancestors().skip(1).find(|p| {
+        p.file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.ends_with(".app"))
+    })
+}
+
+fn bundle_in_applications(bundle: &std::path::Path, home: Option<&std::path::Path>) -> bool {
+    bundle.starts_with("/Applications")
+        || home.is_some_and(|h| bundle.starts_with(h.join("Applications")))
+}
+
+fn homebrew_managed() -> bool {
+    // Fast path: running straight out of a Caskroom (e.g. Homebrew staging
+    // or a hand-copied bundle kept in place).
+    if std::env::current_exe()
+        .map(|exe| exe.to_string_lossy().contains("/Caskroom/"))
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    // Standard layout: app moved to /Applications, receipt in the Caskroom.
+    // The /Applications qualifier keeps an unrelated copy on the same machine
+    // (e.g. a `tauri dev` build) from being classified as managed.
+    if !cask_receipt_exists(&homebrew_prefixes()) {
+        return false;
+    }
+    let Ok(exe) = std::env::current_exe() else {
+        return false;
+    };
+    let home = std::env::var("HOME")
+        .ok()
+        .map(std::path::PathBuf::from);
+    app_bundle_dir(&exe).is_some_and(|bundle| {
+        bundle_in_applications(bundle, home.as_deref())
+    })
+}
+
 #[tauri::command]
 pub fn get_update_context() -> UpdateContext {
-    let homebrew_managed = std::env::current_exe()
-        .map(|exe| exe.to_string_lossy().contains("/Caskroom/"))
-        .unwrap_or(false);
-
     UpdateContext {
-        homebrew_managed,
+        homebrew_managed: homebrew_managed(),
         platform: std::env::consts::OS.to_string(),
         arch: std::env::consts::ARCH.to_string(),
         macos_major: macos_major_version(),
@@ -3750,7 +3824,9 @@ pub struct UpdateMeta {
     pub body: Option<String>,
 }
 
-/// Process-wide cache of the update found by the last `updater_check`.
+/// Process-wide cache of the update found by the last `updater_check`. The
+/// entry survives a failed `updater_download_and_install` so the frontend's
+/// retry re-downloads; it is only cleared after a successful install.
 #[derive(Default)]
 pub struct PendingUpdate(Mutex<Option<tauri_plugin_updater::Update>>);
 
@@ -3761,7 +3837,7 @@ pub async fn updater_check(
     proxy: Option<String>,
     pending: State<'_, PendingUpdate>,
 ) -> Result<Option<UpdateMeta>, String> {
-    if get_update_context().homebrew_managed {
+    if homebrew_managed() {
         return Err(HOMEBREW_MANAGED_MARKER.to_string());
     }
 
@@ -3811,14 +3887,17 @@ pub async fn updater_download_and_install(
     app: tauri::AppHandle,
     pending: State<'_, PendingUpdate>,
 ) -> Result<(), String> {
-    let update = pending.0.lock().map_err(|e| e.to_string())?.take();
+    // Clone rather than take: `Update` is cheap to clone and the cached one
+    // must survive a failed transfer, otherwise the dialog's retry would
+    // always die with "No update available" instead of re-downloading.
+    let update = pending.0.lock().map_err(|e| e.to_string())?.clone();
     let Some(update) = update else {
         return Err("No update available — run updater_check first".to_string());
     };
 
     let mut downloaded: u64 = 0;
     let progress_app = app.clone();
-    update
+    let result = update
         .download_and_install(
             move |chunk_len, total| {
                 downloaded += chunk_len as u64;
@@ -3829,8 +3908,96 @@ pub async fn updater_download_and_install(
             },
             || {},
         )
-        .await
-        .map_err(|e| e.to_string())
+        .await;
+
+    match result {
+        Ok(()) => {
+            // Installed: drop the cache so a stale `Update` can never be
+            // re-downloaded against the now-current version.
+            *pending.0.lock().map_err(|e| e.to_string())? = None;
+            Ok(())
+        }
+        Err(e) => Err(e.to_string()),
+    }
+}
+
+// ========== Updater Tests ==========
+
+#[cfg(test)]
+mod updater_tests {
+    use super::*;
+
+    #[test]
+    fn cask_receipt_marks_homebrew_managed() {
+        let prefix = tempfile::tempdir().unwrap();
+        for token in HOMEBREW_CASK_TOKENS {
+            let receipt = prefix
+                .path()
+                .join("Caskroom")
+                .join(token)
+                .join(".metadata")
+                .join("INSTALL_RECEIPT.json");
+            std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+            std::fs::write(&receipt, "{}").unwrap();
+            assert!(
+                cask_receipt_exists(&[prefix.path().to_path_buf()]),
+                "receipt for {token} should mark the install as managed"
+            );
+        }
+    }
+
+    #[test]
+    fn no_receipt_means_unmanaged() {
+        let prefix = tempfile::tempdir().unwrap();
+        assert!(!cask_receipt_exists(&[prefix.path().to_path_buf()]));
+
+        // A Caskroom dir without the receipt (e.g. stale leftovers after a
+        // manual delete) must not count as a managed install.
+        let stale = prefix.path().join("Caskroom").join("r-shell").join("2.9.2");
+        std::fs::create_dir_all(&stale).unwrap();
+        assert!(!cask_receipt_exists(&[prefix.path().to_path_buf()]));
+    }
+
+    #[test]
+    fn other_casks_receipts_do_not_count() {
+        let prefix = tempfile::tempdir().unwrap();
+        let receipt = prefix
+            .path()
+            .join("Caskroom")
+            .join("some-other-app")
+            .join(".metadata")
+            .join("INSTALL_RECEIPT.json");
+        std::fs::create_dir_all(receipt.parent().unwrap()).unwrap();
+        std::fs::write(&receipt, "{}").unwrap();
+        assert!(!cask_receipt_exists(&[prefix.path().to_path_buf()]));
+    }
+
+    #[test]
+    fn app_bundle_detection_distinguishes_installed_from_dev_builds() {
+        let installed = std::path::Path::new("/Applications/r-shell.app/Contents/MacOS/r-shell");
+        let bundle = app_bundle_dir(installed).unwrap();
+        assert_eq!(bundle, std::path::Path::new("/Applications/r-shell.app"));
+        assert!(bundle_in_applications(bundle, Some(std::path::Path::new("/Users/dev"))));
+
+        let user_apps = std::path::Path::new("/Users/dev/Applications/r-shell.app/Contents/MacOS/r-shell");
+        assert!(bundle_in_applications(
+            app_bundle_dir(user_apps).unwrap(),
+            Some(std::path::Path::new("/Users/dev"))
+        ));
+
+        // A tauri-dev binary is not inside any .app bundle at all, so a
+        // receipt on the machine must not classify it as managed.
+        let dev_build = std::path::Path::new("/repo/src-tauri/target/debug/r-shell");
+        assert!(app_bundle_dir(dev_build).is_none());
+
+        // An .app bundle outside /Applications (e.g. run from a mounted dmg)
+        // is not the brew-managed copy either.
+        let from_dmg = std::path::Path::new("/Volumes/R-Shell/r-shell.app/Contents/MacOS/r-shell");
+        assert!(!bundle_in_applications(
+            app_bundle_dir(from_dmg).unwrap(),
+            Some(std::path::Path::new("/Users/dev"))
+        ));
+    }
 }
 
 // ========== Local Filesystem Tests ==========

--- a/src-tauri/src/commands.rs
+++ b/src-tauri/src/commands.rs
@@ -7,7 +7,8 @@ use crate::sftp_client::{FileEntry, FileEntryType, SftpAuthMethod, SftpConfig};
 use crate::ssh::{AuthMethod, SshConfig, TunnelConfig};
 use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use tauri::State;
+use tauri::{Emitter, State};
+use tauri_plugin_updater::UpdaterExt;
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ConnectRequest {
@@ -2844,7 +2845,10 @@ pub async fn list_local_files(path: String) -> Result<Vec<FileEntry>, String> {
         #[cfg(unix)]
         let (owner, group): (Option<String>, Option<String>) = {
             use std::os::unix::fs::MetadataExt;
-            (Some(metadata.uid().to_string()), Some(metadata.gid().to_string()))
+            (
+                Some(metadata.uid().to_string()),
+                Some(metadata.gid().to_string()),
+            )
         };
         #[cfg(not(unix))]
         let (owner, group): (Option<String>, Option<String>) = (None, None);
@@ -3631,8 +3635,8 @@ fn master_key() -> Result<Vec<u8>, String> {
 #[tauri::command]
 pub fn credential_seal(secret: String) -> Result<String, String> {
     let key = master_key()?;
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| format!("Failed to init cipher: {e}"))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| format!("Failed to init cipher: {e}"))?;
 
     use rand::RngCore;
     let mut nonce_bytes = [0u8; 12];
@@ -3667,13 +3671,166 @@ pub fn credential_open(sealed: String) -> Result<String, String> {
         .decode(parts[2])
         .map_err(|e| format!("Corrupt ciphertext: {e}"))?;
 
-    let cipher = Aes256Gcm::new_from_slice(&key)
-        .map_err(|e| format!("Failed to init cipher: {e}"))?;
+    let cipher =
+        Aes256Gcm::new_from_slice(&key).map_err(|e| format!("Failed to init cipher: {e}"))?;
     let plaintext = cipher
         .decrypt(Nonce::from_slice(&nonce_bytes), ciphertext.as_ref())
         .map_err(|e| format!("Failed to decrypt secret: {e}"))?;
 
     String::from_utf8(plaintext).map_err(|e| format!("Decrypted secret is not UTF-8: {e}"))
+}
+
+// ========== In-App Updater (channel selection + Homebrew detection) ==========
+
+/// Error marker returned by `updater_check` when the running app lives in a
+/// Homebrew Caskroom. The frontend recognizes it and shows `brew upgrade`
+/// guidance instead of an error — the in-app updater must never replace a
+/// brew-managed .app (it would break the receipt/sha256 tracking).
+pub const HOMEBREW_MANAGED_MARKER: &str = "HOMEBREW_MANAGED_INSTALL";
+
+/// Stable channel manifest. `releases/latest` never points at a prerelease,
+/// so evolution-line tags (`v*-current.N`) cannot hijack this URL.
+const STABLE_MANIFEST_URL: &str =
+    "https://github.com/GOODBOY008/r-shell/releases/latest/download/latest.json";
+/// Evolution channel manifest, attached to the rolling lightweight `current`
+/// tag (moved to the latest `v*-current.N` release by CI).
+const CURRENT_MANIFEST_URL: &str =
+    "https://github.com/GOODBOY008/r-shell/releases/download/current/current.json";
+
+/// Environment facts the update settings UI gates on. `current` channel is
+/// only offered for macOS ≥ 26 on Apple Silicon outside Homebrew.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateContext {
+    pub homebrew_managed: bool,
+    pub platform: String,
+    pub arch: String,
+    pub macos_major: Option<u32>,
+}
+
+/// Parse the macOS major version via `sw_vers -productVersion` (e.g. "26.1"
+/// → 26). Cheap enough to call per settings-modal open; None off-macOS.
+#[cfg(target_os = "macos")]
+fn macos_major_version() -> Option<u32> {
+    let output = std::process::Command::new("sw_vers")
+        .arg("-productVersion")
+        .output()
+        .ok()?;
+    let stdout = String::from_utf8(output.stdout).ok()?;
+    stdout.trim().split('.').next()?.parse().ok()
+}
+
+#[cfg(not(target_os = "macos"))]
+fn macos_major_version() -> Option<u32> {
+    None
+}
+
+#[tauri::command]
+pub fn get_update_context() -> UpdateContext {
+    let homebrew_managed = std::env::current_exe()
+        .map(|exe| exe.to_string_lossy().contains("/Caskroom/"))
+        .unwrap_or(false);
+
+    UpdateContext {
+        homebrew_managed,
+        platform: std::env::consts::OS.to_string(),
+        arch: std::env::consts::ARCH.to_string(),
+        macos_major: macos_major_version(),
+    }
+}
+
+/// Projection of `tauri_plugin_updater::Update` for the frontend. The real
+/// `Update` (not serializable) is cached in [`PendingUpdate`] for the
+/// download-and-install step.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateMeta {
+    pub version: String,
+    pub current_version: String,
+    pub body: Option<String>,
+}
+
+/// Process-wide cache of the update found by the last `updater_check`.
+#[derive(Default)]
+pub struct PendingUpdate(Mutex<Option<tauri_plugin_updater::Update>>);
+
+#[tauri::command]
+pub async fn updater_check(
+    app: tauri::AppHandle,
+    channel: String,
+    proxy: Option<String>,
+    pending: State<'_, PendingUpdate>,
+) -> Result<Option<UpdateMeta>, String> {
+    if get_update_context().homebrew_managed {
+        return Err(HOMEBREW_MANAGED_MARKER.to_string());
+    }
+
+    // Endpoint override only exists on the Rust UpdaterBuilder (the JS
+    // CheckOptions have no such field), which is why the check lives here.
+    let endpoint = match channel.as_str() {
+        "stable" => STABLE_MANIFEST_URL,
+        "current" => CURRENT_MANIFEST_URL,
+        _ => return Err(format!("Unknown update channel: {channel}")),
+    };
+
+    let mut builder = app
+        .updater_builder()
+        .endpoints(vec![endpoint
+            .parse()
+            .map_err(|e| format!("Invalid endpoint: {e}"))?])
+        .map_err(|e| e.to_string())?;
+
+    if let Some(proxy) = proxy {
+        let url: tauri::Url = proxy
+            .parse()
+            .map_err(|_| "Invalid update proxy URL".to_string())?;
+        if url.scheme() != "http" && url.scheme() != "https" {
+            return Err("Invalid update proxy URL".to_string());
+        }
+        builder = builder.proxy(url);
+    }
+
+    let update = builder
+        .build()
+        .map_err(|e| e.to_string())?
+        .check()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    *pending.0.lock().map_err(|e| e.to_string())? = update.clone();
+
+    Ok(update.map(|u| UpdateMeta {
+        version: u.version.clone(),
+        current_version: u.current_version.clone(),
+        body: u.body.clone(),
+    }))
+}
+
+#[tauri::command]
+pub async fn updater_download_and_install(
+    app: tauri::AppHandle,
+    pending: State<'_, PendingUpdate>,
+) -> Result<(), String> {
+    let update = pending.0.lock().map_err(|e| e.to_string())?.take();
+    let Some(update) = update else {
+        return Err("No update available — run updater_check first".to_string());
+    };
+
+    let mut downloaded: u64 = 0;
+    let progress_app = app.clone();
+    update
+        .download_and_install(
+            move |chunk_len, total| {
+                downloaded += chunk_len as u64;
+                let _ = progress_app.emit(
+                    "updater://progress",
+                    serde_json::json!({ "downloaded": downloaded, "total": total }),
+                );
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| e.to_string())
 }
 
 // ========== Local Filesystem Tests ==========

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -78,7 +78,11 @@ fn build_app_menu<F: Fn(&str) -> String>(
         "r-shell",
         true,
         &[
-            &PredefinedMenuItem::about(app, Some(&t("menuBar.about")), Some(AboutMetadata::default()))?,
+            &PredefinedMenuItem::about(
+                app,
+                Some(&t("menuBar.about")),
+                Some(AboutMetadata::default()),
+            )?,
             &PredefinedMenuItem::separator(app)?,
             &PredefinedMenuItem::services(app, Some(&t("menuBar.services")))?,
             &PredefinedMenuItem::separator(app)?,
@@ -399,9 +403,7 @@ pub fn run() {
                 // registers global shortcuts today.
                 if window.label() == "main" {
                     use tauri_plugin_global_shortcut::GlobalShortcutExt;
-                    if let Err(e) =
-                        window.app_handle().global_shortcut().unregister_all()
-                    {
+                    if let Err(e) = window.app_handle().global_shortcut().unregister_all() {
                         tracing::warn!(
                             "Failed to unregister global shortcuts on window destroy: {e}"
                         );
@@ -411,6 +413,7 @@ pub fn run() {
         })
         .manage(connection_manager)
         .manage(quit_guard::QuitGuard::default())
+        .manage(commands::PendingUpdate::default())
         .invoke_handler(tauri::generate_handler![
             commands::ssh_connect,
             commands::ssh_cancel_connect,
@@ -490,6 +493,10 @@ pub fn run() {
             commands::editor_dirty_changed,
             commands::credential_seal,
             commands::credential_open,
+            // In-app updater (channel endpoints + Homebrew detection)
+            commands::get_update_context,
+            commands::updater_check,
+            commands::updater_download_and_install,
             // Note: PTY terminal I/O now uses WebSocket instead of IPC
             // WebSocket server runs on a dynamically assigned port (9001-9010)
         ])
@@ -505,7 +512,9 @@ pub fn run() {
             // convention. code: None means user-initiated window closure —
             // explicit exits (quit_guard app.exit(0), updater restart)
             // arrive as code: Some(_) and fall through unprevented.
-            tauri::RunEvent::ExitRequested { code: None, api, .. } => {
+            tauri::RunEvent::ExitRequested {
+                code: None, api, ..
+            } => {
                 #[cfg(target_os = "macos")]
                 api.prevent_exit();
                 #[cfg(not(target_os = "macos"))]
@@ -566,11 +575,42 @@ mod shortcut_accelerator_tests {
 
         // Named keys and symbols that customizable bindings can produce
         let keys = [
-            "Escape", "Enter", "Space", "Backspace", "Delete", "Insert", "PageUp", "PageDown",
-            "Home", "End", "ArrowUp", "ArrowDown", "ArrowLeft", "ArrowRight", "Pause",
-            "CapsLock", "PrintScreen", "ScrollLock", "NumLock", "F1", "F5", "F13", "F24",
-            "Backquote", "BracketLeft", "BracketRight", "Comma", "Equal", "Minus", "Period",
-            "Quote", "Semicolon", "Slash", "1", "9", "0",
+            "Escape",
+            "Enter",
+            "Space",
+            "Backspace",
+            "Delete",
+            "Insert",
+            "PageUp",
+            "PageDown",
+            "Home",
+            "End",
+            "ArrowUp",
+            "ArrowDown",
+            "ArrowLeft",
+            "ArrowRight",
+            "Pause",
+            "CapsLock",
+            "PrintScreen",
+            "ScrollLock",
+            "NumLock",
+            "F1",
+            "F5",
+            "F13",
+            "F24",
+            "Backquote",
+            "BracketLeft",
+            "BracketRight",
+            "Comma",
+            "Equal",
+            "Minus",
+            "Period",
+            "Quote",
+            "Semicolon",
+            "Slash",
+            "1",
+            "9",
+            "0",
         ];
         for key in keys {
             accelerators.push(format!("CommandOrControl+{key}"));

--- a/src/__tests__/update-checker.test.tsx
+++ b/src/__tests__/update-checker.test.tsx
@@ -3,10 +3,9 @@ import { render, screen, act, waitFor } from '@testing-library/react';
 
 // ── Hoisted mocks (must exist before vi.mock factories run) ─────────────────
 
-const { mockCheck, mockDownload, mockInstall, mockRelaunch, mockToast } = vi.hoisted(() => ({
-  mockCheck: vi.fn(),
-  mockDownload: vi.fn(),
-  mockInstall: vi.fn(),
+const { mockInvoke, mockListen, mockRelaunch, mockToast } = vi.hoisted(() => ({
+  mockInvoke: vi.fn(),
+  mockListen: vi.fn(),
   mockRelaunch: vi.fn(),
   mockToast: {
     loading: vi.fn(),
@@ -17,8 +16,12 @@ const { mockCheck, mockDownload, mockInstall, mockRelaunch, mockToast } = vi.hoi
   },
 }));
 
-vi.mock('@tauri-apps/plugin-updater', () => ({
-  check: (...args: unknown[]) => mockCheck(...args),
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: (...args: unknown[]) => mockInvoke(...args),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: (...args: unknown[]) => mockListen(...args),
 }));
 
 vi.mock('@tauri-apps/plugin-process', () => ({
@@ -52,21 +55,31 @@ vi.mock('../components/ui/button', () => ({
 
 import { UpdateChecker } from '../components/update-checker';
 import { APP_SETTINGS_STORAGE_KEY } from '../lib/keyboard-shortcuts';
+import { isCurrentChannelEligible } from '../lib/update-channel';
+import type { UpdateContext } from '../lib/update-channel';
 
 // ── Helpers ─────────────────────────────────────────────────────────────────
 
-/** Create a fake Update object matching the plugin-updater shape. */
-function makeUpdate(version = '9.9.9', body?: string) {
+/** A non-managed macOS 26 arm64 context — the only shape where `current` is eligible. */
+function eligibleContext(): UpdateContext {
+  return { homebrewManaged: false, platform: 'macos', arch: 'aarch64', macosMajor: 26 };
+}
+
+function makeContext(overrides: Partial<UpdateContext>): UpdateContext {
+  return { ...eligibleContext(), ...overrides };
+}
+
+/** Create a fake UpdateMeta payload matching the `updater_check` result. */
+function makeUpdateMeta(version = '9.9.9', body?: string) {
   return {
-    available: true,
-    currentVersion: '1.0.0',
     version,
-    body,
-    rawJson: {},
-    download: mockDownload,
-    install: mockInstall,
+    currentVersion: '1.0.0',
+    body: body ?? null,
   };
 }
+
+/** Captured updater://progress listener, if the component subscribed one. */
+let progressListener: ((event: { payload: { downloaded: number; total: number | null } }) => void) | null = null;
 
 // ── Tests ───────────────────────────────────────────────────────────────────
 
@@ -74,73 +87,170 @@ describe('UpdateChecker', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     localStorage.clear();
-    // Default: check() resolves to null (no update)
-    mockCheck.mockResolvedValue(null);
+    progressListener = null;
+
+    // Default backend behavior: eligible context, no update available.
+    mockInvoke.mockImplementation((cmd: string) => {
+      if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+      if (cmd === 'updater_check') return Promise.resolve(null);
+      if (cmd === 'updater_download_and_install') return Promise.resolve(undefined);
+      return Promise.reject(new Error(`unexpected command: ${cmd}`));
+    });
+    mockListen.mockImplementation(
+      async (_event: string, handler: (e: { payload: { downloaded: number; total: number | null } }) => void) => {
+        progressListener = handler;
+        return () => {};
+      }
+    );
   });
 
   // ── Auto-check on mount ────────────────────────────────────────────────
 
   describe('auto-check on mount', () => {
-    it('calls check() when auto-check is enabled (default)', async () => {
+    it('runs updater_check when auto-check is enabled (default)', async () => {
       render(<UpdateChecker />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
     });
 
-    it('calls check() when checkUpdates is true in localStorage', async () => {
+    it('runs updater_check when checkUpdates is true in localStorage', async () => {
       localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ checkUpdates: true }));
       render(<UpdateChecker />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
     });
 
-    it('uses the saved proxy when checking for updates', async () => {
-      localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({
-        checkUpdates: true,
-        updateProxy: '  http://127.0.0.1:7890  ',
-      }));
-
-      render(<UpdateChecker />);
-
-      await waitFor(() => {
-        expect(mockCheck).toHaveBeenCalledWith({ proxy: 'http://127.0.0.1:7890' });
-      });
-    });
-
-    it('skips check() when checkUpdates is false in localStorage', async () => {
+    it('skips updater_check when checkUpdates is false in localStorage', async () => {
       localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ checkUpdates: false }));
       render(<UpdateChecker />);
-      // Give time for the effect to run
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      expect(mockCheck).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalledWith('updater_check', expect.anything());
+    });
+
+    it('never auto-checks on a Homebrew-managed install', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(makeContext({ homebrewManaged: true }));
+        if (cmd === 'updater_check') return Promise.resolve(null);
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
+
+      render(<UpdateChecker />);
+      await act(async () => { await new Promise(r => setTimeout(r, 50)); });
+
+      expect(mockInvoke).toHaveBeenCalledWith('get_update_context');
+      expect(mockInvoke).not.toHaveBeenCalledWith('updater_check', expect.anything());
     });
 
     it('shows no toast on silent auto-check when no update', async () => {
       render(<UpdateChecker />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
       expect(mockToast.success).not.toHaveBeenCalled();
       expect(mockToast.error).not.toHaveBeenCalled();
       expect(mockToast.loading).not.toHaveBeenCalled();
     });
 
     it('shows no toast on silent auto-check when check fails', async () => {
-      mockCheck.mockRejectedValue(new Error('network timeout'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('network timeout');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       render(<UpdateChecker />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
       expect(mockToast.error).not.toHaveBeenCalled();
+    });
+  });
+
+  // ── Channel selection → endpoint contract ──────────────────────────────
+
+  describe('channel selection', () => {
+    it('checks the stable channel by default', async () => {
+      render(<UpdateChecker />);
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', {
+          channel: 'stable',
+          proxy: null,
+        })
+      );
+    });
+
+    it('passes the current channel through when the context is eligible', async () => {
+      localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ updateChannel: 'current' }));
+      render(<UpdateChecker />);
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', {
+          channel: 'current',
+          proxy: null,
+        })
+      );
+    });
+
+    it('falls back to stable when the context is not eligible (macOS < 26)', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(makeContext({ macosMajor: 25 }));
+        if (cmd === 'updater_check') return Promise.resolve(null);
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
+      localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({ updateChannel: 'current' }));
+
+      render(<UpdateChecker />);
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
+      expect(mockInvoke).toHaveBeenCalledWith('updater_check', {
+        channel: 'stable',
+        proxy: null,
+      });
+    });
+  });
+
+  // ── Channel eligibility gating (pure helper) ────────────────────────────
+
+  describe('isCurrentChannelEligible', () => {
+    it('is eligible on macOS 26+ Apple Silicon, not Homebrew-managed', () => {
+      expect(isCurrentChannelEligible(eligibleContext())).toBe(true);
+      expect(isCurrentChannelEligible(makeContext({ macosMajor: 27 }))).toBe(true);
+    });
+
+    it('is NOT eligible on macOS < 26', () => {
+      expect(isCurrentChannelEligible(makeContext({ macosMajor: 25 }))).toBe(false);
+      expect(isCurrentChannelEligible(makeContext({ macosMajor: 15 }))).toBe(false);
+    });
+
+    it('is NOT eligible on Intel macs, Linux/Windows, or managed installs', () => {
+      expect(isCurrentChannelEligible(makeContext({ arch: 'x86_64' }))).toBe(false);
+      expect(isCurrentChannelEligible(makeContext({ platform: 'linux', arch: 'x86_64', macosMajor: null }))).toBe(false);
+      expect(isCurrentChannelEligible(makeContext({ platform: 'windows', arch: 'x86_64', macosMajor: null }))).toBe(false);
+      expect(isCurrentChannelEligible(makeContext({ homebrewManaged: true }))).toBe(false);
+    });
+
+    it('is NOT eligible when the macOS version is unknown', () => {
+      expect(isCurrentChannelEligible(makeContext({ macosMajor: null }))).toBe(false);
     });
   });
 
   // ── Manual check via signal ────────────────────────────────────────────
 
   describe('manual check via signal', () => {
-    it('triggers check() when checkSignal changes', async () => {
+    it('triggers updater_check when checkSignal changes', async () => {
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       // auto-check fires on mount
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
-      mockCheck.mockClear();
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
+      mockInvoke.mockClear();
 
       // Increment signal → manual check
       rerender(<UpdateChecker checkSignal={1} />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
     });
 
     it('uses the saved proxy for a manual check', async () => {
@@ -152,9 +262,12 @@ describe('UpdateChecker', () => {
 
       rerender(<UpdateChecker checkSignal={1} />);
 
-      await waitFor(() => {
-        expect(mockCheck).toHaveBeenCalledWith({ proxy: 'http://127.0.0.1:7890' });
-      });
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', {
+          channel: 'stable',
+          proxy: 'http://127.0.0.1:7890',
+        })
+      );
     });
 
     it('rejects an invalid saved proxy before calling the updater', async () => {
@@ -167,28 +280,34 @@ describe('UpdateChecker', () => {
       rerender(<UpdateChecker checkSignal={1} />);
 
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
-      expect(mockCheck).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalledWith('updater_check', expect.anything());
       expect(mockToast.error.mock.calls[0][1].description).toBe(
         'Enter a valid HTTP or HTTPS proxy URL.',
       );
     });
 
     it('shows loading toast during manual check', async () => {
-      // Make check() hang until we resolve it
+      // Make updater_check hang until we resolve it
       let resolveCheck: (v: null) => void;
-      mockCheck.mockImplementation(() => new Promise(r => { resolveCheck = r as (v: null) => void; }));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return new Promise(r => { resolveCheck = r as (v: null) => void; });
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
 
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
-      // Let auto-check settle (it will hang too, but we test manual below)
+      // Let auto-check settle
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-
-      // Resolve the auto-check so busy clears
       await act(async () => { resolveCheck!(null); });
-      mockCheck.mockClear();
+      mockInvoke.mockClear();
       mockToast.loading.mockClear();
 
       // Manual check
-      mockCheck.mockImplementation(() => new Promise(r => { resolveCheck = r as (v: null) => void; }));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return new Promise(r => { resolveCheck = r as (v: null) => void; });
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       rerender(<UpdateChecker checkSignal={1} />);
       await act(async () => { await new Promise(r => setTimeout(r, 30)); });
 
@@ -200,15 +319,39 @@ describe('UpdateChecker', () => {
       expect(mockToast.success).toHaveBeenCalledWith("You're up to date!");
     });
 
-    it('does NOT trigger check() when signal is same value', async () => {
+    it('does NOT trigger updater_check when signal is same value', async () => {
       const { rerender } = render(<UpdateChecker checkSignal={5} />);
-      await waitFor(() => expect(mockCheck).toHaveBeenCalledTimes(1));
-      mockCheck.mockClear();
+      await waitFor(() =>
+        expect(mockInvoke).toHaveBeenCalledWith('updater_check', expect.anything())
+      );
+      mockInvoke.mockClear();
 
       // Re-render with same signal → no new check
       rerender(<UpdateChecker checkSignal={5} />);
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      expect(mockCheck).not.toHaveBeenCalled();
+      expect(mockInvoke).not.toHaveBeenCalledWith('updater_check', expect.anything());
+    });
+
+    it('shows brew guidance toast on a managed install instead of an error', async () => {
+      // Rust side reports the managed marker even though the cached context
+      // said unmanaged (defense in depth: backend is source of truth).
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('HOMEBREW_MANAGED_INSTALL');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
+
+      const { rerender } = render(<UpdateChecker checkSignal={0} />);
+      await act(async () => { await new Promise(r => setTimeout(r, 30)); });
+      mockInvoke.mockClear();
+      mockToast.info.mockClear();
+
+      rerender(<UpdateChecker checkSignal={1} />);
+      await waitFor(() => expect(mockToast.info).toHaveBeenCalled());
+
+      expect(mockToast.error).not.toHaveBeenCalled();
+      expect(mockToast.info.mock.calls[0][0]).toBe('Updates are managed by Homebrew');
+      expect(mockToast.info.mock.calls[0][1].description).toContain('brew upgrade --cask r-shell');
     });
   });
 
@@ -216,7 +359,11 @@ describe('UpdateChecker', () => {
 
   describe('update available', () => {
     it('opens dialog with version info when update is found', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('2.0.0', 'Bug fixes'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('2.0.0', 'Bug fixes'));
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       render(<UpdateChecker />);
 
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -226,7 +373,11 @@ describe('UpdateChecker', () => {
     });
 
     it('shows fallback notes when update has no body', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('2.0.0'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('2.0.0'));
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       render(<UpdateChecker />);
 
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -234,7 +385,11 @@ describe('UpdateChecker', () => {
     });
 
     it('shows Download update button in available state', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('3.0.0'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('3.0.0'));
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       render(<UpdateChecker />);
 
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -247,12 +402,15 @@ describe('UpdateChecker', () => {
 
   describe('error handling', () => {
     it('maps 404 error to friendly message on manual check', async () => {
-      mockCheck.mockRejectedValue(new Error('HTTP 404 not found'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('HTTP 404 not found');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      mockCheck.mockClear();
+      mockInvoke.mockClear();
 
-      mockCheck.mockRejectedValue(new Error('HTTP 404 not found'));
       rerender(<UpdateChecker checkSignal={1} />);
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
 
@@ -262,12 +420,15 @@ describe('UpdateChecker', () => {
     });
 
     it('maps network error to friendly message on manual check', async () => {
-      mockCheck.mockRejectedValue(new Error('dns resolution failed'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('dns resolution failed');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      mockCheck.mockClear();
+      mockInvoke.mockClear();
 
-      mockCheck.mockRejectedValue(new Error('dns resolution failed'));
       rerender(<UpdateChecker checkSignal={1} />);
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
 
@@ -276,12 +437,15 @@ describe('UpdateChecker', () => {
     });
 
     it('maps signature/verify error to friendly message', async () => {
-      mockCheck.mockRejectedValue(new Error('signature verification failed'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('signature verification failed');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      mockCheck.mockClear();
+      mockInvoke.mockClear();
 
-      mockCheck.mockRejectedValue(new Error('signature verification failed'));
       rerender(<UpdateChecker checkSignal={1} />);
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
 
@@ -290,12 +454,15 @@ describe('UpdateChecker', () => {
     });
 
     it('passes through unknown error messages as-is', async () => {
-      mockCheck.mockRejectedValue(new Error('something weird happened'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.reject('something weird happened');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       await act(async () => { await new Promise(r => setTimeout(r, 50)); });
-      mockCheck.mockClear();
+      mockInvoke.mockClear();
 
-      mockCheck.mockRejectedValue(new Error('something weird happened'));
       rerender(<UpdateChecker checkSignal={1} />);
       await waitFor(() => expect(mockToast.error).toHaveBeenCalled());
 
@@ -309,18 +476,23 @@ describe('UpdateChecker', () => {
   describe('busy guard', () => {
     it('prevents concurrent checks when already checking', async () => {
       let resolveCheck: (v: null) => void;
-      mockCheck.mockImplementation(() => new Promise(r => { resolveCheck = r as (v: null) => void; }));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return new Promise(r => { resolveCheck = r as (v: null) => void; });
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
 
       const { rerender } = render(<UpdateChecker checkSignal={0} />);
       await act(async () => { await new Promise(r => setTimeout(r, 30)); });
-      // check() is pending (busy)
+      // updater_check is pending (busy)
 
       // Try manual check while busy
       rerender(<UpdateChecker checkSignal={1} />);
       await act(async () => { await new Promise(r => setTimeout(r, 30)); });
 
-      // check() should still only be called once (from auto-check)
-      expect(mockCheck).toHaveBeenCalledTimes(1);
+      // updater_check should still only be called once (from auto-check)
+      const checks = mockInvoke.mock.calls.filter(([cmd]: [string]) => cmd === 'updater_check');
+      expect(checks).toHaveLength(1);
 
       // Resolve the pending check
       await act(async () => { resolveCheck!(null); });
@@ -330,34 +502,49 @@ describe('UpdateChecker', () => {
   // ── Download flow ─────────────────────────────────────────────────────
 
   describe('download flow', () => {
-    it('tracks download progress and shows ready state', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('5.0.0'));
-
-      // Simulate download with progress events
-      mockDownload.mockImplementation(async (onEvent: (e: any) => void) => {
-        onEvent({ event: 'Started', data: { contentLength: 1000 } });
-        onEvent({ event: 'Progress', data: { chunkLength: 500 } });
-        onEvent({ event: 'Progress', data: { chunkLength: 500 } });
-        onEvent({ event: 'Finished' });
+    it('tracks updater://progress events and shows ready state', async () => {
+      let resolveInstall: (v: undefined) => void;
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('5.0.0'));
+        if (cmd === 'updater_download_and_install') return new Promise(r => { resolveInstall = r; });
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
       });
 
       render(<UpdateChecker />);
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
 
-      // Click "Download update"
+      // Click "Download update" — the install command stays pending while
+      // we feed progress events through the captured listener.
       await act(async () => {
         screen.getByText('Download update').click();
-        await new Promise(r => setTimeout(r, 50));
+        await new Promise(r => setTimeout(r, 30));
       });
 
-      // After download completes, should show "Restart now"
+      expect(mockInvoke).toHaveBeenCalledWith('updater_download_and_install');
+
+      await act(async () => {
+        progressListener!({ payload: { downloaded: 50, total: 100 } });
+        await new Promise(r => setTimeout(r, 10));
+      });
+      expect(screen.getByTestId('progress').getAttribute('data-value')).toBe('50');
+
+      // Finish the install → ready state
+      await act(async () => {
+        resolveInstall!(undefined);
+        await new Promise(r => setTimeout(r, 10));
+      });
       await waitFor(() => expect(screen.getByText('Restart now')).toBeTruthy());
       expect(screen.getByText('Update ready to install')).toBeTruthy();
     });
 
     it('shows error toast when download fails', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('5.0.0'));
-      mockDownload.mockRejectedValue(new Error('disk full'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('5.0.0'));
+        if (cmd === 'updater_download_and_install') return Promise.reject('disk full');
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
 
       render(<UpdateChecker />);
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -377,9 +564,13 @@ describe('UpdateChecker', () => {
   // ── Install flow ──────────────────────────────────────────────────────
 
   describe('install flow', () => {
-    it('calls install() then relaunch() on Restart now', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('5.0.0'));
-      mockDownload.mockResolvedValue(undefined);
+    it('relaunches on Restart now (install already done by the backend)', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('5.0.0'));
+        if (cmd === 'updater_download_and_install') return Promise.resolve(undefined);
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
 
       render(<UpdateChecker />);
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -391,20 +582,23 @@ describe('UpdateChecker', () => {
       });
       await waitFor(() => expect(screen.getByText('Restart now')).toBeTruthy());
 
-      // Install
+      // Restart
       await act(async () => {
         screen.getByText('Restart now').click();
         await new Promise(r => setTimeout(r, 50));
       });
 
-      expect(mockInstall).toHaveBeenCalledTimes(1);
       expect(mockRelaunch).toHaveBeenCalledTimes(1);
     });
 
-    it('shows error toast when install fails', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('5.0.0'));
-      mockDownload.mockResolvedValue(undefined);
-      mockInstall.mockRejectedValue(new Error('permission denied'));
+    it('shows error toast when relaunch fails', async () => {
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('5.0.0'));
+        if (cmd === 'updater_download_and_install') return Promise.resolve(undefined);
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
+      mockRelaunch.mockRejectedValue(new Error('permission denied'));
 
       render(<UpdateChecker />);
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
@@ -431,7 +625,11 @@ describe('UpdateChecker', () => {
 
   describe('later button', () => {
     it('closes dialog and resets state', async () => {
-      mockCheck.mockResolvedValue(makeUpdate('5.0.0'));
+      mockInvoke.mockImplementation((cmd: string) => {
+        if (cmd === 'get_update_context') return Promise.resolve(eligibleContext());
+        if (cmd === 'updater_check') return Promise.resolve(makeUpdateMeta('5.0.0'));
+        return Promise.reject(new Error(`unexpected command: ${cmd}`));
+      });
       render(<UpdateChecker />);
       await waitFor(() => expect(screen.getByRole('dialog')).toBeTruthy());
 

--- a/src/components/settings-modal.tsx
+++ b/src/components/settings-modal.tsx
@@ -59,7 +59,12 @@ import {
   importAllConfig,
 } from '@/lib/config-export-import';
 import { normalizeUpdateProxy } from '@/lib/update-proxy';
-import { isTauri } from '@tauri-apps/api/core';
+import { isTauri, invoke } from '@tauri-apps/api/core';
+import {
+  DEFAULT_UPDATE_CONTEXT,
+  isCurrentChannelEligible,
+  type UpdateContext,
+} from '@/lib/update-channel';
 import { open as openDialog } from '@tauri-apps/plugin-dialog';
 import { readFile } from '@tauri-apps/plugin-fs';
 import { enable as enableAutostart, disable as disableAutostart, isEnabled as isAutostartEnabled } from '@tauri-apps/plugin-autostart';
@@ -139,6 +144,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
     logLevel: 'info',
     maxLogSize: 100,
     checkUpdates: true,
+    updateChannel: 'stable',
     updateProxy: '',
     telemetry: false,
 
@@ -149,6 +155,16 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
   // True once the user has manually changed the autostart toggle (or reset
   // settings) while the modal is open — the OS state query must not clobber it.
   const autostartTouchedRef = useRef(false);
+
+  // Backend facts for the update group: Homebrew detection hides the channel/
+  // auto-check/proxy controls (brew owns updates), platform/arch/macOS major
+  // gate the `current` channel. Null in browser dev mode → gating stays off.
+  const [updateContext, setUpdateContext] = useState<UpdateContext | null>(null);
+
+  const currentChannelEligible = isCurrentChannelEligible(updateContext ?? DEFAULT_UPDATE_CONTEXT);
+  const homebrewManaged = updateContext?.homebrewManaged ?? false;
+  const channelValue =
+    settings.updateChannel === 'current' && currentChannelEligible ? 'current' : 'stable';
 
   // Load settings when modal opens
   useEffect(() => {
@@ -179,6 +195,10 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
       // the actual launch-at-login configuration, not a cached value.
       // Skip in browser dev mode where the Tauri backend is absent.
       if (isTauri()) {
+        invoke<UpdateContext>('get_update_context')
+          .then(setUpdateContext)
+          .catch(() => setUpdateContext(null));
+
         // Each open re-reads the OS state; discard any prior touch flag
         autostartTouchedRef.current = false;
         isAutostartEnabled()
@@ -341,6 +361,9 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
     localStorage.setItem(APP_SETTINGS_STORAGE_KEY, JSON.stringify({
       ...settings,
       updateProxy: updateProxy ?? '',
+      // A stored `current` preference that no longer qualifies (e.g. the app
+      // moved to a Homebrew install or an older macOS) falls back to stable.
+      updateChannel: channelValue,
     }));
     window.dispatchEvent(new Event(APP_SETTINGS_CHANGED_EVENT));
     onOpenChange(false);
@@ -380,6 +403,7 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
         logLevel: 'info',
         maxLogSize: 100,
         checkUpdates: true,
+        updateChannel: 'stable',
         updateProxy: '',
         telemetry: false,
         autostart: false
@@ -1334,47 +1358,86 @@ export function SettingsModal({ open, onOpenChange, onAppearanceChange, onCheckF
 
                 <Separator />
 
-                <div className="flex items-center justify-between">
-                  <div className="space-y-0.5">
-                    <Label>{t('settings.advanced.checkUpdates')}</Label>
-                    <p className="text-sm text-muted-foreground">
-                      {t('settings.advanced.checkUpdatesDesc')}
+                {homebrewManaged ? (
+                  <div className="space-y-2 rounded-lg border border-border bg-muted/50 p-3">
+                    <p className="text-sm font-medium">
+                      {t('settings.updates.homebrewManaged.title')}
                     </p>
+                    <p className="text-sm text-muted-foreground">
+                      {t('settings.updates.homebrewManaged.desc')}
+                    </p>
+                    <code className="block rounded border border-border bg-background px-2 py-1.5 font-mono text-xs">
+                      {t('settings.updates.homebrewManaged.command')}
+                    </code>
                   </div>
-                  <div className="flex items-center gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => {
-                        if (handleSave()) {
-                          onCheckForUpdates?.();
-                        }
-                      }}
-                      className="gap-1.5"
-                    >
-                      <RefreshCw className="h-3.5 w-3.5" />
-                      {t('settings.advanced.checkNow')}
-                    </Button>
-                    <Switch
-                      checked={settings.checkUpdates}
-                      onCheckedChange={(checked) => updateSetting('checkUpdates', checked)}
-                    />
-                  </div>
-                </div>
+                ) : (
+                  <>
+                    <div className="space-y-2">
+                      <Label>{t('settings.updates.channel.label')}</Label>
+                      <Select
+                        value={channelValue}
+                        onValueChange={(value) => updateSetting('updateChannel', value)}
+                      >
+                        <SelectTrigger>
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          <SelectItem value="stable">{t('settings.updates.channel.stable')}</SelectItem>
+                          <SelectItem value="current" disabled={!currentChannelEligible}>
+                            {t('settings.updates.channel.current')}
+                          </SelectItem>
+                        </SelectContent>
+                      </Select>
+                      <p className="text-sm text-muted-foreground">
+                        {currentChannelEligible
+                          ? t('settings.updates.channel.currentHint')
+                          : t('settings.updates.channel.currentUnavailable')}
+                      </p>
+                    </div>
 
-                <div className="space-y-2">
-                  <Label htmlFor="update-proxy">{t('settings.advanced.updateProxy')}</Label>
-                  <Input
-                    id="update-proxy"
-                    type="url"
-                    placeholder={t('settings.advanced.updateProxyPlaceholder')}
-                    value={settings.updateProxy}
-                    onChange={(event) => updateSetting('updateProxy', event.target.value)}
-                  />
-                  <p className="text-sm text-muted-foreground">
-                    {t('settings.advanced.updateProxyDesc')}
-                  </p>
-                </div>
+                    <div className="flex items-center justify-between">
+                      <div className="space-y-0.5">
+                        <Label>{t('settings.advanced.checkUpdates')}</Label>
+                        <p className="text-sm text-muted-foreground">
+                          {t('settings.advanced.checkUpdatesDesc')}
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          onClick={() => {
+                            if (handleSave()) {
+                              onCheckForUpdates?.();
+                            }
+                          }}
+                          className="gap-1.5"
+                        >
+                          <RefreshCw className="h-3.5 w-3.5" />
+                          {t('settings.advanced.checkNow')}
+                        </Button>
+                        <Switch
+                          checked={settings.checkUpdates}
+                          onCheckedChange={(checked) => updateSetting('checkUpdates', checked)}
+                        />
+                      </div>
+                    </div>
+
+                    <div className="space-y-2">
+                      <Label htmlFor="update-proxy">{t('settings.advanced.updateProxy')}</Label>
+                      <Input
+                        id="update-proxy"
+                        type="url"
+                        placeholder={t('settings.advanced.updateProxyPlaceholder')}
+                        value={settings.updateProxy}
+                        onChange={(event) => updateSetting('updateProxy', event.target.value)}
+                      />
+                      <p className="text-sm text-muted-foreground">
+                        {t('settings.advanced.updateProxyDesc')}
+                      </p>
+                    </div>
+                  </>
+                )}
 
                 <div className="flex items-center justify-between">
                   <div className="space-y-0.5">

--- a/src/components/update-checker.tsx
+++ b/src/components/update-checker.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { check, type DownloadEvent, type Update } from '@tauri-apps/plugin-updater';
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { relaunch } from '@tauri-apps/plugin-process';
 // relaunch() calls the process plugin's restart command (process:allow-restart capability)
 import { toast } from 'sonner';
@@ -16,12 +17,31 @@ import { Progress } from './ui/progress';
 import { Button } from './ui/button';
 import { APP_SETTINGS_STORAGE_KEY } from '@/lib/keyboard-shortcuts';
 import { normalizeUpdateProxy } from '@/lib/update-proxy';
+import {
+  DEFAULT_UPDATE_CONTEXT,
+  HOMEBREW_MANAGED_MARKER,
+  getUpdateChannel,
+  isCurrentChannelEligible,
+  type UpdateContext,
+} from '@/lib/update-channel';
 
 interface UpdateCheckerProps {
   checkSignal?: number;
 }
 
 type UpdateStatus = 'idle' | 'checking' | 'available' | 'downloading' | 'installing' | 'ready' | 'error';
+
+/** Mirror of the `UpdateMeta` struct returned by the `updater_check` command. */
+interface UpdateMeta {
+  version: string;
+  currentVersion: string;
+  body: string | null;
+}
+
+interface UpdaterProgressPayload {
+  downloaded: number;
+  total: number | null;
+}
 
 /** Read the user's "auto check for updates" preference from localStorage. */
 const isAutoCheckEnabled = () => {
@@ -55,14 +75,16 @@ const getUpdateProxy = () => {
 export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
   const { t } = useTranslation();
   const [status, setStatus] = useState<UpdateStatus>('idle');
-  const [updateInfo, setUpdateInfo] = useState<Update | null>(null);
+  const [updateInfo, setUpdateInfo] = useState<UpdateMeta | null>(null);
   const [progress, setProgress] = useState(0);
   const [error, setError] = useState<string | null>(null);
   const [dialogOpen, setDialogOpen] = useState(false);
   const lastSignalRef = useRef<number | undefined>(checkSignal);
-  const downloadTotalRef = useRef<number | null>(null);
-  const downloadedBytesRef = useRef(0);
   const busyRef = useRef(false);
+  // Environment facts from the backend (Homebrew detection + channel gating).
+  // The Rust side re-checks Caskroom on every updater_check, so a stale ref
+  // only costs a wasted round-trip, never a wrong install path.
+  const contextRef = useRef<UpdateContext>(DEFAULT_UPDATE_CONTEXT);
 
   const busy = status === 'downloading' || status === 'installing' || status === 'checking';
   busyRef.current = busy;
@@ -91,7 +113,16 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
 
     try {
       const proxy = getUpdateProxy();
-      const update = await check(proxy ? { proxy } : undefined);
+      // The channel preference only applies where the current baseline can
+      // run (macOS 26+ arm64); everyone else follows the stable manifest.
+      const channel =
+        getUpdateChannel() === 'current' && isCurrentChannelEligible(contextRef.current)
+          ? 'current'
+          : 'stable';
+      const update = await invoke<UpdateMeta | null>('updater_check', {
+        channel,
+        proxy: proxy ?? null,
+      });
 
       if (manual) {
         toast.dismiss('update-check');
@@ -112,9 +143,28 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
         toast.dismiss('update-check');
       }
 
-      const raw = caught instanceof Error ? caught.message : t('updateChecker.checkFailedFallback');
-      // Tauri updater throws when the endpoint is unreachable or returns invalid
-      // data. Map the common Rust error substrings to friendlier messages.
+      // invoke() rejects with the bare command error string; the old JS
+      // plugin threw Error objects, so handle both shapes here.
+      const raw =
+        typeof caught === 'string'
+          ? caught
+          : caught instanceof Error
+            ? caught.message
+            : t('updateChecker.checkFailedFallback');
+
+      if (raw === HOMEBREW_MANAGED_MARKER) {
+        // Homebrew Caskroom install: brew owns updates, guide instead of
+        // letting the in-app updater clobber the managed .app bundle.
+        setStatus('idle');
+        if (manual) {
+          toast.info(t('updateChecker.homebrewManaged'), {
+            description: t('updateChecker.homebrewManagedDesc'),
+          });
+        }
+        return;
+      }
+
+      // Map the common Rust error substrings to friendlier messages.
       const lower = raw.toLowerCase();
       const message =
         raw === 'Invalid update proxy URL'
@@ -142,79 +192,102 @@ export function UpdateChecker({ checkSignal }: UpdateCheckerProps) {
   }, [t]);
 
   const handleDownload = useCallback(async () => {
-    if (!updateInfo) {
-      return;
-    }
-
     setStatus('downloading');
     setProgress(0);
     setError(null);
-    downloadTotalRef.current = null;
-    downloadedBytesRef.current = 0;
 
     try {
-      await updateInfo.download((event: DownloadEvent) => {
-        if (event.event === 'Started') {
-          downloadTotalRef.current = event.data.contentLength ?? null;
-          return;
-        }
-
-        if (event.event === 'Progress') {
-          downloadedBytesRef.current += event.data.chunkLength;
-          if (downloadTotalRef.current) {
-            const percent = Math.round((downloadedBytesRef.current / downloadTotalRef.current) * 100);
-            setProgress(Math.max(0, Math.min(100, percent)));
-          }
-          return;
-        }
-
-        if (event.event === 'Finished') {
-          setProgress(100);
-        }
-      });
-
+      // One Rust command downloads AND installs (replaces the binary);
+      // progress arrives via the updater://progress event. The dialog keeps
+      // its "ready → restart" states so the user still controls the relaunch.
+      await invoke('updater_download_and_install');
+      setProgress(100);
       setStatus('ready');
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : t('updateChecker.downloadFailedFallback');
+      const message =
+        typeof caught === 'string'
+          ? caught
+          : caught instanceof Error
+            ? caught.message
+            : t('updateChecker.downloadFailedFallback');
       setStatus('error');
       setError(message);
       toast.error(t('updateChecker.downloadFailed'), { description: message });
     }
-  }, [updateInfo, t]);
+  }, [t]);
 
   const handleInstall = useCallback(async () => {
-    if (!updateInfo) {
-      return;
-    }
-
     setStatus('installing');
 
     try {
-      await updateInfo.install();
-      // On macOS/Linux, install() replaces the binary but does not restart the app.
-      // relaunch() is needed to start the new version.
-      // On Windows (NSIS), the installer handles restart, but relaunch() is a no-op
-      // in that case so calling it is safe.
+      // The new version is already installed by updater_download_and_install;
+      // relaunch() switches to it (a no-op on Windows where the NSIS
+      // installer handles the restart).
       await relaunch();
     } catch (caught) {
-      const message = caught instanceof Error ? caught.message : t('updateChecker.installFailedFallback');
+      const message =
+        typeof caught === 'string'
+          ? caught
+          : caught instanceof Error
+            ? caught.message
+            : t('updateChecker.installFailedFallback');
       setStatus('error');
       setError(message);
       toast.error(t('updateChecker.installFailed'), { description: message });
     }
-  }, [updateInfo, t]);
+  }, [t]);
+
+  // Download progress from the Rust updater command.
+  useEffect(() => {
+    let disposed = false;
+    let unlisten: UnlistenFn | undefined;
+    void listen<UpdaterProgressPayload>('updater://progress', (event) => {
+      const { downloaded, total } = event.payload;
+      if (total && total > 0) {
+        const percent = Math.round((downloaded / total) * 100);
+        setProgress(Math.max(0, Math.min(100, percent)));
+      }
+    }).then((fn) => {
+      if (disposed) {
+        fn();
+      } else {
+        unlisten = fn;
+      }
+    });
+    return () => {
+      disposed = true;
+      unlisten?.();
+    };
+  }, []);
 
   useEffect(() => {
-    if (isAutoCheckEnabled()) {
-      checkForUpdates(false);
-    }
+    let cancelled = false;
+    // Homebrew-managed installs never auto-check: brew owns updates there.
+    // Non-Tauri dev falls through with the default context so a manual
+    // check still surfaces the real backend error.
+    invoke<UpdateContext>('get_update_context')
+      .then((context) => {
+        if (cancelled) return;
+        contextRef.current = context;
+        if (!context.homebrewManaged && isAutoCheckEnabled()) {
+          void checkForUpdates(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled && isAutoCheckEnabled()) {
+          void checkForUpdates(false);
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
   }, [checkForUpdates]);
 
   useEffect(() => {
     if (typeof checkSignal === 'number') {
       if (lastSignalRef.current !== checkSignal) {
         lastSignalRef.current = checkSignal;
-        checkForUpdates(true);
+        void checkForUpdates(true);
       }
     }
   }, [checkSignal, checkForUpdates]);

--- a/src/lib/update-channel.ts
+++ b/src/lib/update-channel.ts
@@ -1,0 +1,49 @@
+import { APP_SETTINGS_STORAGE_KEY } from '@/lib/keyboard-shortcuts';
+
+export type UpdateChannel = 'stable' | 'current';
+
+/** Mirror of `HOMEBREW_MANAGED_MARKER` in src-tauri/src/commands.rs. */
+export const HOMEBREW_MANAGED_MARKER = 'HOMEBREW_MANAGED_INSTALL';
+
+/** Mirror of the `UpdateContext` struct returned by `get_update_context`. */
+export interface UpdateContext {
+  homebrewManaged: boolean;
+  platform: string;
+  arch: string;
+  macosMajor: number | null;
+}
+
+/** Assumed context before `get_update_context` resolves (or in browser dev). */
+export const DEFAULT_UPDATE_CONTEXT: UpdateContext = {
+  homebrewManaged: false,
+  platform: '',
+  arch: '',
+  macosMajor: null,
+};
+
+/**
+ * The `current` channel requires the evolution-line baseline: macOS 26+
+ * (Tahoe minimum system version) on Apple Silicon, and is never offered to
+ * Homebrew-managed installs (brew owns those updates).
+ */
+export function isCurrentChannelEligible(context: UpdateContext): boolean {
+  return (
+    !context.homebrewManaged &&
+    context.platform === 'macos' &&
+    context.arch === 'aarch64' &&
+    context.macosMajor !== null &&
+    context.macosMajor >= 26
+  );
+}
+
+/** Read the persisted channel preference (default and legacy value: stable). */
+export function getUpdateChannel(): UpdateChannel {
+  try {
+    const raw = localStorage.getItem(APP_SETTINGS_STORAGE_KEY);
+    if (!raw) return 'stable';
+    const parsed = JSON.parse(raw) as { updateChannel?: unknown };
+    return parsed.updateChannel === 'current' ? 'current' : 'stable';
+  } catch {
+    return 'stable';
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -438,7 +438,21 @@
       "debug": "Debug"
     },
     "tabScrollLeft": "Scroll left",
-    "tabScrollRight": "Scroll right"
+    "tabScrollRight": "Scroll right",
+    "updates": {
+      "channel": {
+        "label": "Update Channel",
+        "stable": "Stable (recommended)",
+        "current": "Current (macOS 26+)",
+        "currentHint": "The current channel only moves forward: switching back to stable requires manually installing the stable version.",
+        "currentUnavailable": "The current channel requires macOS 26 or later on Apple Silicon."
+      },
+      "homebrewManaged": {
+        "title": "Managed by Homebrew",
+        "desc": "This copy was installed with Homebrew, so updates are handled by brew. In-app updates are disabled to avoid conflicting with it.",
+        "command": "brew upgrade --cask r-shell"
+      }
+    }
   },
   "welcome": {
     "quickTips": "Quick Tips",
@@ -785,7 +799,9 @@
     "downloadingButton": "Downloading…",
     "checkFailedFallback": "Failed to check for updates.",
     "downloadFailedFallback": "Failed to download update.",
-    "installFailedFallback": "Failed to install update."
+    "installFailedFallback": "Failed to install update.",
+    "homebrewManaged": "Updates are managed by Homebrew",
+    "homebrewManagedDesc": "This copy was installed with Homebrew. Run \"brew upgrade --cask r-shell\" to update."
   },
   "syncDialog": {
     "title": "Directory Sync",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -440,7 +440,21 @@
       "debug": "Diagnostyka"
     },
     "tabScrollLeft": "Przewiń w lewo",
-    "tabScrollRight": "Przewiń w prawo"
+    "tabScrollRight": "Przewiń w prawo",
+    "updates": {
+      "channel": {
+        "label": "Kanał aktualizacji",
+        "stable": "Stabilna (zalecana)",
+        "current": "Najnowsza (macOS 26+)",
+        "currentHint": "Kanał najnowszej wersji działa tylko w przód: powrót do wersji stabilnej wymaga ręcznej instalacji wersji stabilnej.",
+        "currentUnavailable": "Kanał najnowszej wersji wymaga macOS 26 lub nowszego na Apple Silicon."
+      },
+      "homebrewManaged": {
+        "title": "Zarządzane przez Homebrew",
+        "desc": "Ta kopia została zainstalowana przez Homebrew, więc aktualizacjami zarządza brew. Aktualizacje w aplikacji są wyłączone, aby uniknąć konfliktu.",
+        "command": "brew upgrade --cask r-shell"
+      }
+    }
   },
   "welcome": {
     "quickTips": "Szybkie wskazówki",
@@ -803,7 +817,9 @@
     "downloadingButton": "Pobieranie…",
     "checkFailedFallback": "Nie udało się sprawdzić aktualizacji.",
     "downloadFailedFallback": "Nie udało się pobrać aktualizacji.",
-    "installFailedFallback": "Nie udało się zainstalować aktualizacji."
+    "installFailedFallback": "Nie udało się zainstalować aktualizacji.",
+    "homebrewManaged": "Aktualizacjami zarządza Homebrew",
+    "homebrewManagedDesc": "Ta kopia została zainstalowana przez Homebrew. Uruchom \"brew upgrade --cask r-shell\", aby zaktualizować."
   },
   "syncDialog": {
     "title": "Synchronizacja katalogów",

--- a/src/locales/zh-CN.json
+++ b/src/locales/zh-CN.json
@@ -438,7 +438,21 @@
       "debug": "调试"
     },
     "tabScrollLeft": "向左滚动",
-    "tabScrollRight": "向右滚动"
+    "tabScrollRight": "向右滚动",
+    "updates": {
+      "channel": {
+        "label": "更新通道",
+        "stable": "稳定版（推荐）",
+        "current": "最新版（macOS 26+）",
+        "currentHint": "最新版通道只升不降：切回稳定版需手动下载稳定版安装包覆盖安装。",
+        "currentUnavailable": "最新版通道仅支持 macOS 26 及以上的 Apple Silicon 设备。"
+      },
+      "homebrewManaged": {
+        "title": "由 Homebrew 管理",
+        "desc": "此副本通过 Homebrew 安装，更新由 brew 负责。为避免冲突，应用内更新已停用。",
+        "command": "brew upgrade --cask r-shell"
+      }
+    }
   },
   "welcome": {
     "quickTips": "快速提示",
@@ -785,7 +799,9 @@
     "downloadingButton": "正在下载…",
     "checkFailedFallback": "检查更新失败。",
     "downloadFailedFallback": "更新下载失败。",
-    "installFailedFallback": "更新安装失败。"
+    "installFailedFallback": "更新安装失败。",
+    "homebrewManaged": "更新由 Homebrew 管理",
+    "homebrewManagedDesc": "此副本通过 Homebrew 安装，请运行 brew upgrade --cask r-shell 获取更新。"
   },
   "syncDialog": {
     "title": "目录同步",


### PR DESCRIPTION
## Summary

Implements **P0 + P1** of the dual-baseline release design (`docs/superpowers/specs/2026-09-12-homebrew-official-dual-baseline-design.md`, v2, committed in this PR). The shelved sections — §3.3 Apple signing/notarization, §3.5 official-cask bump automation, §5 cask draft, §3.6-旧稿 tap migration — are intentionally **not** implemented, per the owner's 2026-09-12 decisions.

### P0 — channel-aware in-app updater + settings

- **Rust** (`commands.rs`, registered in `lib.rs`):
  - `get_update_context` → `{ homebrewManaged, platform, arch, macosMajor }` — Caskroom detection via `current_exe()` path, macOS major via `sw_vers`.
  - `updater_check(channel, proxy)` — endpoint override on `UpdaterBuilder` (JS `CheckOptions` has no such field): stable → `releases/latest/download/latest.json`, current → `releases/download/current/current.json`. Homebrew-managed installs short-circuit with the `HOMEBREW_MANAGED_INSTALL` marker.
  - `updater_download_and_install` — consumes the `Update` cached in new `PendingUpdate` state, emits `updater://progress {downloaded, total}`.
- **Frontend** (`update-checker.tsx` + new `lib/update-channel.ts`): checks now `invoke` the Rust commands; dialog/progress/relaunch UX preserved. Auto-check is skipped on managed installs; a manual check on a managed install shows a `brew upgrade --cask r-shell` guidance toast instead of an error. A stored `current` preference falls back to `stable` whenever the context is ineligible.
- **Settings** (`settings-modal.tsx`): new **Update Channel** select (`updateChannel` key in the existing `sshClientSettings` container, default `stable`). `current` is only selectable on darwin-arm64 + macOS ≥ 26 + not Homebrew-managed, with the reason shown when disabled and a one-way-channel warning when eligible. Managed installs hide channel / auto-check / proxy and show a brew banner. Menu "Check for Updates" chain untouched.
- **i18n**: en / zh-CN / pl in sync.

### P1 — dual-baseline CI (`release.yml`)

- Matrix gains a `baseline` dimension; job-level `if` routes by `-current.` in the tag: compat entries (existing 4 platforms) for plain `v*` tags and `workflow_dispatch`, current entries (mac arm64 + ubuntu + windows) for `v*-current.*` only.
- Current-line mac build injects `--config '{"bundle":{"macOS":{"minimumSystemVersion":"26.0"}}}'`; current-line releases are **prereleases** so `releases/latest` keeps pointing at the stable line.
- New `upload-current-json`: builds `current.json` (same shape as latest.json, 3 platforms, full `-current.N` version) onto the rolling lightweight `current` tag (prerelease) and force-moves that tag — the updater endpoint stays fixed.
- `upload-updater-json` and `update-homebrew` skip `-current.` tags (the tap's `r-shell` cask tracks stable only); `generate-checksums` already covers whichever `.dmg` assets a tag's release carries.

### Tooling

- `bump-version.mjs --channel current` (or `--channel=current`) → `<semver>-current.<N>` with N = existing `v<base>-current.*` tag count + 1; the base stays fixed while on the line (promotion = plain stable bump, which strips the suffix). Also fixes the CHANGELOG insert that silently no-opped without a `## [Unreleased]` heading — it now inserts at the top of the versioned region.

## Verification

- `pnpm i18n:check` ✓ (1179 keys × 3 locales)
- `pnpm lint` ✓ 0 errors / 243 warnings (main baseline: 246)
- `pnpm build` + `tsc --noEmit` ✓
- `pnpm test` ✓ **800/800** (`update-checker.test.tsx` rewritten against mocked invoke/listen: 32 tests incl. channel→endpoint pass-through, managed auto-check suppression, macOS < 26 ineligibility, brew guidance toast, progress events)
- `cargo test` ✓ 178 passed / 12 ignored (docker e2e fixtures); `rustfmt --check` clean on touched files (pre-existing drift in other modules deliberately left alone)
- bump-version flows exercised in a throwaway git sandbox (stable patch, current debut, current N+1, promotion, `--channel=` form)

## Follow-ups

- **P2** (evolution-line debut `v3.0.0-current.1`) lands after this merges: bump with `--channel current`, tag `v3.0.0-current.1`, push → CI builds the current line as a prerelease.